### PR TITLE
支持目录分卷折叠并将 Beta Release 改为手动触发

### DIFF
--- a/.github/workflows/BetaRelease.yml
+++ b/.github/workflows/BetaRelease.yml
@@ -1,17 +1,6 @@
 name: Beta Release
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - '**'
-      - '!**/ISSUE_TEMPLATE/**'
-      - '!**/modules/web/**'
-  workflow_run:
-    workflows: [Build Web]
-    branches: [master]
-    types: [completed]
   workflow_dispatch:
 
 concurrency:

--- a/app/src/main/java/io/legado/app/data/dao/BookChapterDao.kt
+++ b/app/src/main/java/io/legado/app/data/dao/BookChapterDao.kt
@@ -16,6 +16,9 @@ interface BookChapterDao {
     @Query("SELECT * FROM chapters where bookUrl = :bookUrl and `index` >= :start and `index` <= :end and title like '%'||:key||'%' order by `index`")
     fun search(bookUrl: String, key: String, start: Int, end: Int): List<BookChapter>
 
+    @Query("SELECT `index` FROM chapters where bookUrl = :bookUrl and `index` >= :start and `index` <= :end and title like '%'||:key||'%' order by `index`")
+    fun searchIndexes(bookUrl: String, key: String, start: Int, end: Int): List<Int>
+
     @Query("select * from chapters where bookUrl = :bookUrl order by `index`")
     fun getChapterList(bookUrl: String): List<BookChapter>
 

--- a/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
@@ -1,110 +1,161 @@
 package io.legado.app.ui.book.toc
 
 import android.content.Context
+import android.graphics.Rect
 import android.os.Handler
 import android.os.Looper
+import android.view.TouchDelegate
+import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.updatePaddingRelative
 import androidx.recyclerview.widget.DiffUtil
 import io.legado.app.R
 import io.legado.app.base.adapter.DiffRecyclerAdapter
 import io.legado.app.base.adapter.ItemViewHolder
 import io.legado.app.data.entities.Book
 import io.legado.app.data.entities.BookChapter
+import io.legado.app.data.entities.ReplaceBook
 import io.legado.app.databinding.ItemChapterListBinding
 import io.legado.app.help.book.ContentProcessor
 import io.legado.app.help.config.AppConfig
 import io.legado.app.help.coroutine.Coroutine
 import io.legado.app.lib.theme.ThemeUtils
 import io.legado.app.lib.theme.accentColor
+import io.legado.app.utils.dpToPx
 import io.legado.app.utils.getCompatColor
 import io.legado.app.utils.gone
 import io.legado.app.utils.longToastOnUi
 import io.legado.app.utils.visible
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 
 class ChapterListAdapter(context: Context, val callback: Callback) :
-    DiffRecyclerAdapter<BookChapter, ItemChapterListBinding>(context) {
+    DiffRecyclerAdapter<TocListItem, ItemChapterListBinding>(context) {
 
     val cacheFileNames = hashSetOf<String>()
     private val displayTitleMap = ConcurrentHashMap<String, String>()
     private val handler = Handler(Looper.getMainLooper())
+    private val baseStartPadding = 12.dpToPx()
+    private val depthIndent = 10.dpToPx()
+    private var released = false
 
-    override val diffItemCallback: DiffUtil.ItemCallback<BookChapter>
-        get() = object : DiffUtil.ItemCallback<BookChapter>() {
+    override val diffItemCallback: DiffUtil.ItemCallback<TocListItem>
+        get() = object : DiffUtil.ItemCallback<TocListItem>() {
 
             override fun areItemsTheSame(
-                oldItem: BookChapter,
-                newItem: BookChapter
+                oldItem: TocListItem,
+                newItem: TocListItem,
             ): Boolean {
-                return oldItem.index == newItem.index
+                return oldItem.key == newItem.key
             }
 
             override fun areContentsTheSame(
-                oldItem: BookChapter,
-                newItem: BookChapter
+                oldItem: TocListItem,
+                newItem: TocListItem,
             ): Boolean {
-                return oldItem.bookUrl == newItem.bookUrl
-                        && oldItem.url == newItem.url
-                        && oldItem.isVip == newItem.isVip
-                        && oldItem.isPay == newItem.isPay
-                        && oldItem.title == newItem.title
-                        && oldItem.tag == newItem.tag
-                        && oldItem.wordCount == newItem.wordCount
-                        && oldItem.isVolume == newItem.isVolume
-            }
+                if (oldItem::class != newItem::class || oldItem.depth != newItem.depth) {
+                    return false
+                }
+                if (!sameChapterContent(oldItem.chapter, newItem.chapter)) return false
+                return when {
+                    oldItem is TocListItem.Volume && newItem is TocListItem.Volume ->
+                        oldItem.collapsed == newItem.collapsed &&
+                                oldItem.chapterCount == newItem.chapterCount &&
+                                oldItem.matchedCount == newItem.matchedCount &&
+                                oldItem.matchedSelf == newItem.matchedSelf &&
+                                oldItem.containsCurrentChapter == newItem.containsCurrentChapter
 
+                    oldItem is TocListItem.Chapter && newItem is TocListItem.Chapter ->
+                        oldItem.parentVolumeIndex == newItem.parentVolumeIndex
+
+                    else -> false
+                }
+            }
         }
 
-    private var upDisplayTileJob: Coroutine<*>? = null
+    private fun sameChapterContent(oldItem: BookChapter, newItem: BookChapter): Boolean {
+        return oldItem.bookUrl == newItem.bookUrl &&
+                oldItem.url == newItem.url &&
+                oldItem.isVip == newItem.isVip &&
+                oldItem.isPay == newItem.isPay &&
+                oldItem.title == newItem.title &&
+                oldItem.tag == newItem.tag &&
+                oldItem.wordCount == newItem.wordCount &&
+                oldItem.isVolume == newItem.isVolume
+    }
+
+    private var upDisplayTitleJob: Coroutine<*>? = null
 
     override fun onCurrentListChanged() {
         super.onCurrentListChanged()
+        if (released) return
         callback.onListChanged()
+        callback.onItemsUpdated()
+    }
+
+    fun attach() {
+        released = false
+    }
+
+    fun release() {
+        released = true
+        upDisplayTitleJob?.cancel()
+        handler.removeCallbacksAndMessages(null)
     }
 
     fun clearDisplayTitle() {
-        upDisplayTileJob?.cancel()
+        upDisplayTitleJob?.cancel()
         displayTitleMap.clear()
     }
 
     fun upDisplayTitles(startIndex: Int) {
-        upDisplayTileJob?.cancel()
-        upDisplayTileJob = Coroutine.async(callback.scope) {
+        if (released) return
+        upDisplayTitleJob?.cancel()
+        upDisplayTitleJob = Coroutine.async(callback.scope) {
             val book = callback.book ?: return@async
+            val items = getItems()
+            if (items.isEmpty()) return@async
+            val safeStartIndex = startIndex.coerceIn(0, items.lastIndex)
             val replaceRules = ContentProcessor.get(book.name, book.origin).getTitleReplaceRules()
             val replaceBook = book.toReplaceBook()
             val useReplace = AppConfig.tocUiUseReplace && book.getUseReplaceRule()
-            val items = getItems()
             launch {
-                for (i in startIndex until items.size) {
-                    val item = items[i]
-                    if (displayTitleMap[item.title] == null) {
-                        ensureActive()
-                        val displayTitle = item.getDisplayTitle(replaceRules, useReplace, replaceBook = replaceBook)
-                        ensureActive()
-                        displayTitleMap[item.title] = displayTitle
-                        handler.post {
-                            notifyItemChanged(i, true)
-                        }
-                    }
+                for (i in safeStartIndex until items.size) {
+                    updateDisplayTitle(items, i, replaceRules, useReplace, replaceBook)
                 }
             }
             launch {
-                for (i in startIndex downTo 0) {
-                    val item = items[i]
-                    if (displayTitleMap[item.title] == null) {
-                        ensureActive()
-                        val displayTitle = item.getDisplayTitle(replaceRules, useReplace, replaceBook = replaceBook)
-                        ensureActive()
-                        displayTitleMap[item.title] = displayTitle
-                        handler.post {
-                            notifyItemChanged(i, true)
-                        }
-                    }
+                for (i in safeStartIndex - 1 downTo 0) {
+                    updateDisplayTitle(items, i, replaceRules, useReplace, replaceBook)
                 }
+            }
+        }
+    }
+
+    private suspend fun updateDisplayTitle(
+        items: List<TocListItem>,
+        index: Int,
+        replaceRules: List<io.legado.app.data.entities.ReplaceRule>,
+        useReplace: Boolean,
+        replaceBook: ReplaceBook,
+    ) {
+        val item = items[index]
+        val chapter = item.chapter
+        if (displayTitleMap[chapter.title] != null) return
+        currentCoroutineContext().ensureActive()
+        val displayTitle = chapter.getDisplayTitle(
+            replaceRules,
+            useReplace,
+            replaceBook = replaceBook,
+        )
+        currentCoroutineContext().ensureActive()
+        displayTitleMap[chapter.title] = displayTitle
+        handler.post {
+            if (!released && getItem(index)?.key == item.key) {
+                notifyItemChanged(index, true)
             }
         }
     }
@@ -120,79 +171,158 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
     override fun convert(
         holder: ItemViewHolder,
         binding: ItemChapterListBinding,
-        item: BookChapter,
-        payloads: MutableList<Any>
+        item: TocListItem,
+        payloads: MutableList<Any>,
     ) {
         binding.run {
-            val isDur = callback.durChapterIndex() == item.index
-            val cached = callback.isLocalBook
-                    || item.isVolume
-                    || cacheFileNames.contains(item.getFileName())
+            val chapter = item.chapter
+            val isVolume = item is TocListItem.Volume
+            val isCurrentChapter = callback.durChapterIndex() == chapter.index
+            val cached = callback.isLocalBook || isVolume ||
+                    cacheFileNames.contains(chapter.getFileName())
+            tvChapterName.text = getDisplayTitle(chapter)
+
             if (payloads.isEmpty()) {
-                if (isDur) {
+                val isCurrentGroup = isCurrentChapter ||
+                        (item is TocListItem.Volume && item.containsCurrentChapter)
+                tvChapterItem.updatePaddingRelative(
+                    start = baseStartPadding + item.depth * depthIndent
+                )
+                if (isCurrentGroup) {
                     tvChapterName.setTextColor(context.accentColor)
                 } else {
                     tvChapterName.setTextColor(context.getCompatColor(R.color.primaryText))
                 }
-                tvChapterName.text = getDisplayTitle(item)
-                if (item.isVolume) {
-                    //卷名，如第一卷 突出显示
+                if (isVolume) {
                     tvChapterItem.setBackgroundColor(context.getCompatColor(R.color.btn_bg_press))
                 } else {
-                    //普通章节 保持不变
                     tvChapterItem.background =
                         ThemeUtils.resolveDrawable(context, android.R.attr.selectableItemBackground)
                 }
 
-                //卷名不显示 去掉了 !item.isVolume，让卷名也显示
-                if (!item.tag.isNullOrEmpty()) {
-                    //更新时间规则
-                    tvTag.text = item.tag
+                if (item is TocListItem.Volume) {
+                    tvWordCount.gone()
+                    tvTag.text = volumeSummary(item)
                     tvTag.visible()
                 } else {
-                    tvTag.gone()
-                }
-                if (AppConfig.tocCountWords && !item.wordCount.isNullOrEmpty() && !item.isVolume) {
-                    //章节字数
-                    tvWordCount.text = item.wordCount
-                    tvWordCount.visible()
-                } else {
-                    tvWordCount.gone()
+                    if (!chapter.tag.isNullOrEmpty()) {
+                        tvTag.text = chapter.tag
+                        tvTag.visible()
+                    } else {
+                        tvTag.gone()
+                    }
+                    if (AppConfig.tocCountWords && !chapter.wordCount.isNullOrEmpty()) {
+                        tvWordCount.text = chapter.wordCount
+                        tvWordCount.visible()
+                    } else {
+                        tvWordCount.gone()
+                    }
                 }
 
-                if (item.isVip && !item.isPay) {
+                if (chapter.isVip && !chapter.isPay && !isVolume) {
                     ivLocked.visible()
                 } else {
                     ivLocked.gone()
                 }
 
-                upHasCache(binding, isDur, cached)
-            } else {
-                tvChapterName.text = getDisplayTitle(item)
-                upHasCache(binding, isDur, cached)
+                if (item is TocListItem.Volume) {
+                    ivChecked.gone()
+                    if (item.canToggle) {
+                        ivVolumeArrow.setImageResource(
+                            if (item.collapsed) R.drawable.ic_arrow_right
+                            else R.drawable.ic_expand_more
+                        )
+                        ivVolumeArrow.visible()
+                        endActions.contentDescription = context.getString(
+                            if (item.collapsed) R.string.toc_expand_volume
+                            else R.string.toc_collapse_volume
+                        )
+                        endActions.isFocusable = true
+                        endActions.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+                    } else {
+                        ivVolumeArrow.gone()
+                        endActions.contentDescription = null
+                        endActions.isFocusable = false
+                        endActions.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+                    }
+                } else {
+                    ivVolumeArrow.gone()
+                    endActions.contentDescription = null
+                    endActions.isFocusable = false
+                    endActions.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+                }
+                expandEndActionTouchTarget(binding)
             }
+            if (!isVolume) upHasCache(binding, isCurrentChapter, cached)
         }
+    }
+
+    private fun volumeSummary(item: TocListItem.Volume): String {
+        val summary = if (item.matchedCount == null) {
+            context.getString(R.string.all_chapter_num, item.chapterCount)
+        } else if (item.matchedSelf && item.matchedCount == 0) {
+            context.getString(R.string.toc_volume_title_match)
+        } else {
+            context.getString(
+                R.string.toc_search_match_count,
+                item.matchedCount,
+                item.chapterCount,
+            )
+        }
+        return item.chapter.tag
+            ?.takeIf { it.isNotBlank() }
+            ?.let { context.getString(R.string.toc_volume_tag_summary, it, summary) }
+            ?: summary
     }
 
     override fun registerListener(holder: ItemViewHolder, binding: ItemChapterListBinding) {
         holder.itemView.setOnClickListener {
-            getItem(holder.layoutPosition)?.let {
-                callback.openChapter(it)
+            getItem(holder.layoutPosition)?.let { item ->
+                callback.openChapter(item.chapter)
+            }
+        }
+        binding.endActions.setOnClickListener {
+            getItem(holder.layoutPosition)?.let { item ->
+                if (item is TocListItem.Volume && item.canToggle) {
+                    callback.onVolumeToggled(item.chapter.index)
+                } else {
+                    callback.openChapter(item.chapter)
+                }
             }
         }
         holder.itemView.setOnLongClickListener {
             getItem(holder.layoutPosition)?.let { item ->
-                context.longToastOnUi(getDisplayTitle(item))
+                context.longToastOnUi(getDisplayTitle(item.chapter))
             }
             true
         }
     }
 
-    private fun upHasCache(binding: ItemChapterListBinding, isDur: Boolean, cached: Boolean) =
+    private fun expandEndActionTouchTarget(binding: ItemChapterListBinding) {
+        binding.tvChapterItem.post {
+            val bounds = Rect()
+            binding.endActions.getHitRect(bounds)
+            val inset = 12.dpToPx()
+            bounds.inset(-inset, -inset)
+            binding.tvChapterItem.touchDelegate = TouchDelegate(bounds, binding.endActions)
+        }
+    }
+
+    fun findVisiblePositionByChapterIndex(chapterIndex: Int): Int {
+        return getItems().indexOfFirst {
+            it is TocListItem.Chapter && it.chapter.index == chapterIndex
+        }
+    }
+
+    fun findVisiblePositionByItemKey(key: String): Int {
+        return getItems().indexOfFirst { it.key == key }
+    }
+
+    private fun upHasCache(binding: ItemChapterListBinding, isCurrent: Boolean, cached: Boolean) =
         binding.apply {
             ivChecked.setImageResource(R.drawable.ic_outline_cloud_24)
             ivChecked.visible(!cached)
-            if (isDur) {
+            if (isCurrent) {
                 ivChecked.setImageResource(R.drawable.ic_check)
                 ivChecked.visible()
             }
@@ -205,6 +335,7 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
         fun openChapter(bookChapter: BookChapter)
         fun durChapterIndex(): Int
         fun onListChanged()
+        fun onVolumeToggled(volumeIndex: Int)
+        fun onItemsUpdated()
     }
-
 }

--- a/app/src/main/java/io/legado/app/ui/book/toc/ChapterListFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/ChapterListFragment.kt
@@ -28,29 +28,38 @@ import io.legado.app.utils.applyNavigationBarPadding
 import io.legado.app.utils.observeEvent
 import io.legado.app.utils.viewbindingdelegate.viewBinding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers.Default
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class ChapterListFragment : VMBaseFragment<TocViewModel>(R.layout.fragment_chapter_list),
     ChapterListAdapter.Callback,
     TocViewModel.ChapterListCallBack {
+
     override val viewModel by activityViewModels<TocViewModel>()
     private val binding by viewBinding(FragmentChapterListBinding::bind)
-    private val mLayoutManager by lazy { UpLinearLayoutManager(requireContext()) }
+    private val layoutManager by lazy { UpLinearLayoutManager(requireContext()) }
     private val adapter by lazy { ChapterListAdapter(requireContext(), this) }
+    private val tocListState = TocListState()
     private var durChapterIndex = 0
+    private var chapterList: List<BookChapter> = emptyList()
+    private var currentSearchKey: String? = null
+    private var chapterListJob: Job? = null
+    private var cacheFileJob: Job? = null
+    private var pendingScrollItemKey: String? = null
+    private var pendingChapterScroll: Int? = null
 
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) = binding.run {
         viewModel.chapterListCallBack = this@ChapterListFragment
-        val bbg = bottomBackground
-        val btc = requireContext().getPrimaryTextColor(ColorUtils.isColorLight(bbg))
-        llChapterBaseInfo.setBackgroundColor(bbg)
-        tvCurrentChapterInfo.setTextColor(btc)
-        ivChapterTop.setColorFilter(btc, PorterDuff.Mode.SRC_IN)
-        ivChapterBottom.setColorFilter(btc, PorterDuff.Mode.SRC_IN)
+        val background = bottomBackground
+        val foreground = requireContext().getPrimaryTextColor(ColorUtils.isColorLight(background))
+        llChapterBaseInfo.setBackgroundColor(background)
+        tvCurrentChapterInfo.setTextColor(foreground)
+        ivChapterTop.setColorFilter(foreground, PorterDuff.Mode.SRC_IN)
+        ivChapterBottom.setColorFilter(foreground, PorterDuff.Mode.SRC_IN)
         initRecyclerView()
         initView()
         viewModel.bookData.observe(this@ChapterListFragment) {
@@ -59,51 +68,69 @@ class ChapterListFragment : VMBaseFragment<TocViewModel>(R.layout.fragment_chapt
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
+        chapterListJob?.cancel()
+        cacheFileJob?.cancel()
+        pendingScrollItemKey = null
+        pendingChapterScroll = null
+        binding.recyclerView.adapter = null
+        adapter.release()
         viewModel.chapterListCallBack = clearCallbackIfOwned(
             viewModel.chapterListCallBack,
-            this
+            this,
         )
+        super.onDestroyView()
     }
 
     private fun initRecyclerView() {
-        binding.recyclerView.layoutManager = mLayoutManager
+        adapter.attach()
+        binding.recyclerView.layoutManager = layoutManager
         binding.recyclerView.addItemDecoration(VerticalDivider(requireContext()))
         binding.recyclerView.adapter = adapter
     }
 
     private fun initView() = binding.run {
         ivChapterTop.setOnClickListener {
-            mLayoutManager.scrollToPositionWithOffset(0, 0)
+            layoutManager.scrollToPositionWithOffset(0, 0)
         }
         ivChapterBottom.setOnClickListener {
             if (adapter.itemCount > 0) {
-                mLayoutManager.scrollToPositionWithOffset(adapter.itemCount - 1, 0)
+                layoutManager.scrollToPositionWithOffset(adapter.itemCount - 1, 0)
             }
         }
         tvCurrentChapterInfo.setOnClickListener {
-            mLayoutManager.scrollToPositionWithOffset(durChapterIndex, 0)
+            scrollToChapterIndex(durChapterIndex, expandVolume = true)
         }
-        binding.llChapterBaseInfo.applyNavigationBarPadding()
+        llChapterBaseInfo.applyNavigationBarPadding()
     }
 
     @SuppressLint("SetTextI18n")
     private fun initBook(book: Book) {
-        lifecycleScope.launch {
-            upChapterList(null)
-            durChapterIndex = book.durChapterIndex
-            binding.tvCurrentChapterInfo.text =
-                "${book.durChapterTitle}(${book.durChapterIndex + 1}/${book.simulatedTotalChapterNum()})"
-            initCacheFileNames(book)
+        chapterListJob?.cancel()
+        cacheFileJob?.cancel()
+        durChapterIndex = book.durChapterIndex
+        binding.tvCurrentChapterInfo.text =
+            "${book.durChapterTitle}(${book.durChapterIndex + 1}/${book.simulatedTotalChapterNum()})"
+        adapter.cacheFileNames.clear()
+        tocListState.clear()
+        chapterList = emptyList()
+        adapter.setItems(emptyList())
+        currentSearchKey = null
+        pendingScrollItemKey = null
+        pendingChapterScroll = null
+        chapterListJob = viewLifecycleOwner.lifecycleScope.launch {
+            val chapters = queryChapterList(book)
+            chapterList = chapters
+            tocListState.setFullChapters(
+                chapters = chapters,
+                currentChapterIndex = durChapterIndex,
+                reverseOrder = book.getReverseToc(),
+                resetCollapse = true,
+            )
+            adapter.setItems(tocListState.showNormal(durChapterIndex))
         }
-    }
-
-    private fun initCacheFileNames(book: Book) {
-        lifecycleScope.launch(IO) {
-            adapter.cacheFileNames.addAll(BookHelp.getChapterFiles(book))
-            withContext(Main) {
-                adapter.notifyItemRangeChanged(0, adapter.itemCount, true)
-            }
+        cacheFileJob = viewLifecycleOwner.lifecycleScope.launch {
+            adapter.cacheFileNames.addAll(withContext(IO) { BookHelp.getChapterFiles(book) })
+            adapter.notifyItemRangeChanged(0, adapter.itemCount, true)
         }
     }
 
@@ -112,57 +139,155 @@ class ChapterListFragment : VMBaseFragment<TocViewModel>(R.layout.fragment_chapt
             viewModel.bookData.value?.bookUrl?.let { bookUrl ->
                 if (book.bookUrl == bookUrl) {
                     adapter.cacheFileNames.add(chapter.getFileName())
-                    if (viewModel.searchKey.isNullOrEmpty()) {
-                        adapter.notifyItemChanged(chapter.index, true)
-                    } else {
-                        adapter.getItems().forEachIndexed { index, bookChapter ->
-                            if (bookChapter.index == chapter.index) {
-                                adapter.notifyItemChanged(index, true)
-                            }
-                        }
-                    }
+                    notifyVisibleChapterChanged(chapter.index)
                 }
             }
         }
     }
 
-    override fun upChapterList(searchKey: String?) {
-        lifecycleScope.launch {
-            withContext(IO) {
-                val end = (book?.simulatedTotalChapterNum() ?: Int.MAX_VALUE) - 1
-                when {
-                    searchKey.isNullOrBlank() ->
-                        appDb.bookChapterDao.getChapterList(viewModel.bookUrl, 0, end).also {
-                            chapterList = it
-                        }
-
-                    else -> appDb.bookChapterDao.search(viewModel.bookUrl, searchKey, 0, end)
+    override fun upChapterList(searchKey: String?, resetCollapse: Boolean) {
+        chapterListJob?.cancel()
+        chapterListJob = viewLifecycleOwner.lifecycleScope.launch {
+            val normalizedSearchKey = searchKey?.takeIf { it.isNotBlank() }
+            currentSearchKey = normalizedSearchKey
+            pendingScrollItemKey = null
+            pendingChapterScroll = null
+            val currentBook = book ?: return@launch
+            val reverseOrder = currentBook.getReverseToc()
+            if (normalizedSearchKey == null) {
+                if (resetCollapse || !tocListState.hasFullChapters()) {
+                    val chapters = queryChapterList(currentBook)
+                    chapterList = chapters
+                    tocListState.setFullChapters(
+                        chapters = chapters,
+                        currentChapterIndex = durChapterIndex,
+                        reverseOrder = reverseOrder,
+                        resetCollapse = resetCollapse,
+                    )
                 }
-            }.let {
-                adapter.setItems(it)
+                adapter.setItems(tocListState.showNormal(durChapterIndex))
+            } else {
+                delay(150)
+                if (resetCollapse || !tocListState.hasFullChapters()) {
+                    val chapters = queryChapterList(currentBook)
+                    chapterList = chapters
+                    tocListState.setFullChapters(
+                        chapters = chapters,
+                        currentChapterIndex = durChapterIndex,
+                        reverseOrder = reverseOrder,
+                        resetCollapse = resetCollapse,
+                    )
+                }
+                adapter.setItems(
+                    tocListState.showSearch(
+                        searchResultIndexes = queryChapterIndexes(
+                            currentBook,
+                            normalizedSearchKey,
+                        ),
+                        currentChapterIndex = durChapterIndex,
+                    )
+                )
+            }
+        }
+    }
+
+    private suspend fun queryChapterList(book: Book): List<BookChapter> {
+        return withContext(IO) {
+            val end = book.simulatedTotalChapterNum() - 1
+            appDb.bookChapterDao.getChapterList(book.bookUrl, 0, end)
+        }
+    }
+
+    private suspend fun queryChapterIndexes(book: Book, searchKey: String): List<Int> {
+        return withContext(IO) {
+            val end = book.simulatedTotalChapterNum() - 1
+            appDb.bookChapterDao.searchIndexes(book.bookUrl, searchKey, 0, end)
+        }
+    }
+
+    private fun notifyVisibleChapterChanged(chapterIndex: Int) {
+        val position = adapter.findVisiblePositionByChapterIndex(chapterIndex)
+        if (position >= 0) {
+            adapter.notifyItemChanged(position, true)
+        }
+    }
+
+    private fun scrollToChapterIndex(chapterIndex: Int, expandVolume: Boolean) {
+        if (expandVolume && currentSearchKey == null &&
+            tocListState.expandVolumeContainingChapter(chapterIndex)
+        ) {
+            pendingChapterScroll = chapterIndex
+            adapter.setItems(tocListState.showNormal(durChapterIndex))
+            return
+        }
+        scrollToResolvedChapterPosition(chapterIndex)
+    }
+
+    private fun scrollToResolvedChapterPosition(chapterIndex: Int) {
+        binding.recyclerView.post {
+            val position = tocListState.findFallbackVisiblePositionForChapterIndex(chapterIndex)
+            if (position >= 0) {
+                layoutManager.scrollToPositionWithOffset(position, 0)
+                adapter.upDisplayTitles(position)
             }
         }
     }
 
     override fun onListChanged() {
-        lifecycleScope.launch {
-            var scrollPos = 0
-            withContext(Default) {
-                adapter.getItems().forEachIndexed { index, bookChapter ->
-                    if (bookChapter.index >= durChapterIndex) {
-                        return@withContext
-                    }
-                    scrollPos = index
-                }
+        if (pendingScrollItemKey != null || pendingChapterScroll != null) return
+        viewLifecycleOwner.lifecycleScope.launch(Main) {
+            val scrollPosition = if (currentSearchKey == null) {
+                tocListState.findFallbackVisiblePositionForChapterIndex(durChapterIndex)
+                    .coerceAtLeast(0)
+            } else {
+                0
             }
-            mLayoutManager.scrollToPositionWithOffset(scrollPos, 0)
-            adapter.upDisplayTitles(scrollPos)
+            layoutManager.scrollToPositionWithOffset(scrollPosition, 0)
+            adapter.upDisplayTitles(scrollPosition)
+        }
+    }
+
+    override fun onVolumeToggled(volumeIndex: Int) {
+        if (currentSearchKey != null) return
+        val firstVisibleItem = adapter.getItem(layoutManager.findFirstVisibleItemPosition())
+        pendingScrollItemKey = if (
+            firstVisibleItem is TocListItem.Chapter &&
+            firstVisibleItem.parentVolumeIndex == volumeIndex &&
+            !tocListState.isVolumeCollapsed(volumeIndex)
+        ) {
+            "volume:$volumeIndex"
+        } else {
+            firstVisibleItem?.key
+        }
+        if (tocListState.toggleVolume(volumeIndex)) {
+            adapter.setItems(tocListState.showNormal(durChapterIndex))
+        } else {
+            pendingScrollItemKey = null
+        }
+    }
+
+    override fun onItemsUpdated() {
+        pendingChapterScroll?.let { chapterIndex ->
+            pendingChapterScroll = null
+            scrollToResolvedChapterPosition(chapterIndex)
+            return
+        }
+        val anchorKey = pendingScrollItemKey ?: return
+        pendingScrollItemKey = null
+        binding.recyclerView.post {
+            val position = adapter.findVisiblePositionByItemKey(anchorKey)
+            if (position >= 0) {
+                layoutManager.scrollToPositionWithOffset(position, 0)
+                adapter.upDisplayTitles(position)
+            } else {
+                adapter.upDisplayTitles(layoutManager.findFirstVisibleItemPosition())
+            }
         }
     }
 
     override fun clearDisplayTitle() {
         adapter.clearDisplayTitle()
-        adapter.upDisplayTitles(mLayoutManager.findFirstVisibleItemPosition())
+        adapter.upDisplayTitles(layoutManager.findFirstVisibleItemPosition())
     }
 
     override fun upAdapter() {
@@ -170,7 +295,7 @@ class ChapterListFragment : VMBaseFragment<TocViewModel>(R.layout.fragment_chapt
     }
 
     override val scope: CoroutineScope
-        get() = lifecycleScope
+        get() = viewLifecycleOwner.lifecycleScope
 
     override val book: Book?
         get() = viewModel.bookData.value
@@ -181,28 +306,21 @@ class ChapterListFragment : VMBaseFragment<TocViewModel>(R.layout.fragment_chapt
     override fun durChapterIndex(): Int {
         return durChapterIndex
     }
-    private var chapterList: List<BookChapter>? = null
 
     override fun openChapter(bookChapter: BookChapter) {
         activity?.run {
             if (book?.isVideo == true) {
-                val volumes = arrayListOf<BookChapter>()
-                chapterList?.forEach { chapter ->
-                    if (chapter.isVolume) {
-                        volumes.add(chapter)
-                    }
-                }
+                val volumes = chapterList.filterTo(arrayListOf()) { it.isVolume }
                 var chapterInVolumeIndex = 0
                 var durVolumeIndex = 0
                 if (volumes.isNotEmpty()) {
                     for ((index, volume) in volumes.reversed().withIndex()) {
-                        val first = bookChapter.index
-                        if (volume.index < first) {
-                            chapterInVolumeIndex = first - volume.index - 1
+                        val chapterIndex = bookChapter.index
+                        if (volume.index < chapterIndex) {
+                            chapterInVolumeIndex = chapterIndex - volume.index - 1
                             durVolumeIndex = volumes.size - index - 1
                             break
-                        } else if (volume.index == first) {
-                            chapterInVolumeIndex = 0
+                        } else if (volume.index == chapterIndex) {
                             durVolumeIndex = volumes.size - index - 1
                             break
                         }
@@ -211,22 +329,23 @@ class ChapterListFragment : VMBaseFragment<TocViewModel>(R.layout.fragment_chapt
                     chapterInVolumeIndex = bookChapter.index
                 }
                 setResult(
-                    RESULT_OK, Intent()
+                    RESULT_OK,
+                    Intent()
                         .putExtra("index", bookChapter.index)
                         .putExtra("chapterChanged", bookChapter.index != durChapterIndex)
                         .putExtra("durVolumeIndex", durVolumeIndex)
-                        .putExtra("chapterInVolumeIndex", chapterInVolumeIndex)
+                        .putExtra("chapterInVolumeIndex", chapterInVolumeIndex),
                 )
                 finish()
                 return@run
             }
             setResult(
-                RESULT_OK, Intent()
+                RESULT_OK,
+                Intent()
                     .putExtra("index", bookChapter.index)
-                    .putExtra("chapterChanged", bookChapter.index != durChapterIndex)
+                    .putExtra("chapterChanged", bookChapter.index != durChapterIndex),
             )
             finish()
         }
     }
-
 }

--- a/app/src/main/java/io/legado/app/ui/book/toc/TocActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/TocActivity.kt
@@ -139,7 +139,10 @@ class TocActivity : VMBaseActivity<ActivityChapterListBinding, TocViewModel>(),
             }
 
             R.id.menu_reverse_toc -> viewModel.reverseToc {
-                viewModel.chapterListCallBack?.upChapterList(searchView?.query?.toString())
+                viewModel.chapterListCallBack?.upChapterList(
+                    searchView?.query?.toString(),
+                    resetCollapse = true,
+                )
                 setResult(RESULT_OK, Intent().apply {
                     putExtra("index", it.durChapterIndex)
                     putExtra("chapterPos", 0)

--- a/app/src/main/java/io/legado/app/ui/book/toc/TocListItem.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/TocListItem.kt
@@ -1,0 +1,31 @@
+package io.legado.app.ui.book.toc
+
+import io.legado.app.data.entities.BookChapter
+
+sealed class TocListItem {
+    abstract val key: String
+    abstract val chapter: BookChapter
+    abstract val depth: Int
+
+    data class Volume(
+        override val chapter: BookChapter,
+        override val depth: Int,
+        val collapsed: Boolean,
+        val chapterCount: Int,
+        val matchedCount: Int? = null,
+        val matchedSelf: Boolean = false,
+        val containsCurrentChapter: Boolean = false,
+    ) : TocListItem() {
+        override val key: String = "volume:${chapter.index}"
+        val canToggle: Boolean
+            get() = chapterCount > 0 && matchedCount == null
+    }
+
+    data class Chapter(
+        override val chapter: BookChapter,
+        override val depth: Int,
+        val parentVolumeIndex: Int? = null,
+    ) : TocListItem() {
+        override val key: String = "chapter:${chapter.index}"
+    }
+}

--- a/app/src/main/java/io/legado/app/ui/book/toc/TocListState.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/TocListState.kt
@@ -1,0 +1,292 @@
+package io.legado.app.ui.book.toc
+
+import io.legado.app.data.entities.BookChapter
+
+class TocListState {
+
+    private data class VolumeGroup(
+        val volume: BookChapter?,
+        val chapters: List<BookChapter>,
+    )
+
+    private var fullChapters: List<BookChapter> = emptyList()
+    private var groups: List<VolumeGroup> = emptyList()
+    private var parentVolumeByChapterIndex: Map<Int, Int> = emptyMap()
+    private var volumeGroupByIndex: Map<Int, VolumeGroup> = emptyMap()
+    private val collapsedVolumeIndexes = mutableSetOf<Int>()
+    private var collapseInitialized = false
+    private var reverseOrder = false
+
+    var visibleItems: List<TocListItem> = emptyList()
+        private set
+
+    fun hasFullChapters(): Boolean = fullChapters.isNotEmpty()
+
+    fun clear() {
+        fullChapters = emptyList()
+        groups = emptyList()
+        parentVolumeByChapterIndex = emptyMap()
+        volumeGroupByIndex = emptyMap()
+        collapsedVolumeIndexes.clear()
+        collapseInitialized = false
+        reverseOrder = false
+        visibleItems = emptyList()
+    }
+
+    fun setFullChapters(
+        chapters: List<BookChapter>,
+        currentChapterIndex: Int,
+        reverseOrder: Boolean,
+        resetCollapse: Boolean = false,
+    ) {
+        val directionChanged = this.reverseOrder != reverseOrder
+        val previousCollapsibleVolumeIndexes = volumeGroupByIndex
+            .filterValues { it.chapters.isNotEmpty() }
+            .keys
+        this.reverseOrder = reverseOrder
+        fullChapters = chapters
+        groups = buildGroups(chapters, reverseOrder)
+        rebuildIndexes()
+        val collapsibleVolumeIndexes = groups
+            .filter { it.volume != null && it.chapters.isNotEmpty() }
+            .mapTo(mutableSetOf()) { it.volume!!.index }
+        if (resetCollapse || directionChanged || !collapseInitialized) {
+            resetDefaultCollapse(currentChapterIndex)
+            collapseInitialized = true
+        } else {
+            collapsedVolumeIndexes.retainAll(collapsibleVolumeIndexes)
+            val currentVolumeIndex = volumeIndexContaining(currentChapterIndex)
+            (collapsibleVolumeIndexes - previousCollapsibleVolumeIndexes).forEach { volumeIndex ->
+                if (volumeIndex != currentVolumeIndex) {
+                    collapsedVolumeIndexes.add(volumeIndex)
+                }
+            }
+        }
+    }
+
+    fun showNormal(currentChapterIndex: Int): List<TocListItem> {
+        val items = mutableListOf<TocListItem>()
+        groups.forEach { group ->
+            val volume = group.volume
+            if (volume == null) {
+                group.chapters.forEach { chapter ->
+                    items.add(TocListItem.Chapter(chapter = chapter, depth = 0))
+                }
+                return@forEach
+            }
+
+            val collapsed = collapsedVolumeIndexes.contains(volume.index)
+            val volumeItem = volumeItem(
+                group = group,
+                collapsed = collapsed,
+                currentChapterIndex = currentChapterIndex,
+            )
+            if (collapsed) {
+                items.add(volumeItem)
+            } else {
+                items.add(volumeItem)
+                addChapterItems(items, group)
+            }
+        }
+        visibleItems = items
+        return items
+    }
+
+    fun showSearch(
+        searchResultIndexes: Collection<Int>,
+        currentChapterIndex: Int,
+    ): List<TocListItem> {
+        val matchedIndexes = searchResultIndexes.toHashSet()
+        val items = mutableListOf<TocListItem>()
+        groups.forEach { group ->
+            val matchedChapters = group.chapters.filter { it.index in matchedIndexes }
+            val volume = group.volume
+            if (volume == null) {
+                matchedChapters.forEach { chapter ->
+                    items.add(TocListItem.Chapter(chapter = chapter, depth = 0))
+                }
+                return@forEach
+            }
+
+            val matchedSelf = volume.index in matchedIndexes
+            if (!matchedSelf && matchedChapters.isEmpty()) return@forEach
+            val volumeItem = volumeItem(
+                group = group,
+                collapsed = false,
+                currentChapterIndex = currentChapterIndex,
+                matchedCount = matchedChapters.size,
+                matchedSelf = matchedSelf,
+            )
+            items.add(volumeItem)
+            addChapterItems(items, group, matchedChapters)
+        }
+        visibleItems = items
+        return items
+    }
+
+    fun toggleVolume(volumeIndex: Int): Boolean {
+        val group = volumeGroupByIndex[volumeIndex] ?: return false
+        if (group.chapters.isEmpty()) return false
+        if (!collapsedVolumeIndexes.add(volumeIndex)) {
+            collapsedVolumeIndexes.remove(volumeIndex)
+        }
+        return true
+    }
+
+    fun expandVolumeContainingChapter(chapterIndex: Int): Boolean {
+        val volumeIndex = volumeIndexContaining(chapterIndex) ?: return false
+        return collapsedVolumeIndexes.remove(volumeIndex)
+    }
+
+    fun isVolumeCollapsed(volumeIndex: Int): Boolean {
+        return collapsedVolumeIndexes.contains(volumeIndex)
+    }
+
+    fun parentVolumeIndexOf(chapterIndex: Int): Int? {
+        return parentVolumeByChapterIndex[chapterIndex]
+    }
+
+    fun findVisiblePositionByChapterIndex(chapterIndex: Int): Int {
+        return visibleItems.indexOfFirst {
+            it is TocListItem.Chapter && it.chapter.index == chapterIndex
+        }
+    }
+
+    fun findVisiblePositionByVolumeIndex(volumeIndex: Int): Int {
+        return visibleItems.indexOfFirst {
+            it is TocListItem.Volume && it.chapter.index == volumeIndex
+        }
+    }
+
+    fun findFallbackVisiblePositionForChapterIndex(chapterIndex: Int): Int {
+        val chapterPosition = findVisiblePositionByChapterIndex(chapterIndex)
+        if (chapterPosition >= 0) return chapterPosition
+        val volumePosition = findVisiblePositionByVolumeIndex(chapterIndex)
+        if (volumePosition >= 0) return volumePosition
+        val parentVolumeIndex = parentVolumeByChapterIndex[chapterIndex] ?: return -1
+        return findVisiblePositionByVolumeIndex(parentVolumeIndex)
+    }
+
+    fun findVisiblePositionByItemKey(key: String): Int {
+        return visibleItems.indexOfFirst { it.key == key }
+    }
+
+    private fun volumeItem(
+        group: VolumeGroup,
+        collapsed: Boolean,
+        currentChapterIndex: Int,
+        matchedCount: Int? = null,
+        matchedSelf: Boolean = false,
+    ): TocListItem.Volume {
+        val volume = requireNotNull(group.volume)
+        return TocListItem.Volume(
+            chapter = volume,
+            depth = 0,
+            collapsed = collapsed,
+            chapterCount = group.chapters.size,
+            matchedCount = matchedCount,
+            matchedSelf = matchedSelf,
+            containsCurrentChapter = volume.index == currentChapterIndex ||
+                    parentVolumeByChapterIndex[currentChapterIndex] == volume.index,
+        )
+    }
+
+    private fun addChapterItems(
+        target: MutableList<TocListItem>,
+        group: VolumeGroup,
+        chapters: List<BookChapter> = group.chapters,
+    ) {
+        val volumeIndex = group.volume?.index
+        chapters.forEach { chapter ->
+            target.add(
+                TocListItem.Chapter(
+                    chapter = chapter,
+                    depth = if (volumeIndex == null) 0 else 1,
+                    parentVolumeIndex = volumeIndex,
+                )
+            )
+        }
+    }
+
+    private fun buildGroups(
+        chapters: List<BookChapter>,
+        reverseOrder: Boolean,
+    ): List<VolumeGroup> {
+        return if (reverseOrder) {
+            buildReverseGroups(chapters)
+        } else {
+            buildForwardGroups(chapters)
+        }
+    }
+
+    private fun buildForwardGroups(chapters: List<BookChapter>): List<VolumeGroup> {
+        val result = mutableListOf<VolumeGroup>()
+        var currentVolume: BookChapter? = null
+        var currentChapters = mutableListOf<BookChapter>()
+
+        fun flush() {
+            if (currentVolume != null || currentChapters.isNotEmpty()) {
+                result.add(VolumeGroup(currentVolume, currentChapters.toList()))
+            }
+        }
+
+        chapters.forEach { chapter ->
+            if (chapter.isVolume) {
+                flush()
+                currentVolume = chapter
+                currentChapters = mutableListOf()
+            } else {
+                currentChapters.add(chapter)
+            }
+        }
+        flush()
+        return result
+    }
+
+    private fun buildReverseGroups(chapters: List<BookChapter>): List<VolumeGroup> {
+        val result = mutableListOf<VolumeGroup>()
+        var currentChapters = mutableListOf<BookChapter>()
+        chapters.forEach { chapter ->
+            if (chapter.isVolume) {
+                result.add(VolumeGroup(chapter, currentChapters.toList()))
+                currentChapters = mutableListOf()
+            } else {
+                currentChapters.add(chapter)
+            }
+        }
+        if (currentChapters.isNotEmpty()) {
+            result.add(VolumeGroup(null, currentChapters.toList()))
+        }
+        return result
+    }
+
+    private fun rebuildIndexes() {
+        val parentMap = mutableMapOf<Int, Int>()
+        val volumeMap = mutableMapOf<Int, VolumeGroup>()
+        groups.forEach { group ->
+            val volume = group.volume ?: return@forEach
+            volumeMap[volume.index] = group
+            group.chapters.forEach { chapter ->
+                parentMap[chapter.index] = volume.index
+            }
+        }
+        parentVolumeByChapterIndex = parentMap
+        volumeGroupByIndex = volumeMap
+    }
+
+    private fun resetDefaultCollapse(currentChapterIndex: Int) {
+        collapsedVolumeIndexes.clear()
+        val currentVolumeIndex = volumeIndexContaining(currentChapterIndex)
+        groups.forEach { group ->
+            val volumeIndex = group.volume?.index ?: return@forEach
+            if (group.chapters.isNotEmpty() && volumeIndex != currentVolumeIndex) {
+                collapsedVolumeIndexes.add(volumeIndex)
+            }
+        }
+    }
+
+    private fun volumeIndexContaining(chapterIndex: Int): Int? {
+        return parentVolumeByChapterIndex[chapterIndex]
+            ?: chapterIndex.takeIf { volumeGroupByIndex.containsKey(it) }
+    }
+}

--- a/app/src/main/java/io/legado/app/ui/book/toc/TocViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/TocViewModel.kt
@@ -123,7 +123,7 @@ class TocViewModel(application: Application) : BaseViewModel(application) {
     }
 
     interface ChapterListCallBack {
-        fun upChapterList(searchKey: String?)
+        fun upChapterList(searchKey: String?, resetCollapse: Boolean = false)
 
         fun clearDisplayTitle()
 

--- a/app/src/main/res/layout/item_chapter_list.xml
+++ b/app/src/main/res/layout/item_chapter_list.xml
@@ -31,7 +31,7 @@
         android:singleLine="true"
         app:layout_constraintBottom_toTopOf="@+id/barrier"
         app:layout_constraintStart_toEndOf="@+id/iv_locked"
-        app:layout_constraintEnd_toStartOf="@+id/iv_checked"
+        app:layout_constraintEnd_toStartOf="@+id/end_actions"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="标题" />
 
@@ -65,7 +65,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@+id/tv_tag"
         app:layout_constraintTop_toBottomOf="@+id/barrier"
-        app:layout_constraintEnd_toStartOf="@+id/iv_checked"
+        app:layout_constraintEnd_toStartOf="@+id/end_actions"
         app:layout_constraintHorizontal_bias="0"
         app:layout_goneMarginStart="0dp"
         tools:ignore="RtlSymmetry"
@@ -79,18 +79,36 @@
         app:barrierDirection="top"
         app:constraint_referenced_ids="tv_word_count,tv_tag" />
 
-    <ImageView
-        android:id="@+id/iv_checked"
+    <FrameLayout
+        android:id="@+id/end_actions"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:contentDescription="@string/success"
-        android:padding="4dp"
-        android:src="@drawable/ic_check"
-        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:tint="@color/secondaryText"
-        tools:visibility="visible" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/iv_checked"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:contentDescription="@string/success"
+            android:padding="4dp"
+            android:src="@drawable/ic_check"
+            android:visibility="invisible"
+            app:tint="@color/secondaryText"
+            tools:visibility="visible" />
+
+        <ImageView
+            android:id="@+id/iv_volume_arrow"
+            android:layout_width="18dp"
+            android:layout_height="18dp"
+            android:layout_gravity="center"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_expand_more"
+            android:visibility="gone"
+            app:tint="@color/secondaryText"
+            tools:visibility="visible" />
+
+    </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -131,6 +131,11 @@
     <string name="screen_unspecified">Adaptado del sistema</string>
     <string name="disclaimer">Descargo de responsabilidad</string>
     <string name="all_chapter_num">%d capítulos</string>
+    <string name="toc_search_match_count">Coinciden %1$d/%2$d capítulos</string>
+    <string name="toc_volume_title_match">El título del volumen coincide</string>
+    <string name="toc_volume_tag_summary">%1$s · %2$s</string>
+    <string name="toc_expand_volume">Expandir volumen</string>
+    <string name="toc_collapse_volume">Contraer volumen</string>
     <string name="interface_setting">Interfaz</string>
     <string name="brightness">Brillo</string>
     <string name="chapter_list">Capítulos</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -135,6 +135,11 @@
     <string name="screen_unspecified">Follow system</string>
     <string name="disclaimer">Disclaimer</string>
     <string name="all_chapter_num">%d chapters</string>
+    <string name="toc_search_match_count">%1$d/%2$d 章が一致</string>
+    <string name="toc_volume_title_match">巻タイトルが一致</string>
+    <string name="toc_volume_tag_summary">%1$s · %2$s</string>
+    <string name="toc_expand_volume">巻を展開</string>
+    <string name="toc_collapse_volume">巻を折りたたむ</string>
     <string name="interface_setting">Interface</string>
     <string name="brightness">Brightness</string>
     <string name="chapter_list">Chapters</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -135,6 +135,11 @@
     <string name="screen_unspecified">Adaptar do sistema</string>
     <string name="disclaimer">Isenção de responsabilidade</string>
     <string name="all_chapter_num">%d capítulos</string>
+    <string name="toc_search_match_count">%1$d/%2$d capítulos correspondentes</string>
+    <string name="toc_volume_title_match">Título do volume correspondente</string>
+    <string name="toc_volume_tag_summary">%1$s · %2$s</string>
+    <string name="toc_expand_volume">Expandir volume</string>
+    <string name="toc_collapse_volume">Recolher volume</string>
     <string name="interface_setting">Interface</string>
     <string name="brightness">Brilho</string>
     <string name="chapter_list">Capítulos</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -130,6 +130,11 @@
     <string name="screen_unspecified">Theo hệ thống</string>
     <string name="disclaimer">Tuyên bố miễn trừ trách nhiệm</string>
     <string name="all_chapter_num">%d chương</string>
+    <string name="toc_search_match_count">Khớp %1$d/%2$d chương</string>
+    <string name="toc_volume_title_match">Khớp tiêu đề tập</string>
+    <string name="toc_volume_tag_summary">%1$s · %2$s</string>
+    <string name="toc_expand_volume">Mở rộng tập</string>
+    <string name="toc_collapse_volume">Thu gọn tập</string>
     <string name="interface_setting">Giao diện</string>
     <string name="brightness">Độ sáng</string>
     <string name="chapter_list">Danh sách chương</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -127,6 +127,11 @@
     <string name="screen_unspecified">跟隨系統</string>
     <string name="disclaimer">免責聲明</string>
     <string name="all_chapter_num">共%d章</string>
+    <string name="toc_search_match_count">符合 %1$d/%2$d 章</string>
+    <string name="toc_volume_title_match">卷名符合</string>
+    <string name="toc_volume_tag_summary">%1$s · %2$s</string>
+    <string name="toc_expand_volume">展開分卷</string>
+    <string name="toc_collapse_volume">收合分卷</string>
     <string name="interface_setting">介面</string>
     <string name="brightness">亮度</string>
     <string name="chapter_list">目錄</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -129,6 +129,11 @@
     <string name="screen_unspecified">跟隨系統</string>
     <string name="disclaimer">免責聲明</string>
     <string name="all_chapter_num">共%d章</string>
+    <string name="toc_search_match_count">符合 %1$d/%2$d 章</string>
+    <string name="toc_volume_title_match">卷名符合</string>
+    <string name="toc_volume_tag_summary">%1$s · %2$s</string>
+    <string name="toc_expand_volume">展開分卷</string>
+    <string name="toc_collapse_volume">收合分卷</string>
     <string name="interface_setting">介面</string>
     <string name="brightness">亮度</string>
     <string name="chapter_list">目錄</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -135,6 +135,11 @@
     <string name="screen_unspecified">跟随系统</string>
     <string name="disclaimer">免责声明</string>
     <string name="all_chapter_num">共 %d 章</string>
+    <string name="toc_search_match_count">匹配 %1$d/%2$d 章</string>
+    <string name="toc_volume_title_match">卷名匹配</string>
+    <string name="toc_volume_tag_summary">%1$s · %2$s</string>
+    <string name="toc_expand_volume">展开分卷</string>
+    <string name="toc_collapse_volume">折叠分卷</string>
     <string name="interface_setting">界面</string>
     <string name="brightness">亮度</string>
     <string name="chapter_list">目录</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,6 +137,11 @@
     <string name="screen_unspecified">Follow system</string>
     <string name="disclaimer">Disclaimer</string>
     <string name="all_chapter_num">%d chapters</string>
+    <string name="toc_search_match_count">%1$d/%2$d chapters matched</string>
+    <string name="toc_volume_title_match">Volume title matched</string>
+    <string name="toc_volume_tag_summary">%1$s · %2$s</string>
+    <string name="toc_expand_volume">Expand volume</string>
+    <string name="toc_collapse_volume">Collapse volume</string>
     <string name="interface_setting">Interface</string>
     <string name="brightness">Brightness</string>
     <string name="chapter_list">Chapters</string>

--- a/app/src/test/java/io/legado/app/ci/BetaReleaseWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/BetaReleaseWorkflowTest.kt
@@ -1,0 +1,38 @@
+package io.legado.app.ci
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class BetaReleaseWorkflowTest {
+
+    private val workflowText by lazy {
+        val userDir = requireNotNull(System.getProperty("user.dir"))
+        val workflowFile = generateSequence(File(userDir)) {
+            it.parentFile
+        }.map {
+            File(it, ".github/workflows/BetaRelease.yml")
+        }.first { it.isFile }
+        workflowFile
+            .readText()
+            .replace("\r\n", "\n")
+    }
+
+    @Test
+    fun `beta release only exposes the manual trigger`() {
+        val triggerBlock = workflowText
+            .substringAfter("on:\n")
+            .substringBefore("\nconcurrency:")
+
+        assertEquals("workflow_dispatch:", triggerBlock.trim())
+    }
+
+    @Test
+    fun `beta release keeps the merge commit guard`() {
+        val expected = "if: " + "$" +
+                "{{ !startsWith(github.event.head_commit.message, 'Merge pull request') }}"
+
+        assertTrue(workflowText.contains(expected))
+    }
+}

--- a/app/src/test/java/io/legado/app/ui/book/toc/TocListStateTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/toc/TocListStateTest.kt
@@ -1,0 +1,281 @@
+package io.legado.app.ui.book.toc
+
+import io.legado.app.data.entities.BookChapter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TocListStateTest {
+
+    @Test
+    fun `book without volumes stays flat`() {
+        val state = stateOf(listOf(chapter(0), chapter(1), chapter(2)), current = 1)
+
+        val items = state.showNormal(currentChapterIndex = 1)
+
+        assertEquals(listOf("chapter:0", "chapter:1", "chapter:2"), items.keys())
+        assertEquals(listOf(0, 0, 0), items.map { it.depth })
+    }
+
+    @Test
+    fun `default collapse only keeps current volume expanded`() {
+        val state = stateOf(
+            listOf(
+                volume(0, "First"), chapter(1), chapter(2),
+                volume(3, "Second"), chapter(4), chapter(5),
+            ),
+            current = 4,
+        )
+
+        val items = state.showNormal(currentChapterIndex = 4)
+
+        assertTrue(state.isVolumeCollapsed(0))
+        assertFalse(state.isVolumeCollapsed(3))
+        assertEquals(listOf("volume:0", "volume:3", "chapter:4", "chapter:5"), items.keys())
+        assertEquals(2, state.findVisiblePositionByChapterIndex(4))
+    }
+
+    @Test
+    fun `toggle changes visible rows and preserves current group marker`() {
+        val state = stateOf(
+            listOf(volume(0, "First"), chapter(1), chapter(2)),
+            current = 1,
+        )
+
+        assertTrue(state.toggleVolume(0))
+        val items = state.showNormal(currentChapterIndex = 1)
+
+        assertEquals(listOf("volume:0"), items.keys())
+        assertTrue((items.single() as TocListItem.Volume).containsCurrentChapter)
+    }
+
+    @Test
+    fun `empty volume remains actionable instead of pretending to collapse`() {
+        val state = stateOf(
+            listOf(volume(0, "Empty"), volume(1, "Second"), chapter(2)),
+            current = 2,
+        )
+
+        val items = state.showNormal(currentChapterIndex = 2)
+
+        assertFalse(state.isVolumeCollapsed(0))
+        assertFalse(state.toggleVolume(0))
+        assertEquals(listOf("volume:0", "volume:1", "chapter:2"), items.keys())
+        val emptyVolume = items.first() as TocListItem.Volume
+        assertEquals(0, emptyVolume.chapterCount)
+        assertFalse(emptyVolume.canToggle)
+    }
+
+    @Test
+    fun `hidden chapter falls back to parent and can expand it`() {
+        val state = stateOf(
+            listOf(volume(0, "First"), chapter(1), volume(2, "Second"), chapter(3)),
+            current = 1,
+        )
+        state.showNormal(currentChapterIndex = 1)
+
+        assertEquals(2, state.findFallbackVisiblePositionForChapterIndex(3))
+        assertTrue(state.expandVolumeContainingChapter(3))
+        state.showNormal(currentChapterIndex = 1)
+        assertEquals(3, state.findVisiblePositionByChapterIndex(3))
+    }
+
+    @Test
+    fun `search adds one parent context and keeps collapse state`() {
+        val all = listOf(
+            volume(0, "First"), chapter(1), chapter(2),
+            volume(3, "Second"), chapter(4), chapter(5),
+        )
+        val state = stateOf(all, current = 1)
+        assertTrue(state.isVolumeCollapsed(3))
+
+        val items = state.showSearch(listOf(4, 5), currentChapterIndex = 1)
+
+        assertEquals(listOf("volume:3", "chapter:4", "chapter:5"), items.keys())
+        val volumeItem = items.first() as TocListItem.Volume
+        assertEquals(2, volumeItem.matchedCount)
+        assertEquals(2, volumeItem.chapterCount)
+        assertFalse(volumeItem.canToggle)
+        assertTrue(state.isVolumeCollapsed(3))
+    }
+
+    @Test
+    fun `search volume title and child does not duplicate parent`() {
+        val all = listOf(volume(0, "First"), chapter(1), chapter(2))
+        val state = stateOf(all, current = 1)
+
+        val items = state.showSearch(listOf(0, 2), currentChapterIndex = 1)
+
+        assertEquals(listOf("volume:0", "chapter:2"), items.keys())
+        val volumeItem = items.first() as TocListItem.Volume
+        assertTrue(volumeItem.matchedSelf)
+        assertEquals(1, volumeItem.matchedCount)
+    }
+
+    @Test
+    fun `volume title match can stand without child matches`() {
+        val onlyVolume = volume(0, "First")
+        val state = stateOf(listOf(onlyVolume, chapter(1)), current = 1)
+
+        val items = state.showSearch(listOf(onlyVolume.index), currentChapterIndex = 1)
+
+        assertEquals(listOf("volume:0"), items.keys())
+        val volumeItem = items.single() as TocListItem.Volume
+        assertTrue(volumeItem.matchedSelf)
+        assertEquals(0, volumeItem.matchedCount)
+    }
+
+    @Test
+    fun `loose chapters stay at depth zero`() {
+        val state = stateOf(
+            listOf(chapter(0), volume(1, "First"), chapter(2), chapter(3)),
+            current = 2,
+        )
+
+        val items = state.showNormal(currentChapterIndex = 2)
+
+        assertEquals(listOf("chapter:0", "volume:1", "chapter:2", "chapter:3"), items.keys())
+        assertEquals(listOf(0, 0, 1, 1), items.map { it.depth })
+    }
+
+    @Test
+    fun `refresh preserves collapse state until an explicit reset`() {
+        val chapters = listOf(
+            volume(0, "First"), chapter(1),
+            volume(2, "Second"), chapter(3),
+        )
+        val state = stateOf(chapters, current = 1)
+        assertTrue(state.toggleVolume(2))
+
+        state.setFullChapters(chapters, 1, reverseOrder = false, resetCollapse = false)
+        state.showNormal(currentChapterIndex = 1)
+        assertFalse(state.isVolumeCollapsed(2))
+
+        state.setFullChapters(chapters, 3, reverseOrder = false, resetCollapse = true)
+        state.showNormal(currentChapterIndex = 3)
+        assertTrue(state.isVolumeCollapsed(0))
+        assertFalse(state.isVolumeCollapsed(2))
+    }
+
+    @Test
+    fun `new volume defaults to collapsed during a non resetting refresh`() {
+        val initial = listOf(volume(0, "First"), chapter(1))
+        val state = stateOf(initial, current = 1)
+        val refreshed = initial + listOf(volume(2, "Second"), chapter(3))
+
+        state.setFullChapters(refreshed, 1, reverseOrder = false, resetCollapse = false)
+        val items = state.showNormal(currentChapterIndex = 1)
+
+        assertTrue(state.isVolumeCollapsed(2))
+        assertEquals(listOf("volume:0", "chapter:1", "volume:2"), items.keys())
+    }
+
+    @Test
+    fun `reverse order assigns preceding chapters to trailing volume headers`() {
+        val reversed = listOf(
+            chapter(0, "C3"),
+            volume(1, "V2"),
+            chapter(2, "C2"),
+            chapter(3, "C1"),
+            volume(4, "V1"),
+        )
+        val state = stateOf(reversed, current = 0, reverse = true)
+
+        val items = state.showNormal(currentChapterIndex = 0)
+
+        assertEquals(listOf("volume:1", "chapter:0", "volume:4"), items.keys())
+        assertEquals(1, state.parentVolumeIndexOf(0))
+        assertEquals(4, state.parentVolumeIndexOf(2))
+        assertEquals(4, state.parentVolumeIndexOf(3))
+    }
+
+    @Test
+    fun `reverse search keeps volume before its matching child`() {
+        val reversed = listOf(
+            chapter(0, "C3"),
+            volume(1, "V2"),
+            chapter(2, "C2"),
+            chapter(3, "C1"),
+            volume(4, "V1"),
+        )
+        val state = stateOf(reversed, current = 0, reverse = true)
+
+        val items = state.showSearch(listOf(reversed[3].index), currentChapterIndex = 0)
+
+        assertEquals(listOf("volume:4", "chapter:3"), items.keys())
+    }
+
+    @Test
+    fun `switching direction rebuilds groups and collapse defaults`() {
+        val forward = listOf(volume(0, "V1"), chapter(1), volume(2, "V2"), chapter(3))
+        val state = stateOf(forward, current = 1)
+        val reversed = listOf(chapter(0, "C2"), volume(1, "V2"), chapter(2, "C1"), volume(3, "V1"))
+
+        state.setFullChapters(reversed, 0, reverseOrder = true, resetCollapse = false)
+        val items = state.showNormal(currentChapterIndex = 0)
+
+        assertEquals(listOf("volume:1", "chapter:0", "volume:3"), items.keys())
+        assertTrue(state.isVolumeCollapsed(3))
+    }
+
+    @Test
+    fun `item keys remain unique across a mixed list`() {
+        val state = stateOf(
+            listOf(chapter(0), volume(1, "V1"), chapter(2), volume(3, "Empty")),
+            current = 2,
+        )
+
+        val keys = state.showNormal(currentChapterIndex = 2).keys()
+
+        assertEquals(keys.size, keys.toSet().size)
+    }
+
+    @Test
+    fun `clear invalidates full and visible directory state`() {
+        val state = stateOf(listOf(volume(0, "V1"), chapter(1)), current = 1)
+        state.showNormal(currentChapterIndex = 1)
+
+        state.clear()
+
+        assertFalse(state.hasFullChapters())
+        assertTrue(state.visibleItems.isEmpty())
+        assertEquals(null, state.parentVolumeIndexOf(1))
+    }
+
+    private fun stateOf(
+        chapters: List<BookChapter>,
+        current: Int,
+        reverse: Boolean = false,
+    ): TocListState {
+        return TocListState().apply {
+            setFullChapters(
+                chapters = chapters,
+                currentChapterIndex = current,
+                reverseOrder = reverse,
+                resetCollapse = true,
+            )
+        }
+    }
+
+    private fun List<TocListItem>.keys(): List<String> = map { it.key }
+
+    private fun volume(index: Int, title: String): BookChapter {
+        return BookChapter(
+            url = "volume-$index",
+            title = title,
+            isVolume = true,
+            bookUrl = "book",
+            index = index,
+        )
+    }
+
+    private fun chapter(index: Int, title: String = "Chapter $index"): BookChapter {
+        return BookChapter(
+            url = "chapter-$index",
+            title = title,
+            bookUrl = "book",
+            index = index,
+        )
+    }
+}


### PR DESCRIPTION
## 更新内容

### 目录分卷折叠

- 参考 `skybbk1001/legadoT` 的 `621e73eb5`，按当前目录、缓存、视频入口和生命周期实现重新适配，没有直接引入该提交中的无关改动。
- 新增独立目录状态层，统一管理完整目录、可见条目、卷归属和折叠状态；默认折叠除当前章节所在卷以外的分卷。
- 保留整行点击打开章节或分卷内容，只由右侧箭头切换折叠，空分卷不显示无效开关。
- 当前章节被折叠时高亮所属分卷；跳转当前章节前自动展开分卷，并等待列表提交完成后再定位。
- 搜索结果补充分卷上下文和匹配数量，清空搜索后恢复原折叠状态；查询改为只读取匹配章节索引，并加入 150 ms 防抖和过期任务取消。
- 修正倒序目录中分卷与章节的分组和显示顺序，缓存状态更新改为通过章节索引定位可见条目。
- 分离搜索任务和缓存扫描任务，视图销毁时主动释放适配器、异步标题任务和触摸代理，避免旧页面回调更新新列表。
- 为折叠按钮补充 48dp 触摸区域、无障碍操作说明，并补齐现有全部本地化语言。

### Beta Release

- `BetaRelease.yml` 只保留 `workflow_dispatch`，不再由分支推送或其他工作流自动触发。
- 完整保留 `if: ${{ !startsWith(github.event.head_commit.message, 'Merge pull request') }}` 条件。
- 新增工作流回归测试，约束手动触发入口和现有 Merge 提交过滤条件。

## 兼容与边界

- 不涉及数据库结构迁移，也不改变对外接口；完整章节列表仍保留给现有视频入口使用。
- 当前章节模型只记录扁平的 `isVolume`，因此本次按一级分卷处理，无法可靠恢复 EPUB/MOBI 的多级目录深度。
- 倒序目录的列表分组已适配；视频播放模块原有的“分卷位于剧集之前”假设不在本次范围内。

## 验证

- `:app:testAppReleaseUnitTest --build-cache --parallel --daemon --warning-mode all`
- `:app:assembleRelease -ParmOnly=true --build-cache --parallel --daemon --warning-mode all`
- `:app:assembleRelease --build-cache --parallel --daemon --warning-mode all`
- ARM 与通用 APK 均完成本地构建，R8、lint 和新增单元测试通过。
- PR 创建后由 `test.yml` 继续执行远端编译测试。