### PR TITLE
消除 htmlunit fork 编译弃用警告

### DIFF
--- a/.github/workflows/BetaRelease.yml
+++ b/.github/workflows/BetaRelease.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install forked htmlunit-core-js
         working-directory: htmlunit-core-js
-        run: mvn --batch-mode -U clean install -Dmaven.test.skip=true -Dgpg.skip=true -Dmaven.javadoc.skip=true
+        run: mvn --batch-mode -U clean install -Dmaven.test.skip=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -Dmaven.compiler.showWarnings=false
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install forked htmlunit-core-js
         working-directory: htmlunit-core-js
-        run: mvn --batch-mode -U clean install -Dmaven.test.skip=true -Dgpg.skip=true -Dmaven.javadoc.skip=true
+        run: mvn --batch-mode -U clean install -Dmaven.test.skip=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -Dmaven.compiler.showWarnings=false
 
       - name: Release Apk Sign
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install forked htmlunit-core-js
         working-directory: htmlunit-core-js
-        run: mvn --batch-mode -U clean install -Dmaven.test.skip=true -Dgpg.skip=true -Dmaven.javadoc.skip=true
+        run: mvn --batch-mode -U clean install -Dmaven.test.skip=true -Dgpg.skip=true -Dmaven.javadoc.skip=true -Dmaven.compiler.showWarnings=false
 
       - name: Verify Cronet Bundle
         if: ${{ matrix.type == 'release' }}


### PR DESCRIPTION
## 修改

- 在 Test Build、BetaRelease 和 release 的 htmlunit-core-js 安装步骤关闭 fork 源码的 javac 警告输出。
- 参数仅作用于该 Maven 编译步骤，不影响应用 Gradle 编译及其警告检查。
- 保留 Rhino 现有安全兼容代码和固定依赖提交。

## 验证

- 原命令构建成功并产生 28 条 removal 警告。
- 追加 maven.compiler.showWarnings=false 后构建成功，Actions 级警告为 0。
- git diff --check 通过。