### PR TITLE
补充 Java 字符串脚本边界说明

### DIFF
--- a/app/src/main/assets/web/help/md/jsHelp.md
+++ b/app/src/main/assets/web/help/md/jsHelp.md
@@ -795,6 +795,44 @@ function getContent(chapter, book, nextChapterUrl) {
 函数运行时可使用 `java`、`sourceApi`、`baseUrl`、`cookie`、`cache` 和当前函数参数。
 每次调用都会建立新的脚本作用域并重新执行主脚本，编译缓存不会保留顶层变量值。
 
+#### Java String 包装边界
+
+`key`、`baseUrl` 等直接绑定的字符串是 JS 原生字符串。从 Java 对象成员或 Java 方法取得的
+字符串，例如 `book.bookUrl`、`chapter.title`、`chapter.url`、Jsoup 的 `.text()`/`.attr()`
+以及 `java.ajax()` 返回值，则可能保留为 Java `String` 包装对象。两者显示和拼接结果相同，
+但类型、真假值、严格相等和同名方法分派不同。
+
+以下示例假设 `chapter.title` 为 `"第1章"`、`chapter.url` 为 `"https://a/b/"`、
+`chapter.tag` 为 Java 空字符串：
+
+|表达式|当前行为|
+|---|---|
+|`typeof chapter.title`|`"object"`|
+|`typeof chapter.title.length`|`"function"`；Java 长度应调用 `chapter.title.length()`|
+|`chapter.tag ? "T" : "F"`|`"T"`；包装后的 Java 空字符串仍是真值|
+|`chapter.title === "第1章"`|`false`；使用宽松相等 `==` 才按文本相等|
+|`chapter.url.replace(/b/, "X")`|可能因 Java `replace` 重载无法唯一选择而抛错|
+|`chapter.url.split("/").length`|`4`；调用 Java `split(regex)`，会丢弃尾部空串|
+|`chapter.url.split("/", -1).length`|`5`；Java 双参数重载可保留尾部空串|
+
+需要使用 JS 的正则 `replace`、`split`、`.length` 属性、空串真假值或严格相等时，先用
+`String(...)` 归一化：
+
+```js
+var url = String(chapter.url || "");
+var title = String(chapter.title || "");
+var tag = String(chapter.tag || "");
+
+url.replace(/b/, "X");       // https://a/X/
+url.split("/").length;       // 5，使用 JS split 语义
+title.length;                 // 3，使用 JS length 属性
+tag ? "T" : "F";             // F
+title === "第1章";           // true
+```
+
+若明确需要 Java 语义，可以直接调用 `length()`、`indexOf(...)`、`split(regex, limit)` 等
+Java 方法。不要依赖某个方法名恰好回落到 `String.prototype`；跨 Java/JS 边界后先归一化最稳妥。
+
 - 不要依赖顶层可变变量在函数或请求之间传递状态。
 - 不要假设搜索、详情、目录和正文一定按固定顺序执行。
 - 同一个书源可能同时执行多个请求。

--- a/app/src/test/java/io/legado/app/JsTest.kt
+++ b/app/src/test/java/io/legado/app/JsTest.kt
@@ -121,6 +121,53 @@ class JsTest {
     }
 
     @Test
+    fun javaStringInteropBoundary() {
+        val chapter = BookChapter(
+            title = "第1章",
+            url = "https://a/b/",
+            tag = "",
+        )
+        val bindings = ScriptBindings()
+        bindings["chapter"] = chapter
+        bindings["key"] = "native"
+        bindings["baseUrl"] = "https://base.example"
+        fun evaluate(js: String) = RhinoScriptEngine.eval(js, bindings)
+
+        Assert.assertEquals("string", evaluate("typeof key"))
+        Assert.assertEquals("string", evaluate("typeof baseUrl"))
+        Assert.assertEquals("object", evaluate("typeof chapter.title"))
+        Assert.assertEquals("object", evaluate("typeof chapter.title.substring(0, 1)"))
+        Assert.assertEquals("function", evaluate("typeof chapter.title.length"))
+        Assert.assertEquals("3", evaluate("'' + chapter.title.length()"))
+        Assert.assertEquals("3", evaluate("'' + String(chapter.title).length"))
+
+        Assert.assertEquals("T", evaluate("chapter.tag ? 'T' : 'F'"))
+        Assert.assertEquals("F", evaluate("String(chapter.tag) ? 'T' : 'F'"))
+        Assert.assertEquals(
+            "false:true:true",
+            evaluate(
+                "(chapter.title === '第1章') + ':' + " +
+                    "(chapter.title == '第1章') + ':' + " +
+                    "(String(chapter.title) === '第1章')"
+            ),
+        )
+
+        val ambiguousReplace = runCatching {
+            evaluate("chapter.url.replace(/b/, 'X')")
+        }
+        Assert.assertTrue("Java replace overload should reject a JS RegExp", ambiguousReplace.isFailure)
+        Assert.assertEquals(
+            "https://a/X/",
+            evaluate("String(chapter.url).replace(/b/, 'X')"),
+        )
+
+        Assert.assertEquals("4", evaluate("'' + chapter.url.split('/').length"))
+        Assert.assertEquals("5", evaluate("'' + chapter.url.split('/', -1).length"))
+        Assert.assertEquals("5", evaluate("'' + String(chapter.url).split('/').length"))
+        Assert.assertEquals("string", evaluate("typeof String(chapter.url)"))
+    }
+
+    @Test
     fun typeofString() {
         val bindings = ScriptBindings()
         @Language("js")

--- a/app/src/test/java/io/legado/app/model/jsSource/JsSourceAuthorGuideTest.kt
+++ b/app/src/test/java/io/legado/app/model/jsSource/JsSourceAuthorGuideTest.kt
@@ -56,6 +56,24 @@ class JsSourceAuthorGuideTest {
         assertFalse(guide.contains("getReviewSummary"))
     }
 
+    @Test
+    fun `guide documents Java string wrapper boundaries`() {
+        val requiredText = listOf(
+            "`typeof chapter.title`",
+            "`chapter.title.length()`",
+            "`chapter.tag ? \"T\" : \"F\"`",
+            "`chapter.title === \"第1章\"`",
+            "`chapter.url.replace(/b/, \"X\")`",
+            "`chapter.url.split(\"/\", -1).length`",
+            "String(chapter.url || \"\")",
+            "String(chapter.tag || \"\")",
+        )
+
+        requiredText.forEach { text ->
+            assertTrue("Missing Java string boundary documentation: $text", guide.contains(text))
+        }
+    }
+
     private fun source(relativePath: String): String {
         return File(repositoryRoot(), relativePath).readText()
     }


### PR DESCRIPTION
## 背景

JavaScript 单文件书源运行时既会接收 JS 原生字符串，也会接收来自 Java 对象属性和方法返回值的 Java `String` 包装对象。两者显示结果相近，但在类型判断、长度、空字符串真假值、严格相等以及同名方法分派上存在明显差异，容易造成规则在运行时出现难以定位的问题。

## 更新内容

- 在 JavaScript 书源帮助中新增 Java `String` 包装边界说明
- 列出 `typeof`、`length()`、空字符串真假值、严格/宽松相等的当前行为
- 说明 Java `replace` 重载歧义和 `split(regex[, limit])` 的尾空串差异
- 给出使用 `String(...)` 转为 JS 原生字符串的推荐写法
- 增加 Rhino 运行时契约测试，覆盖上述差异
- 增加文档哨兵测试，防止关键说明在后续调整中被遗漏

## 兼容性

本次只修改帮助文档和测试，不改变 JavaScript 书源生产逻辑。测试断言基于项目当前使用的 Rhino 1.8.1 实际运行结果，未依赖异常消息或具体异常类型。

## 验证

```
./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.JsTest --tests io.legado.app.model.jsSource.JsSourceAuthorGuideTest
```

本地验证通过，`test.yml` 的 release 与 releaseA 构建均已通过。