### PR TITLE
补充 JavaScript 引擎能力测试

### DIFF
--- a/app/src/test/java/io/legado/app/JsEngineCapabilitiesTest.kt
+++ b/app/src/test/java/io/legado/app/JsEngineCapabilitiesTest.kt
@@ -1,0 +1,97 @@
+package io.legado.app
+
+import com.script.ScriptBindings
+import com.script.rhino.RhinoScriptEngine
+import org.intellij.lang.annotations.Language
+import org.junit.Assert
+import org.junit.Test
+import org.mozilla.javascript.Scriptable
+import org.mozilla.javascript.ScriptableObject
+
+class JsEngineCapabilitiesTest {
+
+    @Test
+    fun currentRhinoSupportsStableModernSyntax() {
+        val cases = listOf(
+            "const suffix = 'ok'; `rhino-${'$'}{suffix}`" to "rhino-ok",
+            "var {left, right} = {left: 2, right: 3}; " +
+                "var [first, second] = [4, 5]; '' + (left + right + first + second)" to "14",
+            "function valueOr(value = 7) { return value }; '' + valueOr()" to "7",
+            "var config = {nested: {value: 5}}; " +
+                "'' + (config.missing?.value ?? config.nested?.value)" to "5",
+            "var key = 'n'; var value = {[key]: 4, double() { return this[key] * 2 }}; " +
+                "'' + value.double()" to "8",
+        )
+
+        cases.forEach { (js, expected) ->
+            Assert.assertEquals(
+                "Unexpected result for: $js",
+                expected,
+                RhinoScriptEngine.eval(js, ScriptBindings()),
+            )
+        }
+    }
+
+    @Test
+    fun topLevelDeclarationsRemainVisibleToSourceExtraction() {
+        listOf("var", "let", "const").forEach { declaration ->
+            val scope = RhinoScriptEngine.getRuntimeScope(ScriptBindings())
+            RhinoScriptEngine.eval("$declaration source = {value: 1}", scope)
+
+            Assert.assertNotSame(
+                "Top-level $declaration declaration is no longer visible",
+                Scriptable.NOT_FOUND,
+                ScriptableObject.getProperty(scope, "source"),
+            )
+        }
+    }
+
+    @Test
+    fun restParametersDoNotImplySpreadSyntaxSupport() {
+        val supported = """
+            function collect(head, ...tail) {
+                return head + ':' + tail.join('-')
+            }
+            collect('x', 1, 2)
+        """.trimIndent()
+        Assert.assertEquals("x:1-2", RhinoScriptEngine.eval(supported, ScriptBindings()))
+
+        assertUnsupported("function add(a, b) { return a + b }; add(...[1, 2])")
+        assertUnsupported("var [head, ...tail] = [1, 2, 3]; tail.length")
+    }
+
+    @Test
+    fun logicalAssignmentOperatorsPreserveShortCircuitSemantics() {
+        val cases = listOf(
+            "var a = null, b = 0; a ??= 5; b ??= 6; a + ':' + b" to "5:0",
+            "var a = 1, b = 0; a &&= 7; b &&= 8; a + ':' + b" to "7:0",
+            "var a = 1, b = 0; a ||= 7; b ||= 8; a + ':' + b" to "1:8",
+        )
+
+        cases.forEach { (js, expected) ->
+            Assert.assertEquals(expected, RhinoScriptEngine.eval(js, ScriptBindings()))
+        }
+    }
+
+    @Test
+    fun jsoupIsReachableFromJsScope() {
+        @Language("js")
+        val js = """
+            var doc = org.jsoup.Jsoup.parse(
+                '<div><a class="t">first</a><a class="t">second</a></div>'
+            )
+            var values = []
+            for (var element of doc.select('a.t')) {
+                values.push(element.text())
+            }
+            values.join(',')
+        """.trimIndent()
+
+        Assert.assertEquals("first,second", RhinoScriptEngine.eval(js, ScriptBindings()))
+    }
+
+    private fun assertUnsupported(js: String) {
+        val result = runCatching { RhinoScriptEngine.eval(js, ScriptBindings()) }
+        Assert.assertTrue("Current Rhino unexpectedly accepted: $js", result.isFailure)
+    }
+}


### PR DESCRIPTION
## 背景

对比仓库中的部分 JavaScript 能力结论来自不同的脚本引擎，不能直接套用到当前项目。此次按项目实际使用的 Rhino 1.8.1 重新执行能力探针，并将稳定行为固化为测试，便于后续升级引擎时及时发现兼容性变化。

## 更新内容

- 验证模板字符串、基础解构、默认参数、计算属性、方法简写、可选链和空值合并
- 验证顶层 `var`、`let`、`const` 均可被书源提取逻辑读取
- 明确 rest 参数可用，但当前调用展开和 rest 解构仍不支持
- 验证 `??=`、`&&=`、`||=` 的赋值及短路语义
- 验证脚本作用域可直接访问 `org.jsoup.Jsoup` 并遍历选择结果

## 兼容性

本次仅新增运行时能力测试，不修改 JavaScript 执行、书源解析或应用界面。断言基于当前依赖版本的真实执行结果，后续升级 Rhino 时若能力边界变化，测试会直接提示需要重新校准。

## 验证

```
./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.JsEngineCapabilitiesTest
```

目标测试和完整 `:app:testAppReleaseUnitTest --warning-mode all` 均已通过，`test.yml` 的 release 与 releaseA 构建也已通过。