### PR TITLE
补充 JavaScript 书源关键契约测试

### DIFF
--- a/app/src/test/java/io/legado/app/model/jsSource/JsSourceConfigTest.kt
+++ b/app/src/test/java/io/legado/app/model/jsSource/JsSourceConfigTest.kt
@@ -72,6 +72,17 @@ class JsSourceConfigTest {
     }
 
     @Test
+    fun `explore metadata requires matching function`() {
+        assertExtractError(
+            validScript.replace(
+                "header: \"{\\\"User-Agent\\\":\\\"test\\\"}\"",
+                "exploreUrl: \"分类::https://example.com/list\"",
+            ),
+            "explore",
+        )
+    }
+
+    @Test
     fun `normalizes login form array`() {
         val source = JsSourceConfig.extract(
             validScript.replace(
@@ -165,6 +176,37 @@ class JsSourceConfigTest {
             "var source = { lastUpdateTime: 123456 };",
             JsSourceConfig.stampLastUpdateTime(script, 123456),
         )
+    }
+
+    @Test
+    fun `extracts declared update time and defaults missing to zero`() {
+        val declared = JsSourceConfig.extract(
+            validScript.replace(
+                "header: \"{\\\"User-Agent\\\":\\\"test\\\"}\"",
+                "lastUpdateTime: 1752449000000",
+            )
+        )
+
+        assertEquals(1752449000000L, declared.lastUpdateTime)
+        assertEquals(0L, JsSourceConfig.extract(validScript).lastUpdateTime)
+    }
+
+    @Test
+    fun `stamps numeric update time without touching later declarations`() {
+        val script = """
+            var source = {
+                lastUpdateTime: 0 // version timestamp
+            };
+            var fallback = { lastUpdateTime: 1 };
+        """.trimIndent()
+        val expected = """
+            var source = {
+                lastUpdateTime: 123456 // version timestamp
+            };
+            var fallback = { lastUpdateTime: 1 };
+        """.trimIndent()
+
+        assertEquals(expected, JsSourceConfig.stampLastUpdateTime(script, 123456))
     }
 
     private fun assertExtractError(script: String, messagePart: String) {

--- a/app/src/test/java/io/legado/app/model/jsSource/JsSourceDispatchSentinelTest.kt
+++ b/app/src/test/java/io/legado/app/model/jsSource/JsSourceDispatchSentinelTest.kt
@@ -1,0 +1,72 @@
+package io.legado.app.model.jsSource
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class JsSourceDispatchSentinelTest {
+
+    @Test
+    fun `web book entries dispatch before declarative handling`() {
+        val webBook = readProjectFile(
+            "app/src/main/java/io/legado/app/model/webBook/WebBook.kt"
+        )
+        val contracts = listOf(
+            DispatchContract("searchBookAwait", "JsSourceBook.searchAwait", "val searchUrl"),
+            DispatchContract("exploreBookAwait", "JsSourceBook.exploreAwait", "val ruleData"),
+            DispatchContract("getBookInfoAwait", "JsSourceBook.getBookInfoAwait", "book.removeAllBookType()"),
+            DispatchContract("getChapterListAwait", "JsSourceBook.getChapterListAwait", "book.removeAllBookType()"),
+            DispatchContract("getContentAwait", "JsSourceBook.getContentAwait", "val contentRule"),
+        )
+
+        contracts.forEach { contract ->
+            val method = suspendMethodBody(webBook, contract.methodName)
+            val dispatch = method.indexOf(contract.dispatchCall)
+            val declarativeStart = method.indexOf(contract.declarativeStart)
+
+            assertTrue("${contract.methodName} is missing ${contract.dispatchCall}", dispatch >= 0)
+            assertTrue(
+                "${contract.methodName} is missing declarative marker ${contract.declarativeStart}",
+                declarativeStart >= 0,
+            )
+            assertTrue(
+                "${contract.methodName} must dispatch JS sources before declarative handling",
+                dispatch < declarativeStart,
+            )
+        }
+    }
+
+    private fun suspendMethodBody(source: String, methodName: String): String {
+        val start = source.indexOf("suspend fun $methodName(")
+        check(start >= 0) { "Missing suspend method $methodName" }
+        val bodyStart = source.indexOf('{', start)
+        check(bodyStart >= 0) { "Missing body for suspend method $methodName" }
+        var depth = 0
+        for (index in bodyStart until source.length) {
+            when (source[index]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) return source.substring(bodyStart + 1, index)
+                }
+            }
+        }
+        error("Unclosed body for suspend method $methodName")
+    }
+
+    private fun readProjectFile(path: String): String {
+        val userDirectory = File(requireNotNull(System.getProperty("user.dir"))).absoluteFile
+        val repositoryRoot = generateSequence(userDirectory) { it.parentFile }
+            .firstOrNull { File(it, "app/src/main").isDirectory }
+        requireNotNull(repositoryRoot) { "Repository root not found from $userDirectory" }
+        val file = File(repositoryRoot, path)
+        require(file.isFile) { "Project file not found: $file" }
+        return file.readText()
+    }
+
+    private data class DispatchContract(
+        val methodName: String,
+        val dispatchCall: String,
+        val declarativeStart: String,
+    )
+}

--- a/app/src/test/java/io/legado/app/model/jsSource/JsSourceEngineTest.kt
+++ b/app/src/test/java/io/legado/app/model/jsSource/JsSourceEngineTest.kt
@@ -84,6 +84,37 @@ class JsSourceEngineTest {
         assertNull(JsSourceEngine.normalizeJsResult(result, scope))
     }
 
+    @Test
+    fun `optional function returns null when missing`() {
+        val source = BookSource(
+            bookSourceUrl = "https://example.com",
+            bookSourceName = "test",
+            mainJs = "var source = {};",
+        )
+
+        assertNull(JsSourceEngine(source).callFunctionIfExists("getBookInfo", emptyList()))
+    }
+
+    @Test
+    fun `optional function executes when present`() {
+        val source = BookSource(
+            bookSourceUrl = "https://example.com",
+            bookSourceName = "test",
+            mainJs = """
+                var source = {};
+                function getBookInfo() {
+                    return { intro: "optional result" };
+                }
+            """.trimIndent(),
+        )
+
+        val json = JsSourceEngine(source)
+            .callFunctionIfExists("getBookInfo", emptyList())
+            .orEmpty()
+
+        assertTrue(json.contains("optional result"))
+    }
+
     private fun evaluate(
         script: String,
         expression: String,

--- a/app/src/test/java/io/legado/app/model/jsSource/JsSourceTocWriteBackSentinelTest.kt
+++ b/app/src/test/java/io/legado/app/model/jsSource/JsSourceTocWriteBackSentinelTest.kt
@@ -1,0 +1,59 @@
+package io.legado.app.model.jsSource
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class JsSourceTocWriteBackSentinelTest {
+
+    @Test
+    fun `chapter parsing writes book metadata after empty check`() {
+        val source = readProjectFile(
+            "app/src/main/java/io/legado/app/model/jsSource/JsSourceBook.kt"
+        )
+        val method = suspendMethodBody(source, "getChapterListAwait")
+        val steps = listOf(
+            "JsSourceMarshaller.parseChapters",
+            "if (chapters.isEmpty())",
+            "BookChapterList.updateBookTocInfo(book, chapters)",
+            "\n            chapters",
+        )
+        val positions = steps.map { step ->
+            method.indexOf(step).also { position ->
+                assertTrue("getChapterListAwait is missing step: $step", position >= 0)
+            }
+        }
+
+        positions.zipWithNext().forEach { (first, second) ->
+            assertTrue("getChapterListAwait steps are out of order", first < second)
+        }
+    }
+
+    private fun suspendMethodBody(source: String, methodName: String): String {
+        val start = source.indexOf("suspend fun $methodName(")
+        check(start >= 0) { "Missing suspend method $methodName" }
+        val bodyStart = source.indexOf('{', start)
+        check(bodyStart >= 0) { "Missing body for suspend method $methodName" }
+        var depth = 0
+        for (index in bodyStart until source.length) {
+            when (source[index]) {
+                '{' -> depth++
+                '}' -> {
+                    depth--
+                    if (depth == 0) return source.substring(bodyStart + 1, index)
+                }
+            }
+        }
+        error("Unclosed body for suspend method $methodName")
+    }
+
+    private fun readProjectFile(path: String): String {
+        val userDirectory = File(requireNotNull(System.getProperty("user.dir"))).absoluteFile
+        val repositoryRoot = generateSequence(userDirectory) { it.parentFile }
+            .firstOrNull { File(it, "app/src/main").isDirectory }
+        requireNotNull(repositoryRoot) { "Repository root not found from $userDirectory" }
+        val file = File(repositoryRoot, path)
+        require(file.isFile) { "Project file not found: $file" }
+        return file.readText()
+    }
+}


### PR DESCRIPTION
## 变更内容

- 为当前 JavaScript 单文件书源实现补充跨层回归保护，覆盖 WebBook 的搜索、发现、书籍详情、目录和正文五个入口。
- 固定 JS 书源分流必须发生在声明式规则处理之前，避免后续重构把单文件源错误地送入旧路径。
- 固定目录解析、空目录判断、书籍目录信息回写和返回结果的顺序，确保目录更新时间等共享字段不会被遗漏。
- 补充 `callFunctionIfExists` 的可选函数行为：函数缺失时返回空结果，存在时执行并正确归一化返回对象。
- 补充发现函数配对校验、导入版本时间戳提取默认值，以及带注释数字时间戳的首个声明替换行为。
- 结构哨兵测试会从 Gradle 工作目录向上定位仓库根目录，并按真实方法体范围检查，避免对其他方法或重复文本产生误判。

## 兼容性说明

- 本 PR 只增加测试，不改变应用运行时代码、资源和更新日志。
- 测试断言围绕当前主线已经存在的 JS 单文件源契约，不引入新的运行时依赖。

## 验证

- `./gradlew :app:testAppReleaseUnitTest --tests io.legado.app.model.jsSource.JsSourceConfigTest --tests io.legado.app.model.jsSource.JsSourceEngineTest --tests io.legado.app.model.jsSource.JsSourceDispatchSentinelTest --tests io.legado.app.model.jsSource.JsSourceTocWriteBackSentinelTest`
- 相关测试全部通过。