### PR TITLE
修复本地书覆盖后复用旧解析缓存

### DIFF
--- a/app/src/main/java/io/legado/app/model/localBook/EpubFile.kt
+++ b/app/src/main/java/io/legado/app/model/localBook/EpubFile.kt
@@ -40,7 +40,7 @@ class EpubFile(var book: Book) : AutoCloseable {
         @Synchronized
         private fun getEFile(book: Book): EpubFile {
             return cache.getOrCreate(
-                matches = { it.book.bookUrl == book.bookUrl },
+                matches = { it.openedBookUrl == book.bookUrl },
                 create = { EpubFile(book) },
             ).also { it.book = book }
         }
@@ -72,7 +72,14 @@ class EpubFile(var book: Book) : AutoCloseable {
         fun clear() {
             cache.clear()
         }
+
+        @Synchronized
+        fun clear(bookUrl: String) {
+            cache.clearIf { it.openedBookUrl == bookUrl }
+        }
     }
+
+    private val openedBookUrl = book.bookUrl
 
     private var mCharset: Charset = Charset.defaultCharset()
 

--- a/app/src/main/java/io/legado/app/model/localBook/LocalBook.kt
+++ b/app/src/main/java/io/legado/app/model/localBook/LocalBook.kt
@@ -279,12 +279,14 @@ object LocalBook {
             upBookInfo(book)
             appDb.bookDao.insert(book)
         } else {
-            deleteBook(book, false)
-            upBookInfo(book)
-            // 触发 isLocalModified
-            book.latestChapterTime = 0
-            //已有书籍说明是更新,删除原有目录
-            appDb.bookChapterDao.delByBook(bookUrl)
+            withParserCacheInvalidated(book) {
+                deleteBook(book, false)
+                upBookInfo(book)
+                // 触发 isLocalModified
+                book.latestChapterTime = 0
+                //已有书籍说明是更新,删除原有目录
+                appDb.bookChapterDao.delByBook(bookUrl)
+            }
         }
         return book
     }
@@ -295,6 +297,54 @@ object LocalBook {
             book.isUmd -> UmdFile.upBookInfo(book)
             book.isPdf -> PdfFile.upBookInfo(book)
             book.isMobi -> MobiFile.upBookInfo(book)
+        }
+    }
+
+    fun <T> withParserCacheInvalidated(
+        uri: Uri,
+        fileName: String,
+        action: () -> T,
+    ): T {
+        return withParserCacheInvalidated(
+            FileDoc.fromUri(uri, false).toString(),
+            fileName,
+            action,
+        )
+    }
+
+    private fun <T> withParserCacheInvalidated(book: Book, action: () -> T): T {
+        return withParserCacheInvalidated(book.bookUrl, book.originName, action)
+    }
+
+    private fun <T> withParserCacheInvalidated(
+        bookUrl: String,
+        fileName: String,
+        action: () -> T,
+    ): T {
+        return when {
+            fileName.endsWith(".epub", true) -> synchronized(EpubFile) {
+                EpubFile.clear(bookUrl)
+                action()
+            }
+
+            fileName.endsWith(".umd", true) -> synchronized(UmdFile) {
+                UmdFile.clear(bookUrl)
+                action()
+            }
+
+            fileName.endsWith(".pdf", true) -> synchronized(PdfFile) {
+                PdfFile.clear(bookUrl)
+                action()
+            }
+
+            fileName.endsWith(".mobi", true) ||
+                fileName.endsWith(".azw3", true) ||
+                fileName.endsWith(".azw", true) -> synchronized(MobiFile) {
+                MobiFile.clear(bookUrl)
+                action()
+            }
+
+            else -> action()
         }
     }
 
@@ -466,16 +516,20 @@ object LocalBook {
                     )
                         ?: throw SecurityException("请重新设置书籍保存位置\nPermission Denial")
                 }
