### PR TITLE
修复内置浏览器固定高度与合并提交计数

### DIFF
--- a/.github/workflows/BetaRelease.yml
+++ b/.github/workflows/BetaRelease.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Build With Gradle
         run: |
           echo "当前版本号: $VERSION"
-          sed -i "/def version/c\def version = \"$VERSION\"" "$GITHUB_WORKSPACE/app/build.gradle"
+          sed -i "s/^def version = .*/def version = \"$VERSION\"/" "$GITHUB_WORKSPACE/app/build.gradle"
 
           if [ "$type" == "release" ]; then
             typeName="新包名"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
           set -o pipefail
           build_log="$RUNNER_TEMP/gradle-build.log"
           echo "当前版本号: $VERSION"
-          sed -i "/def version/c\def version = \"$VERSION\"" "$GITHUB_WORKSPACE/app/build.gradle"
+          sed -i "s/^def version = .*/def version = \"$VERSION\"/" "$GITHUB_WORKSPACE/app/build.gradle"
 
           if [ "$type" == "release" ]; then
             typeName="新包名"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,14 +21,17 @@ static def releaseTime() {
 
 def name = "legado"
 def version = "3." + releaseTime()
-def gitCommits = 0
+def versionCodeValue = 30000
+// Preserve the published code at this point, then ignore GitHub wrapper merge commits.
+def versionCodeBaseCommit = '9639f027fbc8cfdf57ce136a9e0c98829a235aef'
+def versionCodeAtBase = 37540
 try {
     def gitCount = providers.exec {
-        commandLine 'git', 'rev-list', 'HEAD', '--count'
+        commandLine 'git', 'rev-list', "${versionCodeBaseCommit}..HEAD", '--count', '--no-merges'
         ignoreExitValue = true
     }.standardOutput.asText.get().trim()
     if (gitCount) {
-        gitCommits = Integer.parseInt(gitCount)
+        versionCodeValue = versionCodeAtBase + Integer.parseInt(gitCount)
     }
 } catch (ignored) {
     // Keep source archives buildable when Git is unavailable.
@@ -62,7 +65,7 @@ android {
         applicationId "com.legado.app"
         minSdk 23
         targetSdk 36
-        versionCode 30000 + gitCommits
+        versionCode = versionCodeValue
         versionName version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         project.ext.set("archivesBaseName", name + "_" + version)

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Context
 import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.net.Uri
 import android.net.http.SslError
@@ -89,10 +90,93 @@ import kotlinx.coroutines.runBlocking
 import java.io.ByteArrayInputStream
 import java.lang.ref.WeakReference
 import java.net.URLDecoder
+import java.util.ArrayDeque
 import java.util.Date
 import androidx.core.graphics.createBitmap
 
+internal data class BottomSheetHeightSpec(
+    val layoutHeight: Int?,
+    val fixedHeight: Int?,
+)
+
+internal fun resolveBottomSheetHeightSpec(
+    screenHeight: Int,
+    dialogHeight: Int?,
+    heightPercentage: Float?,
+    first: Boolean,
+): BottomSheetHeightSpec {
+    val percentageHeight = heightPercentage
+        ?.takeIf { screenHeight > 0 && it > 0f && it <= 1f }
+        ?.let { (screenHeight * it).toInt().coerceAtLeast(1) }
+    val validDialogHeight = dialogHeight?.takeIf {
+        it > 0 || it == ViewGroup.LayoutParams.MATCH_PARENT ||
+                it == ViewGroup.LayoutParams.WRAP_CONTENT
+    }
+    val configuredHeight = percentageHeight ?: validDialogHeight
+    return BottomSheetHeightSpec(
+        layoutHeight = configuredHeight
+            ?: if (first) ViewGroup.LayoutParams.MATCH_PARENT else null,
+        fixedHeight = percentageHeight ?: validDialogHeight?.takeIf { it > 0 },
+    )
+}
+
+internal data class BottomSheetBehaviorSpec(
+    val state: Int?,
+    val peekHeight: Int?,
+    val skipCollapsed: Boolean?,
+    val fitToContents: Boolean?,
+    val draggableOnNestedScroll: Boolean?,
+    val maxHeight: Int?,
+)
+
+internal fun resolveBottomSheetBehaviorSpec(
+    fixedHeight: Int?,
+    resetFixedDefaults: Boolean,
+    state: Int?,
+    peekHeight: Int?,
+    skipCollapsed: Boolean?,
+    fitToContents: Boolean?,
+    draggableOnNestedScroll: Boolean?,
+    maxHeight: Int?,
+): BottomSheetBehaviorSpec {
+    return when {
+        fixedHeight != null -> BottomSheetBehaviorSpec(
+            state = state ?: BottomSheetBehavior.STATE_EXPANDED,
+            peekHeight = peekHeight ?: fixedHeight,
+            skipCollapsed = skipCollapsed ?: true,
+            fitToContents = fitToContents ?: true,
+            draggableOnNestedScroll = draggableOnNestedScroll ?: false,
+            maxHeight = maxHeight ?: fixedHeight,
+        )
+
+        resetFixedDefaults -> BottomSheetBehaviorSpec(
+            state = state,
+            peekHeight = peekHeight ?: BottomSheetBehavior.PEEK_HEIGHT_AUTO,
+            skipCollapsed = skipCollapsed ?: false,
+            fitToContents = fitToContents ?: true,
+            draggableOnNestedScroll = draggableOnNestedScroll ?: true,
+            maxHeight = maxHeight ?: -1,
+        )
+
+        else -> BottomSheetBehaviorSpec(
+            state = state,
+            peekHeight = peekHeight,
+            skipCollapsed = skipCollapsed,
+            fitToContents = fitToContents,
+            draggableOnNestedScroll = draggableOnNestedScroll,
+            maxHeight = maxHeight,
+        )
+    }
+}
+
 class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view), WebJsExtensions.Callback {
+
+    private data class SheetSizeSnapshot(
+        val layoutHeight: Int,
+        val state: Int?,
+        val peekHeight: Int?,
+        val maxHeight: Int?,
+    )
 
     constructor(
         sourceKey: String,
@@ -136,6 +220,12 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
     private var customWebViewCallback: WebChromeClient.CustomViewCallback? = null
     private var originOrientation: Int? = null
     private var needClearHistory = true
+    private var fixedSheetHeight: Int? = null
+    private var configuredHeightPercentage: Float? = null
+    private var peekHeightTracksFixedHeight = false
+    private var maxHeightTracksFixedHeight = false
+    private var sheetSizeBeforeFullScreen: SheetSizeSnapshot? = null
+    private val pendingFullScreenConfigs = ArrayDeque<Config>()
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -171,20 +261,56 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
         if (!isAdded || context == null) {
             return
         }
+        val heightSpec = resolveBottomSheetHeightSpec(
+            displayMetrics.heightPixels,
+            config.dialogHeight,
+            config.heightPercentage,
+            first,
+        )
+        val resetFixedDefaults = fixedSheetHeight != null &&
+                heightSpec.layoutHeight != null && heightSpec.fixedHeight == null
+        if (heightSpec.layoutHeight != null) {
+            fixedSheetHeight = heightSpec.fixedHeight
+            configuredHeightPercentage = config.heightPercentage
+                ?.takeIf { heightSpec.fixedHeight != null && it > 0f && it <= 1f }
+            peekHeightTracksFixedHeight = heightSpec.fixedHeight != null &&
+                    config.peekHeight == null
+            maxHeightTracksFixedHeight = heightSpec.fixedHeight != null &&
+                    config.maxHeight == null
+        } else if (fixedSheetHeight != null) {
+            if (config.peekHeight != null) {
+                peekHeightTracksFixedHeight = false
+            }
+            if (config.maxHeight != null) {
+                maxHeightTracksFixedHeight = false
+            }
+        }
+        val behaviorSpec = resolveBottomSheetBehaviorSpec(
+            fixedHeight = heightSpec.fixedHeight,
+            resetFixedDefaults = resetFixedDefaults,
+            state = config.state,
+            peekHeight = config.peekHeight,
+            skipCollapsed = config.skipCollapsed,
+            fitToContents = config.setFitToContents,
+            draggableOnNestedScroll = config.isDraggableOnNestedScroll,
+            maxHeight = config.maxHeight,
+        )
         behavior?.let { behavior ->
-            config.state?.let { behavior.state = it }
-            config.peekHeight?.let { behavior.peekHeight = it }
+            behaviorSpec.state?.let { behavior.state = it }
+            behaviorSpec.peekHeight?.let { behavior.peekHeight = it }
             config.isHideable?.let { behavior.isHideable = it }
-            config.skipCollapsed?.let { behavior.skipCollapsed = it }
+            behaviorSpec.skipCollapsed?.let { behavior.skipCollapsed = it }
             config.setHalfExpandedRatio?.let { behavior.setHalfExpandedRatio(it) }
             config.setExpandedOffset?.let { behavior.setExpandedOffset(it) }
-            config.setFitToContents?.let { behavior.setFitToContents(it) }
+            behaviorSpec.fitToContents?.let { behavior.setFitToContents(it) }
             config.isDraggable?.let { behavior.isDraggable = it }
-            config.isDraggableOnNestedScroll?.let { behavior.isDraggableOnNestedScroll = it }
+            behaviorSpec.draggableOnNestedScroll?.let {
+                behavior.isDraggableOnNestedScroll = it
+            }
             config.significantVelocityThreshold?.let { behavior.significantVelocityThreshold = it }
             config.hideFriction?.let { behavior.hideFriction = it }
             config.maxWidth?.let { behavior.maxWidth = it }
-            config.maxHeight?.let { behavior.maxHeight = it }
+            behaviorSpec.maxHeight?.let { behavior.maxHeight = it }
             config.isGestureInsetBottomIgnored?.let { behavior.isGestureInsetBottomIgnored = it }
             config.setUpdateImportantForAccessibilityOnSiblings?.let {
                 behavior.setUpdateImportantForAccessibilityOnSiblings(it)
@@ -292,24 +418,10 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
                 }
             }
 
-            val dialogHeight = config.dialogHeight ?: if (first) -1 else null
+            val dialogHeight = heightSpec.layoutHeight
             dialogHeight?.let { height ->
                 params.height = height
                 hasChanged = true
-            }
-            config.heightPercentage?.let { percentage ->
-                if (percentage in 0.0..1.0) {
-                    val height = (displayMetrics.heightPixels * percentage).toInt()
-                    params.height = height
-                    // 同时更新peekHeight和最大高度
-                    if (config.peekHeight == null) {
-                        behavior?.peekHeight = height
-                    }
-                    if (config.maxHeight == null) {
-                        behavior?.maxHeight = height
-                    }
-                    hasChanged = true
-                }
             }
             if (hasChanged) {
                 sheet.layoutParams = params
@@ -320,7 +432,9 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
             val screenWidth = displayMetrics.widthPixels
             if (screenWidth < breakpoint) {
                 // 移动端布局（小屏幕）设置
-                behavior?.peekHeight = config.peekHeight ?: 300
+                if (fixedSheetHeight == null) {
+                    behavior?.peekHeight = config.peekHeight ?: 300
+                }
                 config.widthPercentage?.let { percentage ->
                     if (percentage > 0.8f) {
                         // 小屏幕上最大宽度限制
@@ -330,7 +444,9 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
                 }
             } else {
                 // 平板/大屏幕布局设置
-                behavior?.peekHeight = config.peekHeight ?: 400
+                if (fixedSheetHeight == null) {
+                    behavior?.peekHeight = config.peekHeight ?: 400
+                }
                 config.widthPercentage?.let { percentage ->
                     if (percentage < 0.6f) {
                         // 大屏幕上居中显示
@@ -363,6 +479,69 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
             } else {
                 currentWebView.setOnLongClickListener(null)
             }
+        }
+    }
+
+    private fun reapplyPercentageHeight() {
+        val percentage = configuredHeightPercentage ?: return
+        val height = resolveBottomSheetHeightSpec(
+            displayMetrics.heightPixels,
+            dialogHeight = null,
+            heightPercentage = percentage,
+            first = false,
+        ).fixedHeight ?: return
+        fixedSheetHeight = height
+        bottomSheet?.let { sheet ->
+            val params = sheet.layoutParams
+            params.height = height
+            sheet.layoutParams = params
+        }
+        behavior?.let { behavior ->
+            if (peekHeightTracksFixedHeight) {
+                behavior.peekHeight = height
+            }
+            if (maxHeightTracksFixedHeight) {
+                behavior.maxHeight = height
+            }
+        }
+    }
+
+    private fun expandSheetForFullScreen() {
+        if (fixedSheetHeight != null && sheetSizeBeforeFullScreen == null) {
+            bottomSheet?.let { sheet ->
+                sheetSizeBeforeFullScreen = SheetSizeSnapshot(
+                    layoutHeight = sheet.layoutParams.height,
+                    state = behavior?.state,
+                    peekHeight = behavior?.peekHeight,
+                    maxHeight = behavior?.maxHeight,
+                )
+                val params = sheet.layoutParams
+                params.height = ViewGroup.LayoutParams.MATCH_PARENT
+                sheet.layoutParams = params
+                behavior?.maxHeight = -1
+            }
+        }
+        behavior?.state = BottomSheetBehavior.STATE_EXPANDED
+    }
+
+    private fun restoreSheetAfterFullScreen() {
+        val snapshot = sheetSizeBeforeFullScreen
+        if (snapshot != null) {
+            bottomSheet?.let { sheet ->
+                val params = sheet.layoutParams
+                params.height = snapshot.layoutHeight
+                sheet.layoutParams = params
+            }
+            behavior?.let { behavior ->
+                snapshot.maxHeight?.let { behavior.maxHeight = it }
+                snapshot.peekHeight?.let { behavior.peekHeight = it }
+            }
+        }
+        sheetSizeBeforeFullScreen = null
+        reapplyPercentageHeight()
+        snapshot?.state?.let { behavior?.state = it }
+        while (pendingFullScreenConfigs.isNotEmpty()) {
+            setConfig(pendingFullScreenConfigs.removeFirst())
         }
     }
 
@@ -612,11 +791,22 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
         super.onDestroyView()
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        if (!isFullScreen) {
+            reapplyPercentageHeight()
+        }
+    }
+
     override fun upConfig(config: String) {
         try {
             lifecycleScope.launch(Dispatchers.Main) {
                 GSON.fromJsonObject<Config>(config).getOrThrow().let { config ->
-                    setConfig(config)
+                    if (isFullScreen) {
+                        pendingFullScreenConfigs.addLast(config)
+                    } else {
+                        setConfig(config)
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -722,15 +912,16 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
             binding.customWebView.addView(view)
             customWebViewCallback = callback
             dialog?.keepScreenOn(true)
-            behavior?.state = BottomSheetBehavior.STATE_EXPANDED
+            expandSheetForFullScreen()
         }
 
         override fun onHideCustomView() {
+            isFullScreen = false
+            restoreSheetAfterFullScreen()
             originOrientation?.let {
                 activity?.requestedOrientation = it
                 originOrientation = null
             }
-            isFullScreen = false
             binding.webViewContainer.visible()
             binding.customWebView.removeAllViews()
             customWebViewCallback = null

--- a/app/src/test/java/io/legado/app/ui/widget/dialog/BottomWebViewHeightConfigTest.kt
+++ b/app/src/test/java/io/legado/app/ui/widget/dialog/BottomWebViewHeightConfigTest.kt
@@ -1,0 +1,136 @@
+package io.legado.app.ui.widget.dialog
+
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BottomWebViewHeightConfigTest {
+
+    @Test
+    fun `positive pixel height enables fixed mode`() {
+        val spec = resolveBottomSheetHeightSpec(1_000, 480, null, first = true)
+
+        assertEquals(480, spec.layoutHeight)
+        assertEquals(480, spec.fixedHeight)
+    }
+
+    @Test
+    fun `valid percentage takes precedence and enables fixed mode`() {
+        val spec = resolveBottomSheetHeightSpec(1_000, 480, 0.4f, first = true)
+
+        assertEquals(400, spec.layoutHeight)
+        assertEquals(400, spec.fixedHeight)
+    }
+
+    @Test
+    fun `invalid percentage falls back without creating zero height fixed mode`() {
+        assertEquals(
+            BottomSheetHeightSpec(480, 480),
+            resolveBottomSheetHeightSpec(1_000, 480, 0f, first = true),
+        )
+        assertEquals(
+            BottomSheetHeightSpec(ViewGroup.LayoutParams.MATCH_PARENT, null),
+            resolveBottomSheetHeightSpec(1_000, null, 1.1f, first = true),
+        )
+    }
+
+    @Test
+    fun `zero and unknown negative pixel heights are ignored`() {
+        assertEquals(
+            BottomSheetHeightSpec(ViewGroup.LayoutParams.MATCH_PARENT, null),
+            resolveBottomSheetHeightSpec(1_000, 0, null, first = true),
+        )
+        assertEquals(
+            BottomSheetHeightSpec(null, null),
+            resolveBottomSheetHeightSpec(1_000, -3, null, first = false),
+        )
+    }
+
+    @Test
+    fun `layout constants retain flexible behavior`() {
+        val matchParent = resolveBottomSheetHeightSpec(
+            1_000,
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            null,
+            first = true,
+        )
+        val wrapContent = resolveBottomSheetHeightSpec(
+            1_000,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            null,
+            first = false,
+        )
+
+        assertNull(matchParent.fixedHeight)
+        assertNull(wrapContent.fixedHeight)
+        assertEquals(ViewGroup.LayoutParams.MATCH_PARENT, matchParent.layoutHeight)
+        assertEquals(ViewGroup.LayoutParams.WRAP_CONTENT, wrapContent.layoutHeight)
+    }
+
+    @Test
+    fun `fixed mode supplies stable defaults`() {
+        val spec = resolveBottomSheetBehaviorSpec(
+            fixedHeight = 480,
+            resetFixedDefaults = false,
+            state = null,
+            peekHeight = null,
+            skipCollapsed = null,
+            fitToContents = null,
+            draggableOnNestedScroll = null,
+            maxHeight = null,
+        )
+
+        assertEquals(BottomSheetBehavior.STATE_EXPANDED, spec.state)
+        assertEquals(480, spec.peekHeight)
+        assertEquals(480, spec.maxHeight)
+        assertTrue(spec.skipCollapsed == true)
+        assertTrue(spec.fitToContents == true)
+        assertFalse(spec.draggableOnNestedScroll == true)
+    }
+
+    @Test
+    fun `explicit behavior fields override fixed mode defaults`() {
+        val spec = resolveBottomSheetBehaviorSpec(
+            fixedHeight = 480,
+            resetFixedDefaults = false,
+            state = BottomSheetBehavior.STATE_COLLAPSED,
+            peekHeight = 320,
+            skipCollapsed = false,
+            fitToContents = false,
+            draggableOnNestedScroll = true,
+            maxHeight = 640,
+        )
+
+        assertEquals(BottomSheetBehavior.STATE_COLLAPSED, spec.state)
+        assertEquals(320, spec.peekHeight)
+        assertEquals(640, spec.maxHeight)
+        assertFalse(spec.skipCollapsed == true)
+        assertFalse(spec.fitToContents == true)
+        assertTrue(spec.draggableOnNestedScroll == true)
+    }
+
+    @Test
+    fun `leaving fixed mode restores flexible constraints without changing state`() {
+        val spec = resolveBottomSheetBehaviorSpec(
+            fixedHeight = null,
+            resetFixedDefaults = true,
+            state = null,
+            peekHeight = null,
+            skipCollapsed = null,
+            fitToContents = null,
+            draggableOnNestedScroll = null,
+            maxHeight = null,
+        )
+
+        assertNull(spec.state)
+        assertEquals(BottomSheetBehavior.PEEK_HEIGHT_AUTO, spec.peekHeight)
+        assertEquals(-1, spec.maxHeight)
+        assertFalse(spec.skipCollapsed == true)
+        assertTrue(spec.fitToContents == true)
+        assertTrue(spec.draggableOnNestedScroll == true)
+    }
+}


### PR DESCRIPTION
## 背景

### 内置浏览器固定高度

`java.showBrowser` 已支持通过 `dialogHeight` 或 `heightPercentage` 指定底部浏览器高度，但当前实现只修改布局高度。WebView 位于顶部时继续上滑，嵌套滚动仍可能驱动 BottomSheet 改变状态，导致固定高度弹窗出现位置或高度跳动。

本次基于 `skybbk1001/legadoT` 的 `2c5421c79` 提交重新分析并按当前主线实现，只提取固定高度修复，不引入新的展开高度配置接口。

### 合并提交计数

GitHub 使用 merge commit 合并 PR 时，功能提交和 `Merge pull request #...` 包装提交会同时进入历史。以 `92b7b98b` 与 `9639f027` 为例，两者最终源码树相同，但旧版 `git rev-list HEAD --count` 会让包装提交再次增加 `versionCode`。

已有发布历史保持不变，避免强推导致标签、分支和 PR 引用失效。从 `9639f027` 对应的已发布 `versionCode 37540` 开始，只统计后续非 merge 提交。

## 更新内容

- 正数 `dialogHeight` 或合法 `heightPercentage` 默认进入固定高度模式：
  - 同步布局高度、`peekHeight` 与 `maxHeight`
  - 默认保持展开并跳过折叠状态
  - 默认禁止 WebView 嵌套滚动拖动 BottomSheet
- 保留调用方显式配置的最高优先级，`state`、`peekHeight`、`maxHeight`、拖动及折叠参数仍可覆盖默认行为。
- 保持 `MATCH_PARENT (-1)`、`WRAP_CONTENT (-2)` 的灵活布局语义；忽略 0、未知负数及非法百分比，避免生成不可见的零高度弹窗。
- 固定高度切回灵活布局时恢复自动 peek、高度上限和嵌套拖动默认值，同时保留运行中的状态。
- `heightPercentage` 在横竖屏或窗口尺寸变化后按最新屏幕高度重新计算。
- HTML5 视频进入全屏时临时解除固定高度约束，退出后恢复原尺寸。
- 全屏期间收到的 `upConfig` 按原调用顺序暂存，退出全屏后逐条应用，避免播放过程中缩回及稀疏配置丢失。
- 响应式断点不再覆盖固定高度模式的 `peekHeight`。
- `versionCode` 以 `9639f027` 的 37540 为连续基线，后续使用 `git rev-list --no-merges` 计数。
- Git 不可用或基线提交不可读取时继续保留源码压缩包的原有回退值 30000。

## 合并策略

仓库已关闭 merge commit 与 rebase merge，仅保留 squash merge。后续每个 PR 在 `master` 只产生一个以 PR 标题命名的提交，提交正文合并保留各功能提交说明，不再新增 `Merge pull request #...` 包装提交。

既有 merge commit 不做历史改写；它们已经包含在 37540 基线中，也不会再影响后续版本递增。空提交只能增加一个版本计数，不能抵消已有的 1218 个 merge commit，因此不额外创建空提交。

## 兼容性

- 未新增或删除 `BottomWebViewDialog.Config` 的公开字段。
- 未引入 `expandedHeight` 或 `expandedHeightPercentage`。
- 未配置高度时继续使用原有全屏布局。
- 现有显式 BottomSheet 行为配置保持可用。
- `9639f027` 基线保持 `versionCode=37540`；本 PR squash 合并后，`master` 只新增一个非 merge 提交，正式结果为 37541，不发生版本回退。PR 审查分支中的多个临时提交仅影响测试 artifact。

## 测试

- `./gradlew :app:testAppReleaseUnitTest --build-cache --parallel --daemon --warning-mode all`
- `./gradlew :app:assembleRelease -ParmOnly=true --build-cache --parallel --daemon --warning-mode all`
- `./gradlew :app:processAppReleaseManifest --rerun-tasks --no-daemon --warning-mode all`
- 新增 8 组高度策略测试，覆盖像素高度、百分比优先级、非法值、`-1/-2`、固定模式默认值、显式覆盖及退出固定模式。
- PR #144 历史区间验证：普通计数为 2，排除 merge 后为 1。
- 已验证 37540 基线与 `--no-merges` 计数公式；按仓库 squash 策略合并后，`master` 生成的 Manifest 为 `versionCode=37541`。
- `test.yml` 与 `BetaRelease.yml` 已验证只替换精确的 `def version =` 行，不会改写 `versionCode` 变量。
