### PR TITLE
统一单输入弹窗浮动标签

### DIFF
--- a/app/src/main/java/io/legado/app/ui/widget/text/AutoCompleteTextView.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/text/AutoCompleteTextView.kt
@@ -8,10 +8,12 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewParent
 import android.widget.ArrayAdapter
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatAutoCompleteTextView
+import com.google.android.material.textfield.TextInputLayout as MaterialTextInputLayout
 import io.legado.app.R
 import io.legado.app.lib.theme.accentColor
 import io.legado.app.utils.applyTint
@@ -31,6 +33,19 @@ class AutoCompleteTextView @JvmOverloads constructor(
         applyTint(context.accentColor)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
             isLocalePreferredLineHeightForMinimumUsed = false
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        val currentHint = hint ?: return
+        var ancestor: ViewParent? = parent
+        while (ancestor != null && ancestor !is MaterialTextInputLayout) {
+            ancestor = ancestor.parent
+        }
+        if (ancestor is MaterialTextInputLayout) {
+            ancestor.hint = currentHint
+            hint = null
         }
     }
 

--- a/app/src/main/res/layout/dialog_edit_text.xml
+++ b/app/src/main/res/layout/dialog_edit_text.xml
@@ -7,10 +7,21 @@
     android:paddingLeft="16dp"
     android:paddingRight="16dp">
 
-    <io.legado.app.ui.widget.text.AutoCompleteTextView
-        android:id="@+id/edit_view"
+    <io.legado.app.ui.widget.text.TextInputLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        tools:ignore="SpeakableTextPresentCheck,TouchTargetSizeCheck" />
+        android:layout_height="wrap_content">
+
+        <io.legado.app.ui.widget.text.AutoCompleteTextView
+            android:id="@+id/edit_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:paddingStart="12dp"
+            android:paddingTop="6dp"
+            android:paddingEnd="12dp"
+            android:paddingBottom="6dp"
+            tools:ignore="SpeakableTextPresentCheck,TouchTargetSizeCheck" />
+
+    </io.legado.app.ui.widget.text.TextInputLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/app/src/test/java/io/legado/app/ui/widget/DialogMultipleEditTextLayoutTest.kt
+++ b/app/src/test/java/io/legado/app/ui/widget/DialogMultipleEditTextLayoutTest.kt
@@ -2,6 +2,7 @@ package io.legado.app.ui.widget
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.w3c.dom.Document
 import org.w3c.dom.Element
@@ -34,14 +35,40 @@ class DialogMultipleEditTextLayoutTest {
         assertEquals("12dp", secondLayout.androidAttribute("layout_marginTop"))
     }
 
+    @Test
+    fun singleFieldDialogUsesFloatingLabelForRuntimeHints() {
+        val document = parseProjectXml("src/main/res/layout/dialog_edit_text.xml")
+        val field = document.findElementById("@+id/edit_view")
+        val inputLayout = field.parentNode as Element
+
+        assertEquals("io.legado.app.ui.widget.text.TextInputLayout", inputLayout.tagName)
+        assertEquals("48dp", field.androidAttribute("minHeight"))
+        assertEquals("12dp", field.androidAttribute("paddingStart"))
+        assertEquals("6dp", field.androidAttribute("paddingTop"))
+        assertEquals("12dp", field.androidAttribute("paddingEnd"))
+        assertEquals("6dp", field.androidAttribute("paddingBottom"))
+        assertFalse(field.hasAttributeNS(androidNamespace, "singleLine"))
+
+        val source = readProjectFile(
+            "src/main/java/io/legado/app/ui/widget/text/AutoCompleteTextView.kt"
+        )
+        assertTrue(source.contains("override fun onAttachedToWindow()"))
+        assertTrue(source.contains("ancestor.hint = currentHint"))
+        assertTrue(source.contains("hint = null"))
+    }
+
     private fun parseProjectXml(pathInApp: String): Document {
-        val file = listOf(File(pathInApp), File("app/$pathInApp"))
-            .firstOrNull { it.isFile }
-            ?: error("Missing project file: $pathInApp")
         return DocumentBuilderFactory.newInstance().apply {
             isNamespaceAware = true
-        }.newDocumentBuilder().parse(file)
+        }.newDocumentBuilder().parse(projectFile(pathInApp))
     }
+
+    private fun readProjectFile(pathInApp: String): String = projectFile(pathInApp).readText()
+
+    private fun projectFile(pathInApp: String): File =
+        listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
 
     private fun Document.findElementById(id: String): Element {
         return getElementsByTagName("*").let { nodes ->


### PR DESCRIPTION
## 变更
- 将通用单输入弹窗的输入框放入 `TextInputLayout`，统一为浮动标签样式
- 在 `AutoCompleteTextView` 挂载时把运行时 hint 提升到外层标签，现有调用点无需调整
- 保留多行输入，并补齐最小触控高度与输入内边距
- 扩展布局回归测试

参考 `skybbk1001/legadoT@b90ff57f5032b7ebb11a50bb8713a9e8cab982f9`，按当前主线控件实现适配。

## 验证
- `:app:testAppReleaseUnitTest --tests io.legado.app.ui.widget.DialogMultipleEditTextLayoutTest`
- `:app:testAppReleaseUnitTest`：631 项，0 失败，0 错误，2 跳过