### PR TITLE
清理列表载荷的弃用 Bundle 调用

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceDialog.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.ImageButton
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
-import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.lifecycleScope
@@ -461,7 +460,9 @@ class ChangeBookSourceDialog() : BaseDialogFragment(R.layout.dialog_book_change_
             adapter.notifyItemRangeChanged(
                 0,
                 adapter.itemCount,
-                bundleOf(Pair("upCurSource", oldBookUrl))
+                Bundle().apply {
+                    putString("upCurSource", oldBookUrl)
+                }
             )
         }
     }

--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeChapterSourceDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeChapterSourceDialog.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
-import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle.State.STARTED
@@ -400,7 +399,9 @@ class ChangeChapterSourceDialog() : BaseDialogFragment(R.layout.dialog_chapter_c
             searchBookAdapter.notifyItemRangeChanged(
                 0,
                 searchBookAdapter.itemCount,
-                bundleOf(Pair("upCurSource", oldBookUrl))
+                Bundle().apply {
+                    putString("upCurSource", oldBookUrl)
+                }
             )
         }
     }

--- a/app/src/main/java/io/legado/app/ui/book/explore/ExploreShowActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/explore/ExploreShowActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.MenuItem
 import android.view.ViewGroup
 import androidx.activity.viewModels
-import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import io.legado.app.R
@@ -95,7 +94,9 @@ class ExploreShowActivity : VMBaseActivity<ActivityExploreShowBinding, ExploreSh
             loadMoreViewTop.error(it)
         }
         viewModel.upAdapterLiveData.observe(this) {
-            adapter.notifyItemRangeChanged(0, adapter.itemCount, bundleOf(it to null))
+            adapter.notifyItemRangeChanged(0, adapter.itemCount, Bundle().apply {
+                putString(it, null)
+            })
         }
         viewModel.pageLiveData.observe(this) {
             menuPage.title = getString(R.string.menu_page, it)

--- a/app/src/main/java/io/legado/app/ui/book/manage/BookAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/manage/BookAdapter.kt
@@ -2,9 +2,9 @@ package io.legado.app.ui.book.manage
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.RecyclerView
 import io.legado.app.R
 import io.legado.app.base.adapter.ItemViewHolder
@@ -148,7 +148,9 @@ class BookAdapter(context: Context, val callBack: CallBack) :
                 selectedBooks.add(it)
             }
         }
-        notifyItemRangeChanged(minPosition, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(minPosition, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upSelectCount()
     }
 
@@ -215,7 +217,9 @@ class BookAdapter(context: Context, val callBack: CallBack) :
                     } else {
                         selectedBooks.remove(it)
                     }
-                    notifyItemChanged(position, bundleOf(Pair("selected", null)))
+                    notifyItemChanged(position, Bundle().apply {
+                        putString("selected", null)
+                    })
                     callBack.upSelectCount()
                     return true
                 }

--- a/app/src/main/java/io/legado/app/ui/book/search/SearchActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/search/SearchActivity.kt
@@ -10,7 +10,6 @@ import android.view.View.VISIBLE
 import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.appcompat.widget.SearchView
