### PR TITLE
清理 JavaScript 顶层作用域编译警告

### DIFF
--- a/app/src/main/java/io/legado/app/help/JsExtensions.kt
+++ b/app/src/main/java/io/legado/app/help/JsExtensions.kt
@@ -64,7 +64,6 @@ import org.jsoup.Jsoup
 import org.htmlunit.corejs.javascript.Function
 import org.htmlunit.corejs.javascript.Scriptable
 import org.htmlunit.corejs.javascript.ScriptableObject
-import org.htmlunit.corejs.javascript.TopLevel
 import org.htmlunit.corejs.javascript.Undefined
 import splitties.init.appCtx
 import java.io.ByteArrayInputStream
@@ -1243,7 +1242,7 @@ interface JsExtensions : JsEncodeUtils {
 
     private fun functionThisObj(action: Function): Scriptable {
         val top = action.parentScope?.let { ScriptableObject.getTopLevelScope(it) }
-        return (top as? TopLevel)?.globalThis
+        return top?.globalThis
             ?: Undefined.SCRIPTABLE_UNDEFINED
     }
 


### PR DESCRIPTION
## 变更

- 参考 https://github.com/skybbk1001/legadoT/commit/9f634cdde8fcd45a33d291513787606bd026c8f4
- 移除 getTopLevelScope 返回值的冗余 TopLevel 安全转换
- 同步删除不再使用的 TopLevel 导入
- 保持 globalThis 获取和未定义回退行为不变

## 验证

- ./gradlew.bat :app:compileAppReleaseKotlin --no-daemon --warning-mode all
- 编译成功，JsExtensions.kt 的 No cast needed 警告为 0