### PR TITLE
Update Web cache action to v6

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}


### PR DESCRIPTION
## Summary

- Update the Web workflow cache action from `actions/cache@v4` to `actions/cache@v6`
- Keep the existing pnpm cache path, key, and restore-key behavior unchanged

## Why

The current Build Web run reports that the Node.js 20 runtime used by `actions/cache@v4` is deprecated and is being forced onto Node.js 24. The latest stable cache release is v6.1.0, so using the v6 major tag removes that warning while retaining patch updates.

This is the focused replacement for the only still-relevant part of #92. The stale Gradle cache changes from that pull request are intentionally not included because those steps were already removed from the current workflows.

## Validation

- Parsed `.github/workflows/web.yml` as YAML
- Ran `git diff --check`
- Confirmed the change is limited to one action version line
- `.github/workflows/test.yml` will validate both Android release variants