### PR TITLE
协调升级 Web 构建依赖

### DIFF
--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@tsconfig/node20": "^20.1.4",
     "@types/node": "^20.16.11",
-    "@vitejs/plugin-vue": "^5.1.4",
+    "@vitejs/plugin-vue": "^6.0.8",
     "@vue/eslint-config-prettier": "^10.0.0",
     "@vue/eslint-config-typescript": "^14.0.1",
     "@vue/tsconfig": "^0.5.1",
@@ -42,9 +42,9 @@
     "npm-run-all2": "^6.2.3",
     "prettier": "^3.3.3",
     "sass-embedded": "^1.83.1",
-    "typescript": "~5.5.4",
+    "typescript": "~5.6.3",
     "unplugin-auto-import": "^0.18.3",
-    "unplugin-icons": "^0.19.3",
+    "unplugin-icons": "^23.0.1",
     "unplugin-vue-components": "^0.27.4",
     "vite": "^5.4.8",
     "vue-tsc": "^3.3.7"

--- a/modules/web/pnpm-lock.yaml
+++ b/modules/web/pnpm-lock.yaml
@@ -13,13 +13,13 @@ importers:
         version: 2.3.2
       '@element-plus/icons-vue':
         specifier: ^2.3.1
-        version: 2.3.2(vue@3.5.40(typescript@5.5.4))
+        version: 2.3.2(vue@3.5.40(typescript@5.6.3))
       '@vueuse/core':
         specifier: ^14.3.0
-        version: 14.3.0(vue@3.5.40(typescript@5.5.4))
+        version: 14.3.0(vue@3.5.40(typescript@5.6.3))
       '@vueuse/shared':
         specifier: ^11.1.0
-        version: 11.3.0(vue@3.5.40(typescript@5.5.4))
+        version: 11.3.0(vue@3.5.40(typescript@5.6.3))
       axios:
         specifier: ^1.7.7
         version: 1.18.1
@@ -28,22 +28,22 @@ importers:
         version: 3.4.12
       element-plus:
         specifier: 2.14.3
-        version: 2.14.3(vue@3.5.40(typescript@5.5.4))
+        version: 2.14.3(vue@3.5.40(typescript@5.6.3))
       hotkeys-js:
         specifier: ^4.0.4
         version: 4.0.4
       pinia:
         specifier: ^2.2.4
-        version: 2.3.1(typescript@5.5.4)(vue@3.5.40(typescript@5.5.4))
+        version: 2.3.1(typescript@5.6.3)(vue@3.5.40(typescript@5.6.3))
       vue:
         specifier: ^3.5.12
-        version: 3.5.40(typescript@5.5.4)
+        version: 3.5.40(typescript@5.6.3)
       vue-router:
         specifier: ^5.1.0
-        version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.21.5)(pinia@2.3.1(typescript@5.5.4)(vue@3.5.40(typescript@5.5.4)))(rollup@4.62.2)(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0))(vue@3.5.40(typescript@5.5.4))
+        version: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.21.5)(pinia@2.3.1(typescript@5.6.3)(vue@3.5.40(typescript@5.6.3)))(rollup@4.62.2)(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0))(vue@3.5.40(typescript@5.6.3))
       vue3-virtual-scroll-list:
         specifier: ^0.2.1
-        version: 0.2.1(vue@3.5.40(typescript@5.5.4))
+        version: 0.2.1(vue@3.5.40(typescript@5.6.3))
     devDependencies:
       '@tsconfig/node20':
         specifier: ^20.1.4
@@ -52,14 +52,14 @@ importers:
         specifier: ^20.16.11
         version: 20.19.43
       '@vitejs/plugin-vue':
-        specifier: ^5.1.4
-        version: 5.2.4(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0))(vue@3.5.40(typescript@5.5.4))
+        specifier: ^6.0.8
+        version: 6.0.8(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0))(vue@3.5.40(typescript@5.6.3))
       '@vue/eslint-config-prettier':
         specifier: ^10.0.0
         version: 10.2.0(eslint@9.39.5)(prettier@3.9.5)
       '@vue/eslint-config-typescript':
         specifier: ^14.0.1
