### PR TITLE
切换 protobuf-javalite 到维护版本

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ zxingLite = "3.5.0"
 hutool = "5.8.22"
 
 #noinspection NewerVersionAvailable
-protobufJavalite = "4.26.1"
+protobufJavalite = "3.25.9"
 
 # issue #3811，不要更新版本，新版引入了一个破坏性变更（详见https://github.com/jhy/jsoup/pull/2017）
 # 若要升级请确保相关代码不会受此变更影响（如AnalyzeByJSoup.kt、JsoupXpath库等）


### PR DESCRIPTION
## 问题

- protobuf-javalite 4.35.1 与 firebase-perf 传递的 protolite-well-known-types 18.0.1 重复包含 DescriptorProtos，导致 release/releaseA 均在 duplicate classes 检查失败。
- 排除 Firebase AAR 属于不受支持的运行时替换，不能作为构建修复。
- 当前 4.26.1 已结束维护，因此切换到仍维护的 Java 3.25.x 分支。

## 修改

- protobuf-javalite 从 4.26.1 调整为 3.25.9。
- 不添加依赖排除、packagingOptions 或自定义替换规则。

## 验证

- dependencyInsight 选中 protobuf-javalite 3.25.9，Firebase protolite 保持 18.0.1。
- checkAppReleaseDuplicateClasses 通过。
- testAppReleaseUnitTest：630 项，0 失败，0 错误，2 跳过。
- releaseA/ARM Release/R8 通过。
- 通用 Release/R8 通过。
- 每次 Gradle 后相关构建进程均为 0。

替代 #270。