### PR TITLE
补充 getElements 集合方法回归测试

### DIFF
--- a/app/src/test/java/io/legado/app/JsTest.kt
+++ b/app/src/test/java/io/legado/app/JsTest.kt
@@ -120,6 +120,43 @@ class JsTest {
         Assert.assertEquals(result, 6.0)
     }
 
+    class ElementsProvider {
+        private val document = org.jsoup.Jsoup.parse(
+            """<div id="video-artist-name"><a href="/artist/1">n</a></div>"""
+        )
+
+        fun getElements(rule: String): List<Any> = document.select("$rule a")
+    }
+
+    @Test
+    fun javaListSubclassMethods() {
+        val provider = ElementsProvider()
+        val bindings = ScriptBindings()
+        bindings["java"] = provider
+        bindings["result"] = provider.getElements("#video-artist-name")
+
+        val viaMethod = RhinoScriptEngine.eval(
+            "java.getElements('#video-artist-name').attr('href')", bindings
+        )
+        Assert.assertEquals("/artist/1", viaMethod)
+        val viaBinding = RhinoScriptEngine.eval("result.attr('href')", bindings)
+        Assert.assertEquals("/artist/1", viaBinding)
+    }
+
+    @Test
+    fun analyzeRuleGetElementsKeepsCollectionMethods() {
+        val analyzeRule = io.legado.app.model.analyzeRule.AnalyzeRule()
+        analyzeRule.setContent(
+            """<div id="video-artist-name"><a href="/artist/1">n</a></div>"""
+        )
+        val bindings = ScriptBindings()
+        bindings["java"] = analyzeRule
+        val result = RhinoScriptEngine.eval(
+            "java.getElements('#video-artist-name a').attr('href')", bindings
+        )
+        Assert.assertEquals("/artist/1", result)
+    }
+
     @Test
     fun javaStringInteropBoundary() {
         val chapter = BookChapter(


### PR DESCRIPTION
## 变更

- 参考 https://github.com/skybbk1001/legadoT/commit/c0ca02aa8f62c45e0e937f3c7930d27a7b82f0cc
- 主线 AnalyzeRule 已直接返回原集合，不需要移植 fork 中针对 filterNotNull 的生产修复
- 增加声明返回 List、运行时返回 JSoup Elements 的 Rhino 包装测试
- 增加 java.getElements(...).attr(...) 的 AnalyzeRule 全链路回归测试
- 防止后续集合归一化或 Java 列表包装改动再次丢失 Elements.attr/text/html 等方法

## 验证

- ./gradlew.bat :app:testAppReleaseUnitTest --tests JsTest.javaListSubclassMethods --tests JsTest.analyzeRuleGetElementsKeepsCollectionMethods --no-daemon
- ./gradlew.bat :app:testAppReleaseUnitTest --no-daemon（638 项，0 失败，0 错误，2 跳过）