-        version: 14.9.0(eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.5.4))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5)))(eslint@9.39.5)(typescript@5.5.4)
+        version: 14.9.0(eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.6.3))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5)))(eslint@9.39.5)(typescript@5.6.3)
       '@vue/tsconfig':
         specifier: ^0.5.1
         version: 0.5.1
@@ -68,7 +68,7 @@ importers:
         version: 9.39.5
       eslint-plugin-vue:
         specifier: ^10.10.0
-        version: 10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.5.4))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5))
+        version: 10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.6.3))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5))
       npm-run-all2:
         specifier: ^6.2.3
         version: 6.2.6
@@ -79,37 +79,31 @@ importers:
         specifier: ^1.83.1
         version: 1.100.0
       typescript:
-        specifier: ~5.5.4
-        version: 5.5.4
+        specifier: ~5.6.3
+        version: 5.6.3
       unplugin-auto-import:
         specifier: ^0.18.3
-        version: 0.18.6(@vueuse/core@14.3.0(vue@3.5.40(typescript@5.5.4)))(rollup@4.62.2)
+        version: 0.18.6(@vueuse/core@14.3.0(vue@3.5.40(typescript@5.6.3)))(rollup@4.62.2)
       unplugin-icons:
-        specifier: ^0.19.3
-        version: 0.19.3(@vue/compiler-sfc@3.5.40)
+        specifier: ^23.0.1
+        version: 23.0.1(@vue/compiler-sfc@3.5.40)
       unplugin-vue-components:
         specifier: ^0.27.4
-        version: 0.27.5(@babel/parser@7.29.7)(rollup@4.62.2)(vue@3.5.40(typescript@5.5.4))
+        version: 0.27.5(@babel/parser@7.29.7)(rollup@4.62.2)(vue@3.5.40(typescript@5.6.3))
       vite:
         specifier: ^5.4.8
         version: 5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0)
       vue-tsc:
         specifier: ^3.3.7
-        version: 3.3.7(typescript@5.5.4)
+        version: 3.3.7(typescript@5.6.3)
 
 packages:
-
-  '@antfu/install-pkg@0.4.1':
-    resolution: {integrity: sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==}
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
-
-  '@antfu/utils@8.1.1':
-    resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
 
   '@babel/generator@8.0.0':
     resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
@@ -372,8 +366,8 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  '@iconify/utils@2.3.0':
-    resolution: {integrity: sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==}
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -488,6 +482,9 @@ packages:
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/pluginutils@5.4.0':
     resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
