### PR TITLE
恢复空闲播放器的听书进度

### DIFF
--- a/app/src/main/java/io/legado/app/service/AudioPlayService.kt
+++ b/app/src/main/java/io/legado/app/service/AudioPlayService.kt
@@ -240,7 +240,7 @@ class AudioPlayService : BaseService(),
      */
     @OptIn(UnstableApi::class)
     @SuppressLint("WakelockTimeout")
-    private fun play() {
+    private fun play(preservePosition: Boolean = false) {
         if (useWakeLock) {
             wakeLock.acquire()
             wifiLock?.acquire()
@@ -261,7 +261,9 @@ class AudioPlayService : BaseService(),
                     return@execute
                 }
                 exoPlayer.setMediaSource(mediaSource)
-                position = 0
+                if (!preservePosition) {
+                    position = 0
+                }
             } else {
                 val analyzeUrl = AnalyzeUrl(
                     url,
@@ -300,6 +302,7 @@ class AudioPlayService : BaseService(),
             }
             upPlayProgressJob?.cancel()
             position = exoPlayer.currentPosition.toInt()
+            AudioPlay.playPositionChanged(position)
             if (exoPlayer.isPlaying) exoPlayer.pause()
             upMediaSessionPlaybackState(PlaybackStateCompat.STATE_PAUSED)
             AudioPlay.status = Status.PAUSE
@@ -326,9 +329,8 @@ class AudioPlayService : BaseService(),
                 return
             }
             if (exoPlayer.playbackState == Player.STATE_IDLE) {
-                // 如果播放器处于空闲状态，重新开始播放
-                position = 0
-                play()
+                position = AudioPlay.book?.let { AudioPlay.durChapterPos } ?: position
+                play(preservePosition = true)
                 return
             }
             if (!exoPlayer.isPlaying) {
@@ -563,6 +565,7 @@ class AudioPlayService : BaseService(),
         mediaSessionCompat.setCallback(object : MediaSessionCompat.Callback() {
             override fun onSeekTo(pos: Long) {
                 position = pos.toInt()
+                AudioPlay.playPositionChanged(position)
                 exoPlayer.seekTo(pos)
             }
 

--- a/app/src/test/java/io/legado/app/service/AudioIdleResumeTest.kt
+++ b/app/src/test/java/io/legado/app/service/AudioIdleResumeTest.kt
@@ -1,0 +1,61 @@
+package io.legado.app.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class AudioIdleResumeTest {
+
+    @Test
+    fun idleResumeUsesCurrentAudioProgress() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/service/AudioPlayService.kt"
+        ).readText()
+        val idleBranch = Regex(
+            "if \\(exoPlayer\\.playbackState == Player\\.STATE_IDLE\\) \\{(.*?)\\n\\s*}",
+            RegexOption.DOT_MATCHES_ALL,
+        ).find(source)?.groupValues?.get(1) ?: error("Missing STATE_IDLE resume branch")
+
+        assertTrue(
+            idleBranch.contains(
+                "position = AudioPlay.book?.let { AudioPlay.durChapterPos } ?: position"
+            )
+        )
+        assertTrue(idleBranch.contains("play(preservePosition = true)"))
+        assertFalse(idleBranch.contains("position = 0"))
+    }
+
+    @Test
+    fun positionChangesStayInSyncWithAudioPlay() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/service/AudioPlayService.kt"
+        ).readText()
+
+        val pauseBody = source.substringAfter("private fun pause(")
+            .substringBefore("private fun resume()")
+        assertTrue(pauseBody.contains("AudioPlay.playPositionChanged(position)"))
+
+        val seekBody = source.substringAfter("override fun onSeekTo(pos: Long)")
+            .substringBefore("override fun onMediaButtonEvent")
+        assertTrue(seekBody.contains("AudioPlay.playPositionChanged(position)"))
+    }
+
+    @Test
+    fun jsonPlaybackDoesNotDiscardAResumedPosition() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/service/AudioPlayService.kt"
+        ).readText()
+        val jsonBranch = source.substringAfter("if (url.isJsonArray())")
+            .substringBefore("} else {")
+
+        assertTrue(jsonBranch.contains("if (!preservePosition)"))
+        assertTrue(jsonBranch.contains("position = 0"))
+    }
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+    }
+}


### PR DESCRIPTION
## 修改
- 播放器处于 IDLE 时从当前听书进度重新装载，不再回到开头
- JSON 多段音频在恢复播放时保留已有位置
- 暂停和媒体会话拖动后同步内存进度，避免再次恢复时回退
- 增加 IDLE、JSON 音频和进度同步回归测试

## 测试
- ./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.service.AudioIdleResumeTest --no-daemon
- ./gradlew.bat :app:testAppReleaseUnitTest --no-daemon

## 参考
- https://github.com/skybbk1001/legadoT/commit/04707cd46871fca560526c1182ce5588492a161f