### PR TITLE
统一有声书计数单位为集

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayActivity.kt
@@ -219,6 +219,7 @@ class AudioPlayActivity :
                 SleepTimerDialog.newInstance(
                     AudioPlayService.timeMinute,
                     AudioPlayService.chapterToStop,
+                    useEpisodes = true,
                 )
             )
         }
@@ -417,7 +418,7 @@ class AudioPlayActivity :
         val minute = AudioPlayService.timeMinute
         when {
             chapter > 0 -> {
-                binding.tvTimer.text = getString(R.string.sleep_timer_chapters, chapter)
+                binding.tvTimer.text = getString(R.string.audio_stop_chapters, chapter)
                 binding.tvTimer.visible()
             }
 

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/SleepTimerDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/SleepTimerDialog.kt
@@ -25,6 +25,7 @@ class SleepTimerDialog : BaseDialogFragment(R.layout.dialog_sleep_timer) {
     private var minute = 0
     private var chapter = 0
     private var chapterMode = false
+    private var useEpisodes = false
 
     override fun onStart() {
         super.onStart()
@@ -34,9 +35,14 @@ class SleepTimerDialog : BaseDialogFragment(R.layout.dialog_sleep_timer) {
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
         minute = arguments?.getInt(ARG_MINUTE)?.coerceIn(0, MAX_MINUTES) ?: 0
         chapter = arguments?.getInt(ARG_CHAPTER)?.coerceIn(0, MAX_CHAPTER_STOP_COUNT) ?: 0
+        useEpisodes = arguments?.getBoolean(ARG_EPISODES) == true
         chapterMode = chapter > 0
 
         binding.run {
+            rbChapter.setText(
+                if (useEpisodes) R.string.sleep_timer_by_episode
+                else R.string.sleep_timer_by_chapter
+            )
             rbTime.isChecked = !chapterMode
             rbChapter.isChecked = chapterMode
             rgMode.setOnCheckedChangeListener { _, checkedId ->
@@ -74,7 +80,11 @@ class SleepTimerDialog : BaseDialogFragment(R.layout.dialog_sleep_timer) {
 
     private fun upValueText() {
         binding.tvValue.text = if (chapterMode) {
-            getString(R.string.sleep_timer_chapters, chapter)
+            getString(
+                if (useEpisodes) R.string.audio_stop_chapters
+                else R.string.sleep_timer_chapters,
+                chapter,
+            )
         } else {
             getString(R.string.timer_m, minute)
         }
@@ -83,12 +93,18 @@ class SleepTimerDialog : BaseDialogFragment(R.layout.dialog_sleep_timer) {
     companion object {
         private const val ARG_MINUTE = "minute"
         private const val ARG_CHAPTER = "chapter"
+        private const val ARG_EPISODES = "episodes"
         private const val MAX_MINUTES = 180
 
-        fun newInstance(minute: Int, chapter: Int) = SleepTimerDialog().apply {
+        fun newInstance(
+            minute: Int,
+            chapter: Int,
+            useEpisodes: Boolean = false,
+        ) = SleepTimerDialog().apply {
             arguments = Bundle().apply {
                 putInt(ARG_MINUTE, minute)
                 putInt(ARG_CHAPTER, chapter)
+                putBoolean(ARG_EPISODES, useEpisodes)
             }
         }
     }

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -167,11 +167,13 @@
     <string name="read_aloud_timer">正在朗读（还剩 %d 分钟）</string>
     <string name="read_aloud_timer_chapter">正在朗读（还剩 %d 章）</string>
     <string name="playing_timer">正在播放（还剩 %d 分钟）</string>
-    <string name="playing_timer_chapter">正在播放（还剩 %d 章）</string>
+    <string name="playing_timer_chapter">正在播放（还剩 %d 集）</string>
     <string name="sleep_timer_title">停止设置</string>
     <string name="sleep_timer_by_time">按分钟</string>
     <string name="sleep_timer_by_chapter">按章节</string>
+    <string name="sleep_timer_by_episode">按集数</string>
     <string name="sleep_timer_chapters">%d 章</string>
+    <string name="audio_stop_chapters">听完 %d 集</string>
     <string name="ps_hide_navigation_bar">阅读界面隐藏虚拟按键</string>
     <string name="pt_hide_navigation_bar">隐藏导航栏</string>
     <string name="re_navigation_bar_color">导航栏颜色</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,7 +173,9 @@
     <string name="sleep_timer_title">Sleep timer</string>
     <string name="sleep_timer_by_time">Minutes</string>
     <string name="sleep_timer_by_chapter">Chapters</string>
+    <string name="sleep_timer_by_episode">Chapters</string>
     <string name="sleep_timer_chapters">%d chapters</string>
+    <string name="audio_stop_chapters">Stop after %d chapters</string>
     <string name="ps_hide_navigation_bar">Hide virtual buttons when reading</string>
     <string name="pt_hide_navigation_bar">Hide navigation bar</string>
     <string name="re_navigation_bar_color">Navigation bar color</string>

--- a/app/src/test/java/io/legado/app/ui/book/audio/AudioEpisodeUnitTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/audio/AudioEpisodeUnitTest.kt
@@ -1,0 +1,85 @@
+package io.legado.app.ui.book.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class AudioEpisodeUnitTest {
+
+    @Test
+    fun audioAndReadAloudKeepSeparateChineseCountUnits() {
+        assertEquals("正在朗读（还剩 %d 章）", chineseString("read_aloud_timer_chapter"))
+        assertEquals("正在播放（还剩 %d 集）", chineseString("playing_timer_chapter"))
+        assertEquals("%d 章", chineseString("sleep_timer_chapters"))
+        assertEquals("听完 %d 集", chineseString("audio_stop_chapters"))
+        assertEquals("按集数", chineseString("sleep_timer_by_episode"))
+        assertEquals("Chapters", defaultString("sleep_timer_by_episode"))
+    }
+
+    @Test
+    fun audioPlayerUsesEpisodeLabelsWhileReadAloudKeepsChapterLabels() {
+        val activity = projectFile(
+            "src/main/java/io/legado/app/ui/book/audio/AudioPlayActivity.kt"
+        ).readText()
+        val readAloudDialog = projectFile(
+            "src/main/java/io/legado/app/ui/book/read/config/ReadAloudDialog.kt"
+        ).readText()
+        val dialog = projectFile(
+            "src/main/java/io/legado/app/ui/widget/dialog/SleepTimerDialog.kt"
+        ).readText()
+
+        assertTrue(activity.contains("R.string.audio_stop_chapters"))
+        assertTrue(
+            Regex(
+                "SleepTimerDialog\\.newInstance\\(\\s*" +
+                    "AudioPlayService\\.timeMinute,\\s*" +
+                    "AudioPlayService\\.chapterToStop,\\s*" +
+                    "useEpisodes = true,\\s*\\)"
+            ).containsMatchIn(activity)
+        )
+        assertTrue(
+            Regex(
+                "SleepTimerDialog\\.newInstance\\(\\s*" +
+                    "BaseReadAloudService\\.timeMinute,\\s*" +
+                    "BaseReadAloudService\\.chapterToStop,\\s*\\)"
+            ).containsMatchIn(readAloudDialog)
+        )
+        assertTrue(
+            Regex(
+                "if \\(useEpisodes\\)\\s*R\\.string\\.sleep_timer_by_episode\\s*" +
+                    "else R\\.string\\.sleep_timer_by_chapter"
+            ).containsMatchIn(dialog)
+        )
+        assertTrue(
+            Regex(
+                "if \\(useEpisodes\\)\\s*R\\.string\\.audio_stop_chapters\\s*" +
+                    "else R\\.string\\.sleep_timer_chapters"
+            ).containsMatchIn(dialog)
+        )
+    }
+
+    private fun chineseString(name: String) = stringValue("values-zh", name)
+
+    private fun defaultString(name: String) = stringValue("values", name)
+
+    private fun stringValue(directory: String, name: String): String {
+        val document = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(projectFile("src/main/res/$directory/strings.xml"))
+        return document.getElementsByTagName("string").let { nodes ->
+            (0 until nodes.length)
+                .map { nodes.item(it) as Element }
+                .single { it.getAttribute("name") == name }
+                .textContent
+        }
+    }
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+    }
+}


### PR DESCRIPTION
## 变更

- 参考 https://github.com/skybbk1001/legadoT/commit/b21e4e19ba0a5ade0889b6826ae50f511df15d7b
- 有声书播放通知、停止状态和停止设置统一使用“集”
- 共享停止设置弹窗按调用方区分有声书与朗读文案
- 朗读继续使用“章”，英文文案继续使用 chapters
- 增加资源与调用分支回归测试

## 验证

- ./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.ui.book.audio.AudioEpisodeUnitTest --no-daemon
- ./gradlew.bat :app:testAppReleaseUnitTest --no-daemon（632 项，0 失败，0 错误，2 跳过）