@@ -715,11 +712,11 @@ packages:
     resolution: {integrity: sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitejs/plugin-vue@5.2.4':
-    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  '@vitejs/plugin-vue@6.0.8':
+    resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
   '@volar/language-core@2.4.28':
@@ -1210,10 +1207,6 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  globals@15.15.0:
-    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
-    engines: {node: '>=18'}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1258,6 +1251,9 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -1314,9 +1310,6 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
-
-  kolorist@1.8.0:
-    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1437,6 +1430,10 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1448,9 +1445,6 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
-
-  package-manager-detector@0.2.11:
-    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
   package-manager-detector@1.7.0:
     resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
@@ -1738,9 +1732,6 @@ packages:
     resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -1773,8 +1764,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1799,14 +1790,13 @@ packages:
       '@vueuse/core':
         optional: true
 
-  unplugin-icons@0.19.3:
-    resolution: {integrity: sha512-EUegRmsAI6+rrYr0vXjFlIP+lg4fSC4zb62zAZKx8FGXlWAGgEGBCa3JDe27aRAXhistObLPbBPhwa/0jYLFkQ==}
+  unplugin-icons@23.0.1:
+    resolution: {integrity: sha512-rv0XEJepajKzDLvRUWASM8K+8+/CCfZn2jtogXqg6RIp7kpatRc/aFrVJn8ANQA09e++lPEEv9yX8cC9enc+QQ==}
     peerDependencies:
       '@svgr/core': '>=7.0.0'
       '@svgx/core': ^1.0.1
-      '@vue/compiler-sfc': ^3.0.2 || ^2.7.0
-      vue-template-compiler: ^2.6.12
-      vue-template-es2015-compiler: ^1.9.0
+      '@vue/compiler-sfc': ^3.0.2
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       '@svgr/core':
         optional: true
@@ -1814,9 +1804,7 @@ packages:
         optional: true
       '@vue/compiler-sfc':
         optional: true
-      vue-template-compiler:
-        optional: true
-      vue-template-es2015-compiler:
+      svelte:
         optional: true
 
   unplugin-utils@0.3.2:
@@ -1839,6 +1827,10 @@ packages:
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
     engines: {node: '>=14.0.0'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unplugin@3.3.0:
     resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
@@ -2005,19 +1997,12 @@ packages:
 
 snapshots:
 
-  '@antfu/install-pkg@0.4.1':
-    dependencies:
-      package-manager-detector: 0.2.11
-      tinyexec: 0.3.2
-
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.7.0
       tinyexec: 1.2.4
 
   '@antfu/utils@0.7.10': {}
-
-  '@antfu/utils@8.1.1': {}
 
   '@babel/generator@8.0.0':
     dependencies:
@@ -2060,9 +2045,9 @@ snapshots:
 
   '@element-plus/icons-svg@2.3.2': {}
 
-  '@element-plus/icons-vue@2.3.2(vue@3.5.40(typescript@5.5.4))':
+  '@element-plus/icons-vue@2.3.2(vue@3.5.40(typescript@5.6.3))':
     dependencies:
-      vue: 3.5.40(typescript@5.5.4)
+      vue: 3.5.40(typescript@5.6.3)
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -2208,18 +2193,11 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@iconify/utils@2.3.0':
+  '@iconify/utils@3.1.4':
     dependencies:
       '@antfu/install-pkg': 1.1.0
-      '@antfu/utils': 8.1.1
       '@iconify/types': 2.0.0
-      debug: 4.4.3
-      globals: 15.15.0
-      kolorist: 1.8.0
-      local-pkg: 1.2.1
-      mlly: 1.8.2
-    transitivePeerDependencies:
-      - supports-color
+      import-meta-resolve: 4.2.0
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2314,6 +2292,8 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.3.6': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
     dependencies:
@@ -2425,40 +2405,40 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.5.4))(eslint@9.39.5)(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.6.3))(eslint@9.39.5)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.64.0
-      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.5)(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@5.5.4)
+      '@typescript-eslint/type-utils': 8.64.0(eslint@9.39.5)(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.64.0
       eslint: 9.39.5
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.5.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.5.4)':
+  '@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3
       eslint: 9.39.5
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.64.0(typescript@5.5.4)':
+  '@typescript-eslint/project-service@8.64.0(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.5.4)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.6.3)
       '@typescript-eslint/types': 8.64.0
       debug: 4.4.3
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2467,47 +2447,47 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
 
-  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@5.5.4)':
+  '@typescript-eslint/tsconfig-utils@8.64.0(typescript@5.6.3)':
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.6.3
 
-  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.5)(typescript@5.5.4)':
+  '@typescript-eslint/type-utils@8.64.0(eslint@9.39.5)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@5.6.3)
       debug: 4.4.3
       eslint: 9.39.5
-      ts-api-utils: 2.5.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.5.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.64.0': {}
 
-  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.5.4)':
+  '@typescript-eslint/typescript-estree@8.64.0(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.64.0(typescript@5.5.4)
-      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.5.4)
+      '@typescript-eslint/project-service': 8.64.0(typescript@5.6.3)
+      '@typescript-eslint/tsconfig-utils': 8.64.0(typescript@5.6.3)
       '@typescript-eslint/types': 8.64.0
       '@typescript-eslint/visitor-keys': 8.64.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.5.4)
-      typescript: 5.5.4
+      ts-api-utils: 2.5.0(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.64.0(eslint@9.39.5)(typescript@5.5.4)':
+  '@typescript-eslint/utils@8.64.0(eslint@9.39.5)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
       '@typescript-eslint/scope-manager': 8.64.0
       '@typescript-eslint/types': 8.64.0
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.5.4)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.6.3)
       eslint: 9.39.5
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2516,10 +2496,11 @@ snapshots:
       '@typescript-eslint/types': 8.64.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0))(vue@3.5.40(typescript@5.5.4))':
+  '@vitejs/plugin-vue@6.0.8(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0))(vue@3.5.40(typescript@5.6.3))':
     dependencies:
+      '@rolldown/pluginutils': 1.0.1
       vite: 5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0)