-                appCtx.contentResolver.openOutputStream(doc.uri)!!.use { oStream ->
-                    it.copyTo(oStream)
+                withParserCacheInvalidated(doc.uri, fileName) {
+                    appCtx.contentResolver.openOutputStream(doc.uri)!!.use { oStream ->
+                        it.copyTo(oStream)
+                    }
                 }
                 doc.uri
             } else {
                 try {
                     val treeFile = File(treeUri.path!!)
                     val file = prepareLocalBookOutputFile(treeFile, fileName)
-                    FileOutputStream(file).use { oStream ->
-                        it.copyTo(oStream)
+                    withParserCacheInvalidated(Uri.fromFile(file), fileName) {
+                        FileOutputStream(file).use { oStream ->
+                            it.copyTo(oStream)
+                        }
                     }
                     Uri.fromFile(file)
                 } catch (e: FileNotFoundException) {

--- a/app/src/main/java/io/legado/app/model/localBook/MobiFile.kt
+++ b/app/src/main/java/io/legado/app/model/localBook/MobiFile.kt
@@ -30,7 +30,7 @@ class MobiFile(var book: Book) : AutoCloseable {
         @Synchronized
         private fun getMFile(book: Book): MobiFile {
             return cache.getOrCreate(
-                matches = { it.book.bookUrl == book.bookUrl },
+                matches = { it.openedBookUrl == book.bookUrl },
                 create = { MobiFile(book) },
             ).also { it.book = book }
         }
@@ -59,7 +59,14 @@ class MobiFile(var book: Book) : AutoCloseable {
         fun clear() {
             cache.clear()
         }
+
+        @Synchronized
+        fun clear(bookUrl: String) {
+            cache.clearIf { it.openedBookUrl == bookUrl }
+        }
     }
+
+    private val openedBookUrl = book.bookUrl
 
     private var fileDescriptor: ParcelFileDescriptor? = null
     private var openedMobiBook: MobiBook? = null

--- a/app/src/main/java/io/legado/app/model/localBook/PdfFile.kt
+++ b/app/src/main/java/io/legado/app/model/localBook/PdfFile.kt
@@ -33,7 +33,7 @@ class PdfFile(var book: Book) : AutoCloseable {
         @Synchronized
         private fun getPFile(book: Book): PdfFile {
             return cache.getOrCreate(
-                matches = { it.book.bookUrl == book.bookUrl },
+                matches = { it.openedBookUrl == book.bookUrl },
                 create = { PdfFile(book) },
             ).also { it.book = book }
         }
@@ -63,7 +63,14 @@ class PdfFile(var book: Book) : AutoCloseable {
             cache.clear()
         }
 
+        @Synchronized
+        fun clear(bookUrl: String) {
+            cache.clearIf { it.openedBookUrl == bookUrl }
+        }
+
     }
+
+    private val openedBookUrl = book.bookUrl
 
     /**
      *持有引用，避免被回收

--- a/app/src/main/java/io/legado/app/model/localBook/UmdFile.kt
+++ b/app/src/main/java/io/legado/app/model/localBook/UmdFile.kt
@@ -16,7 +16,7 @@ class UmdFile(var book: Book) {
 
         @Synchronized
         private fun getUFile(book: Book): UmdFile {
-            if (uFile == null || uFile?.book?.bookUrl != book.bookUrl) {
+            if (uFile == null || uFile?.openedBookUrl != book.bookUrl) {
                 uFile = UmdFile(book)
                 return uFile!!
             }
@@ -47,8 +47,16 @@ class UmdFile(var book: Book) {
         override fun upBookInfo(book: Book) {
             return getUFile(book).upBookInfo()
         }
+
+        @Synchronized
+        fun clear(bookUrl: String) {
+            if (uFile?.openedBookUrl == bookUrl) {
+                uFile = null
+            }
+        }
     }
 
+    private val openedBookUrl = book.bookUrl
 
     private var umdBook: UmdBook? = null
         get() {
@@ -64,8 +72,9 @@ class UmdFile(var book: Book) {
     }
 
     private fun readUmd(): UmdBook? {
-        val input = LocalBook.getBookInputStream(book)
-        return UmdReader().read(input)
+        return LocalBook.getBookInputStream(book).use {
+            UmdReader().read(it)
+        }
     }
 
     private fun upBookCover(fastCheck: Boolean = false) {

--- a/app/src/main/java/io/legado/app/ui/association/FileAssociationActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/association/FileAssociationActivity.kt
@@ -15,6 +15,7 @@ import io.legado.app.help.config.AppConfig
 import io.legado.app.lib.dialogs.alert
 import io.legado.app.lib.permission.Permissions
 import io.legado.app.lib.permission.PermissionsCompat
+import io.legado.app.model.localBook.LocalBook
 import io.legado.app.ui.file.HandleFileContract
 import io.legado.app.utils.FileUtils
 import io.legado.app.utils.buildMainHandler
@@ -169,9 +170,11 @@ class FileAssociationActivity :
                                             "请重新设置书籍保存位置\nPermission Denial"
                                         )
                                 }
-                                contentResolver.openOutputStream(doc.uri)!!.use { oStream ->
-                                    inputStream.copyTo(oStream)
-                                    oStream.flush()
+                                LocalBook.withParserCacheInvalidated(doc.uri, name) {
+                                    contentResolver.openOutputStream(doc.uri)!!.use { oStream ->
+                                        inputStream.copyTo(oStream)
+                                        oStream.flush()
+                                    }
                                 }
                             }
                             viewModel.importBook(doc.uri)
@@ -187,9 +190,11 @@ class FileAssociationActivity :
                             val name = fileDoc.name
                             val file = treeFile.getFile(name)
                             if (!file.exists() || fileDoc.lastModified > file.lastModified()) {
-                                FileOutputStream(file).use { oStream ->
-                                    inputStream.copyTo(oStream)
-                                    oStream.flush()
+                                LocalBook.withParserCacheInvalidated(Uri.fromFile(file), name) {
+                                    FileOutputStream(file).use { oStream ->
+                                        inputStream.copyTo(oStream)
+                                        oStream.flush()
+                                    }
                                 }
                             }
                             viewModel.importBook(Uri.fromFile(file))

--- a/app/src/test/java/io/legado/app/model/localBook/LocalBookReaderLifecycleTest.kt
+++ b/app/src/test/java/io/legado/app/model/localBook/LocalBookReaderLifecycleTest.kt
@@ -45,6 +45,105 @@ class LocalBookReaderLifecycleTest {
         assertTrue(checkBlock.contains("LocalBook.getBookInputStream(book).use {}"))
     }
 
+    @Test
+    fun `parser caches support targeted invalidation`() {
+        listOf("EpubFile", "MobiFile", "PdfFile").forEach { parser ->
+            val source = readProjectFile(
+                "src/main/java/io/legado/app/model/localBook/$parser.kt"
+            )
+            val clearBlock = source.substringAfter("fun clear(bookUrl: String)")
+                .substringBefore("\n        }")
+
+            assertTrue(source.contains("private val openedBookUrl = book.bookUrl"))
+            assertTrue(source.contains("matches = { it.openedBookUrl == book.bookUrl }"))
+            assertTrue(clearBlock.contains("cache.clearIf"))
+            assertTrue(clearBlock.contains("it.openedBookUrl == bookUrl"))
+        }
+
+        val umdSource = readProjectFile(
+            "src/main/java/io/legado/app/model/localBook/UmdFile.kt"
+        )
+        val umdClearBlock = umdSource.substringAfter("fun clear(bookUrl: String)")
+            .substringBefore("\n        }")
+        assertTrue(umdSource.contains("private val openedBookUrl = book.bookUrl"))
+        assertTrue(umdSource.contains("uFile?.openedBookUrl != book.bookUrl"))
+        assertTrue(umdClearBlock.contains("uFile?.openedBookUrl == bookUrl"))
+        assertTrue(umdClearBlock.contains("uFile = null"))
+    }
+
+    @Test
+    fun `local book refresh invalidates parser before parsing again`() {
+        val source = readProjectFile(
+            "src/main/java/io/legado/app/model/localBook/LocalBook.kt"
+        )
+        val importFileBlock = source.substringAfter("fun importFile(uri: Uri)")
+            .substringBefore("fun upBookInfo(book: Book)")
+        val existingBookBlock = importFileBlock.substringAfter("} else {")
+
+        assertTrue(existingBookBlock.contains("withParserCacheInvalidated(book)"))
+        assertTrue(existingBookBlock.contains("deleteBook(book, false)"))
+        assertTrue(existingBookBlock.contains("upBookInfo(book)"))
+        assertTrue(
+            existingBookBlock.indexOf("deleteBook(book, false)") <
+                    existingBookBlock.indexOf("upBookInfo(book)")
+        )
+    }
+
+    @Test
+    fun `local book files invalidate parser before overwrite`() {
+        val localBookSource = readProjectFile(
+            "src/main/java/io/legado/app/model/localBook/LocalBook.kt"
+        )
+        assertInvalidationBeforeOutput(
+            localBookSource,
+            "withParserCacheInvalidated(doc.uri, fileName)",
+            "appCtx.contentResolver.openOutputStream(doc.uri)"
+        )
+        assertInvalidationBeforeOutput(
+            localBookSource,
+            "withParserCacheInvalidated(Uri.fromFile(file), fileName)",
+            "FileOutputStream(file)"
+        )
+
+        val associationSource = readProjectFile(
+            "src/main/java/io/legado/app/ui/association/FileAssociationActivity.kt"
+        )
+        assertInvalidationBeforeOutput(
+            associationSource,
+            "LocalBook.withParserCacheInvalidated(doc.uri, name)",
+            "contentResolver.openOutputStream(doc.uri)"
+        )
+        assertInvalidationBeforeOutput(
+            associationSource,
+            "LocalBook.withParserCacheInvalidated(Uri.fromFile(file), name)",
+            "FileOutputStream(file)"
+        )
+    }
+
+    @Test
+    fun `umd parsing closes source stream after eager read`() {
+        val source = readProjectFile(
+            "src/main/java/io/legado/app/model/localBook/UmdFile.kt"
+        )
+        val readBlock = source.substringAfter("private fun readUmd()")
+            .substringBefore("private fun upBookCover")
+
+        assertTrue(readBlock.contains("LocalBook.getBookInputStream(book).use"))
+        assertTrue(readBlock.contains("UmdReader().read(it)"))
+    }
+
+    private fun assertInvalidationBeforeOutput(
+        source: String,
+        invalidation: String,
+        output: String,
+    ) {
+        val invalidationIndex = source.indexOf(invalidation)
+        val outputIndex = source.indexOf(output, invalidationIndex)
+
+        assertTrue("Missing parser invalidation: $invalidation", invalidationIndex >= 0)
+        assertTrue("Missing output after parser invalidation: $output", outputIndex > invalidationIndex)
+    }
+
     private fun readProjectFile(pathInApp: String): String {
         val file = sequenceOf(File(pathInApp), File("app/$pathInApp"))
             .firstOrNull(File::isFile)


### PR DESCRIPTION
## 问题

同一路径的 EPUB、MOBI、AZW、AZW3、PDF 或 UMD 被覆盖后，应用可能继续复用覆盖前的解析状态，导致书名、目录、页数或正文仍来自旧文件。MOBI/PDF/EPUB 解析器还可能在目标文件被截断写入时继续持有旧文件描述符。

此外，解析器原先以可变的 `Book.bookUrl` 作为缓存键。书籍路径被原地修改后，旧解析器中的同一个 `Book` 对象也会同步变成新 URL，造成旧解析器被误判为新路径缓存。

## 修改内容

- 为 EPUB、MOBI、PDF 和 UMD 解析器保存构造时不可变的打开 URL，缓存匹配和定向清理均使用该快照。
- 增加按书籍 URL 定向失效解析状态的能力，不影响其他 URL 的缓存判断。
- 文件关联复制、本地书在线保存和已有书籍重新解析时，在对应格式的解析器同步边界内完成“关闭旧解析器 + 覆盖文件/重新解析”，避免清理与写入之间被阅读线程重新打开。
- UMD 改为在完成一次性解析后立即关闭输入流，成功和异常路径均不会遗留文件句柄。
- 增加回归测试，固定不可变缓存键、定向清理、覆盖入口和 UMD 输入流生命周期。

## 行为影响

- 同一路径更新本地书后会读取新文件的元数据、目录和页数。
- 修改书籍路径后，旧路径解析器不会伪装成新路径缓存。
- TXT、压缩包及在线书籍的既有逻辑不变。
- 不修改最低安卓版本、ABI、Firebase、版本号和发布流程。

## 验证

- `./gradlew :app:testAppDebugUnitTest --tests io.legado.app.model.localBook.LocalBookReaderLifecycleTest --no-daemon`
- `./gradlew :app:compileAppReleaseKotlin --no-daemon`
- `./gradlew :app:testAppReleaseUnitTest --no-daemon`
- PR 将由 `test.yml` 继续验证 `release` 与 `releaseA` 两组 ARM/通用包构建。
