### PR TITLE
修复沉浸式源编辑与调试背景穿透

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/source/debug/BookSourceDebugActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/debug/BookSourceDebugActivity.kt
@@ -1,6 +1,7 @@
 package io.legado.app.ui.book.source.debug
 
 import android.annotation.SuppressLint
+import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -11,11 +12,14 @@ import androidx.lifecycle.lifecycleScope
 import io.legado.app.R
 import io.legado.app.base.VMBaseActivity
 import io.legado.app.databinding.ActivitySourceDebugBinding
+import io.legado.app.help.config.AppConfig
 import io.legado.app.help.source.clearExploreKindsCache
 import io.legado.app.help.source.exploreKinds
 import io.legado.app.lib.dialogs.selector
 import io.legado.app.lib.theme.accentColor
+import io.legado.app.lib.theme.backgroundColor
 import io.legado.app.lib.theme.primaryColor
+import io.legado.app.lib.theme.transparentNavBar
 import io.legado.app.ui.qrcode.QrCodeResult
 import io.legado.app.ui.widget.dialog.TextDialog
 import io.legado.app.utils.applyNavigationBarPadding
@@ -35,6 +39,7 @@ class BookSourceDebugActivity : VMBaseActivity<ActivitySourceDebugBinding, BookS
     override val viewModel by viewModels<BookSourceDebugModel>()
 
     private val adapter by lazy { BookSourceDebugAdapter(this) }
+    private var loading = false
     private val searchView: SearchView by lazy {
         binding.titleBar.findViewById(R.id.search_view)
     }
@@ -45,6 +50,9 @@ class BookSourceDebugActivity : VMBaseActivity<ActivitySourceDebugBinding, BookS
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
+        binding.help.setBackgroundColor(
+            if (transparentNavBar && !AppConfig.isEInkMode) Color.TRANSPARENT else backgroundColor
+        )
         initRecyclerView()
         initSearchView()
         viewModel.init(intent.getStringExtra("key")) {
@@ -54,6 +62,7 @@ class BookSourceDebugActivity : VMBaseActivity<ActivitySourceDebugBinding, BookS
             lifecycleScope.launch {
                 adapter.addItem(msg)
                 if (state == -1 || state == 1000) {
+                    loading = false
                     binding.rotateLoading.gone()
                 }
             }
@@ -168,16 +177,23 @@ class BookSourceDebugActivity : VMBaseActivity<ActivitySourceDebugBinding, BookS
     private fun openOrCloseHelp(open: Boolean) {
         if (open) {
             binding.help.visibility = View.VISIBLE
+            binding.recyclerView.visibility = View.GONE
         } else {
             binding.help.visibility = View.GONE
+            binding.recyclerView.visibility = View.VISIBLE
         }
+        if (open || !loading) binding.rotateLoading.gone() else binding.rotateLoading.visible()
     }
 
     private fun startSearch(key: String) {
+        openOrCloseHelp(false)
         adapter.clearItems()
         viewModel.startDebug(key, {
-            binding.rotateLoading.visible()
+            loading = true
+            if (binding.help.visibility != View.VISIBLE) binding.rotateLoading.visible()
         }, {
+            loading = false
+            binding.rotateLoading.gone()
             toastOnUi("未获取到书源")
         })
     }

--- a/app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt
@@ -1,6 +1,7 @@
 package io.legado.app.ui.book.source.edit
 
 import android.content.Intent
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.view.Menu
@@ -23,6 +24,7 @@ import io.legado.app.data.entities.rule.ExploreRule
 import io.legado.app.data.entities.rule.SearchRule
 import io.legado.app.data.entities.rule.TocRule
 import io.legado.app.databinding.ActivityBookSourceEditBinding
+import io.legado.app.help.config.AppConfig
 import io.legado.app.help.config.LocalConfig
 import io.legado.app.lib.dialogs.SelectItem
 import io.legado.app.lib.dialogs.alert
@@ -30,6 +32,7 @@ import io.legado.app.lib.dialogs.selector
 import io.legado.app.lib.theme.accentColor
 import io.legado.app.lib.theme.backgroundColor
 import io.legado.app.lib.theme.primaryColor
+import io.legado.app.lib.theme.transparentNavBar
 import io.legado.app.ui.about.AppLogDialog
 import io.legado.app.ui.book.search.SearchActivity
 import io.legado.app.ui.book.source.debug.BookSourceDebugActivity
@@ -313,7 +316,11 @@ class BookSourceEditActivity :
                 newFocus.postDelayed({ sendText("") }, 120)
             }
         }