-      vue: 3.5.40(typescript@5.5.4)
+      vue: 3.5.40(typescript@5.6.3)
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -2533,7 +2514,7 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue-macros/common@3.1.3(vue@3.5.40(typescript@5.5.4))':
+  '@vue-macros/common@3.1.3(vue@3.5.40(typescript@5.6.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.40
       ast-kit: 2.2.0
@@ -2541,7 +2522,7 @@ snapshots:
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.2
     optionalDependencies:
-      vue: 3.5.40(typescript@5.5.4)
+      vue: 3.5.40(typescript@5.6.3)
 
   '@vue/compiler-core@3.5.40':
     dependencies:
@@ -2597,16 +2578,16 @@ snapshots:
     transitivePeerDependencies:
       - '@types/eslint'
 
-  '@vue/eslint-config-typescript@14.9.0(eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.5.4))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5)))(eslint@9.39.5)(typescript@5.5.4)':
+  '@vue/eslint-config-typescript@14.9.0(eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.6.3))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5)))(eslint@9.39.5)(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@5.6.3)
       eslint: 9.39.5
-      eslint-plugin-vue: 10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.5.4))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5))
+      eslint-plugin-vue: 10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.6.3))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5))
       fast-glob: 3.3.3
-      typescript-eslint: 8.64.0(eslint@9.39.5)(typescript@5.5.4)
+      typescript-eslint: 8.64.0(eslint@9.39.5)(typescript@5.6.3)
       vue-eslint-parser: 10.4.1(eslint@9.39.5)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2646,25 +2627,25 @@ snapshots:
 
   '@vue/tsconfig@0.5.1': {}
 
-  '@vueuse/core@14.3.0(vue@3.5.40(typescript@5.5.4))':
+  '@vueuse/core@14.3.0(vue@3.5.40(typescript@5.6.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.3.0
-      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@5.5.4))
-      vue: 3.5.40(typescript@5.5.4)
+      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@5.6.3))
+      vue: 3.5.40(typescript@5.6.3)
 
   '@vueuse/metadata@14.3.0': {}
 
-  '@vueuse/shared@11.3.0(vue@3.5.40(typescript@5.5.4))':
+  '@vueuse/shared@11.3.0(vue@3.5.40(typescript@5.6.3))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.40(typescript@5.5.4))
+      vue-demi: 0.14.10(vue@3.5.40(typescript@5.6.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@14.3.0(vue@3.5.40(typescript@5.5.4))':
+  '@vueuse/shared@14.3.0(vue@3.5.40(typescript@5.6.3))':
     dependencies:
-      vue: 3.5.40(typescript@5.5.4)
+      vue: 3.5.40(typescript@5.6.3)
 
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
@@ -2831,15 +2812,15 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  element-plus@2.14.3(vue@3.5.40(typescript@5.5.4)):
+  element-plus@2.14.3(vue@3.5.40(typescript@5.6.3)):
     dependencies:
       '@ctrl/tinycolor': 4.2.0
-      '@element-plus/icons-vue': 2.3.2(vue@3.5.40(typescript@5.5.4))
+      '@element-plus/icons-vue': 2.3.2(vue@3.5.40(typescript@5.6.3))
       '@floating-ui/dom': 1.8.0
       '@popperjs/core': '@sxzz/popperjs-es@2.11.8'
       '@types/lodash': 4.17.24
       '@types/lodash-es': 4.17.12
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@5.5.4))
+      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@5.6.3))
       async-validator: 4.2.5
       dayjs: 1.11.21
       lodash: 4.18.1
@@ -2847,7 +2828,7 @@ snapshots:
       lodash-unified: 1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.18.1)(lodash@4.18.1)
       memoize-one: 6.0.0
       normalize-wheel-es: 1.2.0
-      vue: 3.5.40(typescript@5.5.4)
+      vue: 3.5.40(typescript@5.6.3)
       vue-component-type-helpers: 3.3.7
 
   entities@7.0.1: {}
@@ -2910,7 +2891,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.39.5)
 
-  eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.5.4))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5)):
+  eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.6.3))(eslint@9.39.5)(vue-eslint-parser@10.4.1(eslint@9.39.5)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5)
       eslint: 9.39.5
@@ -2921,7 +2902,7 @@ snapshots:
       vue-eslint-parser: 10.4.1(eslint@9.39.5)
       xml-name-validator: 5.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@5.5.4)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@5.6.3)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -3099,8 +3080,6 @@ snapshots:
 
   globals@14.0.0: {}
 