-import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -441,7 +440,9 @@ class SearchActivity : VMBaseActivity<ActivityBookSearchBinding, SearchViewModel
 
     override fun observeLiveBus() {
         viewModel.upAdapterLiveData.observe(this) {
-            adapter.notifyItemRangeChanged(0, adapter.itemCount, bundleOf(it to null))
+            adapter.notifyItemRangeChanged(0, adapter.itemCount, Bundle().apply {
+                putString(it, null)
+            })
         }
         viewModel.searchFinishLiveData.observe(this) { isEmpty ->
             if (!isEmpty || viewModel.searchScope.isAll()) return@observe

--- a/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceActivity.kt
@@ -10,7 +10,6 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.PopupMenu
 import androidx.appcompat.widget.SearchView
-import androidx.core.os.bundleOf
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -654,7 +653,9 @@ class BookSourceActivity : VMBaseActivity<ActivityBookSourceBinding, BookSourceV
             adapter.notifyItemRangeChanged(
                 0,
                 adapter.itemCount,
-                bundleOf(Pair("checkSourceMessage", null))
+                Bundle().apply {
+                    putString("checkSourceMessage", null)
+                }
             )
             groups.forEach { group ->
                 if (group.contains("失效") && searchView.query.isEmpty()) {
@@ -674,13 +675,17 @@ class BookSourceActivity : VMBaseActivity<ActivityBookSourceBinding, BookSourceV
                         adapter.notifyItemRangeChanged(
                             0,
                             adapter.itemCount,
-                            bundleOf(Pair("checkSourceMessage", null))
+                            Bundle().apply {
+                                putString("checkSourceMessage", null)
+                            }
                         )
                     } else {
                         adapter.notifyItemRangeChanged(
                             firstItem,
                             lastItem + 1,
-                            bundleOf(Pair("checkSourceMessage", null))
+                            Bundle().apply {
+                                putString("checkSourceMessage", null)
+                            }
                         )
                     }
                     if (!Debug.isChecking) {

--- a/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/manage/BookSourceAdapter.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.PopupMenu
-import androidx.core.os.bundleOf
 import androidx.core.view.doOnLayout
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
@@ -156,7 +155,9 @@ class BookSourceAdapter(
         callBack.upCountView()
         recyclerView.doOnLayout {
             handler.post {
-                notifyItemRangeChanged(0, itemCount, bundleOf("upSourceHost" to null))
+                notifyItemRangeChanged(0, itemCount, Bundle().apply {
+                    putString("upSourceHost", null)
+                })
             }
         }
     }
@@ -257,7 +258,9 @@ class BookSourceAdapter(
         getItems().forEach {
             selected.add(it)
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -269,7 +272,9 @@ class BookSourceAdapter(
                 selected.add(it)
             }
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -288,7 +293,9 @@ class BookSourceAdapter(
                 selected.add(it)
             }
         }
-        notifyItemRangeChanged(minPosition, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(minPosition, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -355,7 +362,9 @@ class BookSourceAdapter(
                     } else {
                         selected.remove(it)
                     }
-                    notifyItemChanged(position, bundleOf(Pair("selected", null)))
+                    notifyItemChanged(position, Bundle().apply {
+                        putString("selected", null)
+                    })
                     callBack.upCountView()
                     return true
                 }

--- a/app/src/main/java/io/legado/app/ui/book/toc/rule/TxtTocRuleAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/rule/TxtTocRuleAdapter.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
-import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import io.legado.app.R
@@ -152,14 +151,18 @@ class TxtTocRuleAdapter(context: Context, private val callBack: CallBack) :
         getItems().forEach {
             selected.add(it)
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
     fun clearSelection() {
         if (selected.isEmpty()) return
         selected.clear()
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -171,7 +174,9 @@ class TxtTocRuleAdapter(context: Context, private val callBack: CallBack) :
                 selected.add(it)
             }
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -219,7 +224,9 @@ class TxtTocRuleAdapter(context: Context, private val callBack: CallBack) :
                     } else {
                         selected.remove(it)
                     }
-                    notifyItemChanged(position, bundleOf(Pair("selected", null)))
+                    notifyItemChanged(position, Bundle().apply {
+                        putString("selected", null)
+                    })
                     callBack.upCountView()
                     return true
                 }

--- a/app/src/main/java/io/legado/app/ui/book/toc/rule/TxtTocRuleDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/rule/TxtTocRuleDialog.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
-import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DiffUtil
@@ -310,7 +309,9 @@ class TxtTocRuleDialog() : BaseDialogFragment(R.layout.dialog_toc_regex),
                 rbRegexName.setOnUserCheckedChangeListener { isChecked ->
                     if (isChecked) {
                         selectedName = getItem(holder.layoutPosition)?.name
-                        updateItems(0, itemCount - 1, bundleOf("upSelect" to null))
+                        updateItems(0, itemCount - 1, Bundle().apply {
+                            putString("upSelect", null)
+                        })
                     }
                 }
                 swtEnabled.setOnUserCheckedChangeListener { isChecked ->

--- a/app/src/main/java/io/legado/app/ui/dict/rule/DictRuleAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/dict/rule/DictRuleAdapter.kt
@@ -3,7 +3,6 @@ package io.legado.app.ui.dict.rule
 import android.content.Context
 import android.os.Bundle
 import android.view.ViewGroup
-import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import io.legado.app.base.adapter.ItemViewHolder
@@ -64,7 +63,9 @@ class DictRuleAdapter(context: Context, var callBack: CallBack) :
         getItems().forEach {
             selected.add(it)
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -76,7 +77,9 @@ class DictRuleAdapter(context: Context, var callBack: CallBack) :
                 selected.add(it)
             }
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -190,7 +193,9 @@ class DictRuleAdapter(context: Context, var callBack: CallBack) :
                     } else {
                         selected.remove(it)
                     }
-                    notifyItemChanged(position, bundleOf(Pair("selected", null)))
+                    notifyItemChanged(position, Bundle().apply {
+                        putString("selected", null)
+                    })
                     callBack.upCountView()
                     return true
                 }

--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/style1/books/BaseBooksAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/style1/books/BaseBooksAdapter.kt
@@ -1,7 +1,7 @@
 package io.legado.app.ui.main.bookshelf.style1.books
 
 import android.content.Context
-import androidx.core.os.bundleOf
+import android.os.Bundle
 import androidx.recyclerview.widget.DiffUtil
 import androidx.viewbinding.ViewBinding
 import io.legado.app.base.adapter.DiffRecyclerAdapter
@@ -36,7 +36,7 @@ abstract class BaseBooksAdapter<VB : ViewBinding>(context: Context) :
             }
 
             override fun getChangePayload(oldItem: Book, newItem: Book): Any? {
-                val bundle = bundleOf()
+                val bundle = Bundle()
                 if (oldItem.name != newItem.name) {
                     bundle.putString("name", newItem.name)
                 }
@@ -77,14 +77,19 @@ abstract class BaseBooksAdapter<VB : ViewBinding>(context: Context) :
     fun notification(bookUrl: String) {
         getItems().forEachIndexed { i, it ->
             if (it.bookUrl == bookUrl) {
-                notifyItemChanged(i, bundleOf(Pair("refresh", null), Pair("lastUpdateTime", null)))
+                notifyItemChanged(i, Bundle().apply {
+                    putString("refresh", null)
+                    putString("lastUpdateTime", null)
+                })
                 return
             }
         }
     }
 
     fun upLastUpdateTime() {
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("lastUpdateTime", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("lastUpdateTime", null)
+        })
     }
 
     interface CallBack {

--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/style2/BaseBooksAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/style2/BaseBooksAdapter.kt
@@ -1,9 +1,9 @@
 package io.legado.app.ui.main.bookshelf.style2
 
 import android.content.Context
+import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
-import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
@@ -66,7 +66,7 @@ abstract class BaseBooksAdapter<VH : RecyclerView.ViewHolder>(
         }
 
         override fun getChangePayload(oldItem: Any, newItem: Any): Any? {
-            val bundle = bundleOf()
+            val bundle = Bundle()
             when {
                 oldItem is Book && newItem is Book -> {
                     if (oldItem.name != newItem.name) {
@@ -132,7 +132,9 @@ abstract class BaseBooksAdapter<VH : RecyclerView.ViewHolder>(
         for (i in 0 until itemCount) {
             getItem(i).let {
                 if (it is Book && it.bookUrl == bookUrl) {
-                    notifyItemChanged(i, bundleOf(Pair("refresh", null)))
+                    notifyItemChanged(i, Bundle().apply {
+                        putString("refresh", null)
+                    })
                     return
                 }
             }

--- a/app/src/main/java/io/legado/app/ui/replace/ReplaceRuleAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/replace/ReplaceRuleAdapter.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
-import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import io.legado.app.R
@@ -72,7 +71,9 @@ class ReplaceRuleAdapter(context: Context, var callBack: CallBack) :
         getItems().forEach {
             selected.add(it)
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -84,7 +85,9 @@ class ReplaceRuleAdapter(context: Context, var callBack: CallBack) :
                 selected.add(it)
             }
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -214,7 +217,9 @@ class ReplaceRuleAdapter(context: Context, var callBack: CallBack) :
                     } else {
                         selected.remove(it)
                     }
-                    notifyItemChanged(position, bundleOf(Pair("selected", null)))
+                    notifyItemChanged(position, Bundle().apply {
+                        putString("selected", null)
+                    })
                     callBack.upCountView()
                     return true
                 }

--- a/app/src/main/java/io/legado/app/ui/rss/source/manage/RssSourceAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/rss/source/manage/RssSourceAdapter.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupMenu
-import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import io.legado.app.R
@@ -130,7 +129,9 @@ class RssSourceAdapter(context: Context, val callBack: CallBack) :
         getItems().forEach {
             selected.add(it)
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -142,7 +143,9 @@ class RssSourceAdapter(context: Context, val callBack: CallBack) :
                 selected.add(it)
             }
         }
-        notifyItemRangeChanged(0, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(0, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -161,7 +164,9 @@ class RssSourceAdapter(context: Context, val callBack: CallBack) :
                 selected.add(it)
             }
         }
-        notifyItemRangeChanged(minPosition, itemCount, bundleOf(Pair("selected", null)))
+        notifyItemRangeChanged(minPosition, itemCount, Bundle().apply {
+            putString("selected", null)
+        })
         callBack.upCountView()
     }
 
@@ -227,7 +232,9 @@ class RssSourceAdapter(context: Context, val callBack: CallBack) :
                     } else {
                         selected.remove(it)
                     }
-                    notifyItemChanged(position, bundleOf(Pair("selected", null)))
+                    notifyItemChanged(position, Bundle().apply {
+                        putString("selected", null)
+                    })
                     callBack.upCountView()
                     return true
                 }

--- a/app/src/test/java/io/legado/app/BundlePayloadContractTest.kt
+++ b/app/src/test/java/io/legado/app/BundlePayloadContractTest.kt
@@ -1,0 +1,55 @@
+package io.legado.app
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class BundlePayloadContractTest {
+
+    @Test
+    fun `migrated recycler payloads use platform Bundle`() {
+        val sourceRoot = sourceRoot()
+        val violations = migratedPayloadSources.mapNotNull { relativePath ->
+            val file = File(sourceRoot, relativePath)
+            val source = file.readText()
+            val importsAndroidxBundleOf =
+                source.contains("import androidx.core.os.bundleOf")
+            val callsBundleOf = Regex("""\bbundleOf\s*\(""").containsMatchIn(source)
+            val usesPlatformBundle = Regex("""\bBundle\s*\(""").containsMatchIn(source)
+            if (importsAndroidxBundleOf || callsBundleOf || !usesPlatformBundle) {
+                relativePath
+            } else {
+                null
+            }
+        }
+
+        assertTrue(
+            "Migrated RecyclerView payloads must use android.os.Bundle directly: $violations",
+            violations.isEmpty(),
+        )
+    }
+
+    private fun sourceRoot(): File {
+        return sequenceOf(File("src/main/java"), File("app/src/main/java"))
+            .first { it.isDirectory }
+    }
+
+    private companion object {
+        val migratedPayloadSources = listOf(
+            "io/legado/app/ui/book/changesource/ChangeBookSourceDialog.kt",
+            "io/legado/app/ui/book/changesource/ChangeChapterSourceDialog.kt",
+            "io/legado/app/ui/book/explore/ExploreShowActivity.kt",
+            "io/legado/app/ui/book/manage/BookAdapter.kt",
+            "io/legado/app/ui/book/search/SearchActivity.kt",
+            "io/legado/app/ui/book/source/manage/BookSourceActivity.kt",
+            "io/legado/app/ui/book/source/manage/BookSourceAdapter.kt",
+            "io/legado/app/ui/book/toc/rule/TxtTocRuleAdapter.kt",
+            "io/legado/app/ui/book/toc/rule/TxtTocRuleDialog.kt",
+            "io/legado/app/ui/dict/rule/DictRuleAdapter.kt",
+            "io/legado/app/ui/main/bookshelf/style1/books/BaseBooksAdapter.kt",
+            "io/legado/app/ui/main/bookshelf/style2/BaseBooksAdapter.kt",
+            "io/legado/app/ui/replace/ReplaceRuleAdapter.kt",
+            "io/legado/app/ui/rss/source/manage/RssSourceAdapter.kt",
+        )
+    }
+}


### PR DESCRIPTION
## 更新内容

- 将书籍列表、书源列表、RSS 源列表、替换规则、目录规则和字典规则等 14 个界面中的 34 处 `bundleOf` 载荷构造迁移为平台 `android.os.Bundle` API。
- 清理 AndroidX 对数组、列表及可空值类型推断产生的弃用提示，避免后续依赖升级时继续触发同类构建警告。
- 保持所有 Adapter payload 的键名和值类型不变，包括动态键、布尔值、字符串列表、字符串数组和可空字符串。
- 对原本需要保留空键的场景继续使用 `putString(key, null)`，空载荷继续使用空 `Bundle`，不会改变 `keySet()` 与局部刷新判断行为。
- 新增源码契约测试，限定本次迁移的 14 个文件不得重新引入 `bundleOf`，并检查平台 `Bundle` 构造方式仍被保留。

## 影响范围

- 仅调整 RecyclerView 局部刷新载荷的构造方式，不修改接收端协议、界面逻辑或数据结构。
- 不涉及 Firebase、原生库、ABI、资源语言和发布配置。
- 该项属于构建维护，不增加用户可见功能，因此不修改应用更新日志。

## 验证结果

- `testAppReleaseUnitTest`：382 项测试全部通过，0 失败、0 错误。
- `assembleAppRelease -ParmOnly=true` 编译通过。
- 本次 14 个目标文件已确认不存在残留 `bundleOf` 调用。
- 完整构建未再出现本次所清理的 `bundleOf` 弃用警告。