-        binding.tabLayout.setBackgroundColor(backgroundColor)
+        val transparentBar = transparentNavBar && !AppConfig.isEInkMode
+        binding.tabLayout.setBackgroundColor(
+            if (transparentBar) Color.TRANSPARENT else backgroundColor
+        )
+        if (transparentBar) binding.tabLayout.elevation = 0f
         binding.tabLayout.setSelectedTabIndicatorColor(accentColor)
         binding.tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabReselected(tab: TabLayout.Tab?) {

--- a/app/src/main/java/io/legado/app/ui/rss/source/debug/RssSourceDebugActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/rss/source/debug/RssSourceDebugActivity.kt
@@ -1,6 +1,7 @@
 package io.legado.app.ui.rss.source.debug
 
 import android.annotation.SuppressLint
+import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -10,10 +11,13 @@ import androidx.lifecycle.lifecycleScope
 import io.legado.app.R
 import io.legado.app.base.VMBaseActivity
 import io.legado.app.databinding.ActivityRssSourceDebugBinding
+import io.legado.app.help.config.AppConfig
 import io.legado.app.help.source.sortUrls
 import io.legado.app.lib.dialogs.selector
 import io.legado.app.lib.theme.accentColor
+import io.legado.app.lib.theme.backgroundColor
 import io.legado.app.lib.theme.primaryColor
+import io.legado.app.lib.theme.transparentNavBar
 import io.legado.app.ui.widget.dialog.TextDialog
 import io.legado.app.utils.applyNavigationBarPadding
 import io.legado.app.utils.setEdgeEffectColor
@@ -31,11 +35,15 @@ class RssSourceDebugActivity : VMBaseActivity<ActivityRssSourceDebugBinding, Rss
     override val viewModel by viewModels<RssSourceDebugModel>()
 
     private val adapter by lazy { RssSourceDebugAdapter(this) }
+    private var loading = false
     private val searchView: androidx.appcompat.widget.SearchView by lazy {
         binding.titleBar.findViewById(R.id.search_view)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
+        binding.help.setBackgroundColor(
+            if (transparentNavBar && !AppConfig.isEInkMode) Color.TRANSPARENT else backgroundColor
+        )
         initRecyclerView()
         initSearchView()
         viewModel.initData(intent.getStringExtra("key")) {
@@ -45,6 +53,7 @@ class RssSourceDebugActivity : VMBaseActivity<ActivityRssSourceDebugBinding, Rss
             lifecycleScope.launch {
                 adapter.addItem(msg)
                 if (state == -1 || state == 1000) {
+                    loading = false
                     binding.rotateLoading.gone()
                 }
             }
@@ -145,15 +154,22 @@ class RssSourceDebugActivity : VMBaseActivity<ActivityRssSourceDebugBinding, Rss
     private fun openOrCloseHelp(open: Boolean) {
         if (open) {
             binding.help.visibility = View.VISIBLE
+            binding.recyclerView.visibility = View.GONE
         } else {
             binding.help.visibility = View.GONE
+            binding.recyclerView.visibility = View.VISIBLE
         }
+        if (open || !loading) binding.rotateLoading.gone() else binding.rotateLoading.visible()
     }
     private fun startSearch(key: String) {
+        openOrCloseHelp(false)
         adapter.clearItems()
         viewModel.startDebug(key, {
-            binding.rotateLoading.visible()
+            loading = true
+            if (binding.help.visibility != View.VISIBLE) binding.rotateLoading.visible()
         }, {
+            loading = false
+            binding.rotateLoading.gone()
             toastOnUi("未获取到书源")
         })
     }

--- a/app/src/main/java/io/legado/app/ui/rss/source/edit/RssSourceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/rss/source/edit/RssSourceEditActivity.kt
@@ -1,6 +1,7 @@
 package io.legado.app.ui.rss.source.edit
 
 import android.content.Intent
+import android.graphics.Color
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
@@ -20,12 +21,14 @@ import io.legado.app.R
 import io.legado.app.base.VMBaseActivity
 import io.legado.app.data.entities.RssSource
 import io.legado.app.databinding.ActivityRssSourceEditBinding
+import io.legado.app.help.config.AppConfig
 import io.legado.app.help.config.LocalConfig
 import io.legado.app.lib.dialogs.SelectItem
 import io.legado.app.lib.dialogs.alert
 import io.legado.app.lib.theme.accentColor
 import io.legado.app.lib.theme.backgroundColor
 import io.legado.app.lib.theme.primaryColor
+import io.legado.app.lib.theme.transparentNavBar
 import io.legado.app.ui.about.AppLogDialog
 import io.legado.app.ui.code.CodeEditActivity
 import io.legado.app.ui.file.HandleFileContract
@@ -303,7 +306,11 @@ class RssSourceEditActivity :
                 newFocus.postDelayed({ sendText("") }, 120)
             }
         }
-        binding.tabLayout.setBackgroundColor(backgroundColor)
+        val transparentBar = transparentNavBar && !AppConfig.isEInkMode
+        binding.tabLayout.setBackgroundColor(
+            if (transparentBar) Color.TRANSPARENT else backgroundColor
+        )
+        if (transparentBar) binding.tabLayout.elevation = 0f
         binding.tabLayout.setSelectedTabIndicatorColor(accentColor)
         binding.tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabReselected(tab: TabLayout.Tab?) {

--- a/app/src/main/res/layout/activity_rss_source_debug.xml
+++ b/app/src/main/res/layout/activity_rss_source_debug.xml
@@ -40,6 +40,7 @@
         android:id="@+id/help"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/background"
         android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@+id/title_bar"
         tools:visibility="visible">
@@ -47,7 +48,6 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/background"
             android:orientation="vertical"
             android:padding="16dp">
 

--- a/app/src/main/res/layout/activity_source_debug.xml
+++ b/app/src/main/res/layout/activity_source_debug.xml
@@ -40,6 +40,7 @@
         android:id="@+id/help"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/background"
         android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@+id/title_bar"
         tools:visibility="visible">
@@ -47,7 +48,6 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/background"
             android:orientation="vertical"
             android:padding="16dp">
 

--- a/app/src/test/java/io/legado/app/ui/source/SourceImmersiveBackgroundTest.kt
+++ b/app/src/test/java/io/legado/app/ui/source/SourceImmersiveBackgroundTest.kt
@@ -1,0 +1,85 @@
+package io.legado.app.ui.source
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class SourceImmersiveBackgroundTest {
+
+    @Test
+    fun sourceEditorsMatchTitleBarTransparency() {
+        val titleBar = projectFile("src/main/java/io/legado/app/ui/widget/TitleBar.kt").readText()
+        assertTrue(titleBar.contains("if (AppConfig.isEInkMode)"))
+        assertTrue(titleBar.contains("else if (!opaque && context.transparentNavBar)"))
+
+        listOf(
+            "src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt",
+            "src/main/java/io/legado/app/ui/rss/source/edit/RssSourceEditActivity.kt",
+        ).forEach { path ->
+            val source = projectFile(path).readText()
+            assertTrue(source.contains("transparentNavBar && !AppConfig.isEInkMode"))
+            assertTrue(source.contains("if (transparentBar) Color.TRANSPARENT else backgroundColor"))
+            assertTrue(source.contains("if (transparentBar) binding.tabLayout.elevation = 0f"))
+        }
+    }
+
+    @Test
+    fun sourceDebugHelpPanelsHideLogsAndMatchTitleBarTransparency() {
+        listOf(
+            "src/main/java/io/legado/app/ui/book/source/debug/BookSourceDebugActivity.kt",
+            "src/main/java/io/legado/app/ui/rss/source/debug/RssSourceDebugActivity.kt",
+        ).forEach { path ->
+            val source = projectFile(path).readText()
+            assertTrue(source.contains("transparentNavBar && !AppConfig.isEInkMode"))
+            assertTrue(source.contains("Color.TRANSPARENT else backgroundColor"))
+            assertTrue(source.contains("binding.recyclerView.visibility = View.GONE"))
+            assertTrue(source.contains("binding.recyclerView.visibility = View.VISIBLE"))
+            assertTrue(source.contains("loading = true"))
+            assertTrue(source.contains("loading = false"))
+            assertTrue(
+                Regex("private fun startSearch\\(key: String\\) \\{\\s*openOrCloseHelp\\(false\\)")
+                    .containsMatchIn(source)
+            )
+            assertTrue(
+                source.contains(
+                    "if (open || !loading) binding.rotateLoading.gone() " +
+                        "else binding.rotateLoading.visible()"
+                )
+            )
+        }
+    }
+
+    @Test
+    fun debugHelpBackgroundBelongsToScrollablePanel() {
+        listOf("activity_source_debug.xml", "activity_rss_source_debug.xml").forEach { layout ->
+            val help = viewById(layout, "help")
+            assertEquals("@color/background", help.getAttribute("android:background"))
+            val content = (0 until help.childNodes.length)
+                .map { help.childNodes.item(it) }
+                .filterIsInstance<Element>()
+                .single()
+            assertFalse(content.hasAttribute("android:background"))
+        }
+    }
+
+    private fun viewById(layout: String, id: String): Element {
+        val document = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(projectFile("src/main/res/layout/$layout"))
+        return document.getElementsByTagName("*").let { nodes ->
+            (0 until nodes.length)
+                .map { nodes.item(it) as Element }
+                .single { it.getAttribute("android:id") == "@+id/$id" }
+        }
+    }
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+    }
+}


### PR DESCRIPTION
## 变更

- 参考 https://github.com/skybbk1001/legadoT/commit/b0e94304765c4421e0851bd8f202c2bb692ab57e
- 书源和 RSS 编辑页的 TabLayout 跟随主线 TitleBar 的沉浸式透明条件
- EInk 与非沉浸模式继续使用页面背景色，透明模式移除 TabLayout 阴影
- 书源和 RSS 调试帮助面板统一按相同条件着色
- 帮助面板打开时隐藏日志列表和加载动画，所有调试入口会先关闭帮助面板
- 将两个帮助面板背景移到可整体着色的滚动容器
- 增加四个 Activity 与两个布局的回归测试

## 验证

- ./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.ui.source.SourceImmersiveBackgroundTest --no-daemon
- ./gradlew.bat :app:testAppReleaseUnitTest --no-daemon（637 项，0 失败，0 错误，2 跳过）