-  globals@15.15.0: {}
-
   gopd@1.2.0: {}
 
   has-flag@4.0.0: {}
@@ -3136,6 +3115,8 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -3174,8 +3155,6 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
-
-  kolorist@1.8.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -3289,6 +3268,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  obug@2.1.4: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3305,10 +3286,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  package-manager-detector@0.2.11:
-    dependencies:
-      quansync: 0.2.11
 
   package-manager-detector@1.7.0: {}
 
@@ -3334,13 +3311,13 @@ snapshots:
 
   pidtree@0.6.1: {}
 
-  pinia@2.3.1(typescript@5.5.4)(vue@3.5.40(typescript@5.5.4)):
+  pinia@2.3.1(typescript@5.6.3)(vue@3.5.40(typescript@5.6.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.40(typescript@5.5.4)
-      vue-demi: 0.14.10(vue@3.5.40(typescript@5.5.4))
+      vue: 3.5.40(typescript@5.6.3)
+      vue-demi: 0.14.10(vue@3.5.40(typescript@5.6.3))
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -3571,8 +3548,6 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.3.6
 
-  tinyexec@0.3.2: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
@@ -3584,9 +3559,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@2.5.0(typescript@5.5.4):
+  ts-api-utils@2.5.0(typescript@5.6.3):
     dependencies:
-      typescript: 5.5.4
+      typescript: 5.6.3
 
   tslib@2.8.1: {}
 
@@ -3594,18 +3569,18 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.64.0(eslint@9.39.5)(typescript@5.5.4):
+  typescript-eslint@8.64.0(eslint@9.39.5)(typescript@5.6.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.5.4))(eslint@9.39.5)(typescript@5.5.4)
-      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@5.5.4)
-      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.5.4)
-      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.64.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.6.3))(eslint@9.39.5)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.64.0(typescript@5.6.3)
+      '@typescript-eslint/utils': 8.64.0(eslint@9.39.5)(typescript@5.6.3)
       eslint: 9.39.5
-      typescript: 5.5.4
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.5.4: {}
+  typescript@5.6.3: {}
 
   ufo@1.6.4: {}
 
@@ -3630,7 +3605,7 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  unplugin-auto-import@0.18.6(@vueuse/core@14.3.0(vue@3.5.40(typescript@5.5.4)))(rollup@4.62.2):
+  unplugin-auto-import@0.18.6(@vueuse/core@14.3.0(vue@3.5.40(typescript@5.6.3)))(rollup@4.62.2):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
@@ -3641,30 +3616,26 @@ snapshots:
       unimport: 3.14.6(rollup@4.62.2)
       unplugin: 1.16.1
     optionalDependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@5.5.4))
+      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@5.6.3))
     transitivePeerDependencies:
       - rollup
 
-  unplugin-icons@0.19.3(@vue/compiler-sfc@3.5.40):
+  unplugin-icons@23.0.1(@vue/compiler-sfc@3.5.40):
     dependencies:
-      '@antfu/install-pkg': 0.4.1
-      '@antfu/utils': 0.7.10
-      '@iconify/utils': 2.3.0
-      debug: 4.4.3
-      kolorist: 1.8.0
-      local-pkg: 0.5.1
-      unplugin: 1.16.1
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/utils': 3.1.4
+      local-pkg: 1.2.1
+      obug: 2.1.4
+      unplugin: 2.3.11
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.40
-    transitivePeerDependencies:
-      - supports-color
 
   unplugin-utils@0.3.2:
     dependencies:
       pathe: 2.0.3
       picomatch: 4.0.5
 
-  unplugin-vue-components@0.27.5(@babel/parser@7.29.7)(rollup@4.62.2)(vue@3.5.40(typescript@5.5.4)):
+  unplugin-vue-components@0.27.5(@babel/parser@7.29.7)(rollup@4.62.2)(vue@3.5.40(typescript@5.6.3)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
@@ -3676,7 +3647,7 @@ snapshots:
       minimatch: 9.0.9
       mlly: 1.8.2
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@5.5.4)
+      vue: 3.5.40(typescript@5.6.3)
     optionalDependencies:
       '@babel/parser': 7.29.7
     transitivePeerDependencies:
