### PR TITLE
让通知栏定时按钮延续停止模式

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -153,6 +153,7 @@ object PreferKey {
     const val progressBarBehavior = "progressBarBehavior"
     const val sourceEditMaxLine = "sourceEditMaxLine"
     const val ttsTimer = "ttsTimer"
+    const val sleepTimerPreferChapter = "sleepTimerPreferChapter"
     const val noAnimScrollPage = "noAnimScrollPage"
     const val webDavDeviceName = "webDavDeviceName"
     const val webServiceWakeLock = "webServiceWakeLock"

--- a/app/src/main/java/io/legado/app/help/config/AppConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/AppConfig.kt
@@ -365,6 +365,12 @@ object AppConfig : SharedPreferences.OnSharedPreferenceChangeListener {
             appCtx.putPrefInt(PreferKey.ttsTimer, value)
         }
 
+    var sleepTimerPreferChapter: Boolean
+        get() = appCtx.getPrefBoolean(PreferKey.sleepTimerPreferChapter, false)
+        set(value) {
+            appCtx.putPrefBoolean(PreferKey.sleepTimerPreferChapter, value)
+        }
+
     val speechRatePlay: Int get() = if (ttsFlowSys) defaultSpeechRate else ttsSpeechRate
 
     var chineseConverterType: Int

--- a/app/src/main/java/io/legado/app/service/AudioPlayService.kt
+++ b/app/src/main/java/io/legado/app/service/AudioPlayService.kt
@@ -450,16 +450,10 @@ class AudioPlayService : BaseService(),
     }
 
     private fun addTimer() {
-        if (timeMinute == 180) {
-            timeMinute = 0
-        } else {
-            timeMinute += 10
-            if (timeMinute > 180) timeMinute = 180
-        }
-        chapterStopTimer.clear()
-        chapterToStop = 0
-        postEvent(EventBus.AUDIO_CHAPTER_STOP, 0)
-        doDs()
+        val next = nextSleepTimerIncrement(
+            timeMinute, chapterToStop, AppConfig.sleepTimerPreferChapter
+        )
+        if (next.chapter > 0) setChapterStop(next.chapter) else setTimer(next.minute)
     }
 
     private fun setChapterStop(count: Int) {

--- a/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
+++ b/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
@@ -470,16 +470,10 @@ abstract class BaseReadAloudService : BaseService(),
     }
 
     private fun addTimer() {
-        if (timeMinute == 180) {
-            timeMinute = 0
-        } else {
-            timeMinute += 10
-            if (timeMinute > 180) timeMinute = 180
-        }
-        chapterStopTimer.clear()
-        chapterToStop = 0
-        postEvent(EventBus.READ_ALOUD_CHAPTER_STOP, 0)
-        doDs()
+        val next = nextSleepTimerIncrement(
+            timeMinute, chapterToStop, AppConfig.sleepTimerPreferChapter
+        )
+        if (next.chapter > 0) setChapterStop(next.chapter) else setTimer(next.minute)
     }
 
     private fun setChapterStop(count: Int) {

--- a/app/src/main/java/io/legado/app/service/ChapterStopTimer.kt
+++ b/app/src/main/java/io/legado/app/service/ChapterStopTimer.kt
@@ -7,6 +7,11 @@ internal data class ChapterStopResult(
     val shouldStop: Boolean,
 )
 
+internal data class SleepTimerIncrement(
+    val minute: Int = 0,
+    val chapter: Int = 0,
+)
+
 internal class ChapterStopTimer(initialCount: Int = 0) {
 
     var remaining: Int = normalizeChapterStopCount(initialCount)
@@ -30,4 +35,22 @@ internal class ChapterStopTimer(initialCount: Int = 0) {
 
 internal fun normalizeChapterStopCount(count: Int): Int {
     return count.coerceIn(0, MAX_CHAPTER_STOP_COUNT)
+}
+
+internal fun nextSleepTimerIncrement(
+    timeMinute: Int,
+    chapterToStop: Int,
+    preferChapter: Boolean,
+): SleepTimerIncrement {
+    val minute = timeMinute.coerceIn(0, 180)
+    val chapter = normalizeChapterStopCount(chapterToStop)
+    return when {
+        chapter > 0 -> SleepTimerIncrement(
+            chapter = (chapter + 1).coerceAtMost(MAX_CHAPTER_STOP_COUNT)
+        )
+
+        minute == 0 && preferChapter -> SleepTimerIncrement(chapter = 1)
+        minute == 180 -> SleepTimerIncrement()
+        else -> SleepTimerIncrement(minute = (minute + 10).coerceAtMost(180))
+    }
 }

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/SleepTimerDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/SleepTimerDialog.kt
@@ -7,6 +7,7 @@ import android.widget.SeekBar
 import io.legado.app.R
 import io.legado.app.base.BaseDialogFragment
 import io.legado.app.databinding.DialogSleepTimerBinding
+import io.legado.app.help.config.AppConfig
 import io.legado.app.service.MAX_CHAPTER_STOP_COUNT
 import io.legado.app.ui.widget.seekbar.SeekBarChangeListener
 import io.legado.app.utils.setLayout
@@ -61,8 +62,10 @@ class SleepTimerDialog : BaseDialogFragment(R.layout.dialog_sleep_timer) {
             tvCancel.setOnClickListener { dismissAllowingStateLoss() }
             tvOk.setOnClickListener {
                 if (chapterMode) {
+                    if (chapter > 0) AppConfig.sleepTimerPreferChapter = true
                     callBack?.onSleepTimerChapter(chapter)
                 } else {
+                    if (minute > 0) AppConfig.sleepTimerPreferChapter = false
                     callBack?.onSleepTimerMinute(minute)
                 }
                 dismissAllowingStateLoss()

--- a/app/src/test/java/io/legado/app/service/ChapterStopTimerTest.kt
+++ b/app/src/test/java/io/legado/app/service/ChapterStopTimerTest.kt
@@ -33,6 +33,53 @@ class ChapterStopTimerTest {
     }
 
     @Test
+    fun notificationTimerIncrementKeepsActiveModeAndUsesIdlePreference() {
+        assertEquals(
+            SleepTimerIncrement(minute = 30),
+            nextSleepTimerIncrement(timeMinute = 20, chapterToStop = 0, preferChapter = true)
+        )
+        assertEquals(
+            SleepTimerIncrement(chapter = 3),
+            nextSleepTimerIncrement(timeMinute = 0, chapterToStop = 2, preferChapter = false)
+        )
+        assertEquals(
+            SleepTimerIncrement(chapter = 1),
+            nextSleepTimerIncrement(timeMinute = 0, chapterToStop = 0, preferChapter = true)
+        )
+        assertEquals(
+            SleepTimerIncrement(minute = 10),
+            nextSleepTimerIncrement(timeMinute = 0, chapterToStop = 0, preferChapter = false)
+        )
+        assertEquals(
+            SleepTimerIncrement(),
+            nextSleepTimerIncrement(timeMinute = 180, chapterToStop = 0, preferChapter = false)
+        )
+        assertEquals(
+            SleepTimerIncrement(chapter = MAX_CHAPTER_STOP_COUNT),
+            nextSleepTimerIncrement(
+                timeMinute = 0,
+                chapterToStop = MAX_CHAPTER_STOP_COUNT,
+                preferChapter = false,
+            )
+        )
+    }
+
+    @Test
+    fun notificationTimerButtonsAndDialogUseSharedPreference() {
+        val root = listOf(File("src/main/java"), File("app/src/main/java"))
+            .first { it.isDirectory }
+        val audio = File(root, "io/legado/app/service/AudioPlayService.kt").readText()
+        val readAloud = File(root, "io/legado/app/service/BaseReadAloudService.kt").readText()
+        val dialog = File(root, "io/legado/app/ui/widget/dialog/SleepTimerDialog.kt").readText()
+        val incrementCall = "timeMinute, chapterToStop, AppConfig.sleepTimerPreferChapter"
+
+        assertTrue(audio.contains(incrementCall))
+        assertTrue(readAloud.contains(incrementCall))
+        assertTrue(dialog.contains("if (chapter > 0) AppConfig.sleepTimerPreferChapter = true"))
+        assertTrue(dialog.contains("if (minute > 0) AppConfig.sleepTimerPreferChapter = false"))
+    }
+
+    @Test
     fun onlyNaturalReadAloudTransitionsConsumeChapterCount() {
         val root = listOf(File("src/main/java"), File("app/src/main/java"))
             .first { it.isDirectory }


### PR DESCRIPTION
## 变更

- 参考 https://github.com/skybbk1001/legadoT/commit/52bcb8fddc4e203011c7683c8f17a8c004edfdf0
- 按集停止生效时，通知栏定时按钮改为增加 1 集，不再切回分钟模式
- 没有活动停止任务时，按停止弹窗最近一次确认的模式从 1 集或 10 分钟开始
- 听书和朗读共用同一状态转换逻辑，保持 180 分钟关闭和 99 集上限
- 关闭定时不会覆盖最近模式偏好

## 验证

- ./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.service.ChapterStopTimerTest --no-daemon
- ./gradlew.bat :app:testAppReleaseUnitTest --no-daemon（636 项，0 失败，0 错误，2 跳过）