@@ -3686,6 +3657,13 @@ snapshots:
   unplugin@1.16.1:
     dependencies:
       acorn: 8.17.0
+      webpack-virtual-modules: 0.6.2
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.17.0
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   unplugin@3.3.0(esbuild@0.21.5)(rollup@4.62.2)(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0)):
@@ -3721,9 +3699,9 @@ snapshots:
 
   vue-component-type-helpers@3.3.7: {}
 
-  vue-demi@0.14.10(vue@3.5.40(typescript@5.5.4)):
+  vue-demi@0.14.10(vue@3.5.40(typescript@5.6.3)):
     dependencies:
-      vue: 3.5.40(typescript@5.5.4)
+      vue: 3.5.40(typescript@5.6.3)
 
   vue-eslint-parser@10.4.1(eslint@9.39.5):
     dependencies:
@@ -3737,10 +3715,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.21.5)(pinia@2.3.1(typescript@5.5.4)(vue@3.5.40(typescript@5.5.4)))(rollup@4.62.2)(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0))(vue@3.5.40(typescript@5.5.4)):
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.21.5)(pinia@2.3.1(typescript@5.6.3)(vue@3.5.40(typescript@5.6.3)))(rollup@4.62.2)(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0))(vue@3.5.40(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0
-      '@vue-macros/common': 3.1.3(vue@3.5.40(typescript@5.5.4))
+      '@vue-macros/common': 3.1.3(vue@3.5.40(typescript@5.6.3))
       '@vue/devtools-api': 8.1.5
       ast-walker-scope: 0.9.0
       chokidar: 5.0.0
@@ -3756,11 +3734,11 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin: 3.3.0(esbuild@0.21.5)(rollup@4.62.2)(vite@5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0))
       unplugin-utils: 0.3.2
-      vue: 3.5.40(typescript@5.5.4)
+      vue: 3.5.40(typescript@5.6.3)
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.40
-      pinia: 2.3.1(typescript@5.5.4)(vue@3.5.40(typescript@5.5.4))
+      pinia: 2.3.1(typescript@5.6.3)(vue@3.5.40(typescript@5.6.3))
       vite: 5.4.21(@types/node@20.19.43)(sass-embedded@1.100.0)(sass@1.100.0)
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -3772,17 +3750,17 @@ snapshots:
       - unloader
       - webpack
 
-  vue-tsc@3.3.7(typescript@5.5.4):
+  vue-tsc@3.3.7(typescript@5.6.3):
     dependencies:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 3.3.7
-      typescript: 5.5.4
+      typescript: 5.6.3
 
-  vue3-virtual-scroll-list@0.2.1(vue@3.5.40(typescript@5.5.4)):
+  vue3-virtual-scroll-list@0.2.1(vue@3.5.40(typescript@5.6.3)):
     dependencies:
-      vue: 3.5.40(typescript@5.5.4)
+      vue: 3.5.40(typescript@5.6.3)
 
-  vue@3.5.40(typescript@5.5.4):
+  vue@3.5.40(typescript@5.6.3):
     dependencies:
       '@vue/compiler-dom': 3.5.40
       '@vue/compiler-sfc': 3.5.40
@@ -3790,7 +3768,7 @@ snapshots:
       '@vue/server-renderer': 3.5.40
       '@vue/shared': 3.5.40
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.6.3
 
   webpack-virtual-modules@0.6.2: {}
 


### PR DESCRIPTION
## 问题

- #271 和 #274 的新版本声明使用字符串导出名，TypeScript 5.5.4 无法解析，导致 Web type-check 失败。
- 两个依赖共享同一兼容前提，分开升级会重复修改锁文件并持续红灯。

## 修改

- @vitejs/plugin-vue 升级到 6.0.8。
- unplugin-icons 升级到 23.0.1。
- TypeScript 升级到 5.6.3，以支持 arbitrary module identifiers。
- 保持 Vite 5.4 和现有 Vue 3/ESM 配置不变。
- 使用 CI 同版 pnpm 9.15.9 重建锁文件。

## 验证

- pnpm install --frozen-lockfile 通过。
- TypeScript 版本为 5.6.3。
- pnpm run type-check 通过。
- pnpm run build-only 通过。

替代 #271 和 #274。