### PR TITLE
按实际播放时长记录听书时间

### DIFF
--- a/app/src/main/java/io/legado/app/model/AudioPlay.kt
+++ b/app/src/main/java/io/legado/app/model/AudioPlay.kt
@@ -3,6 +3,7 @@ package io.legado.app.model
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.os.SystemClock
 import io.legado.app.R
 import io.legado.app.constant.AppLog
 import io.legado.app.constant.EventBus
@@ -31,6 +32,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancelChildren
 import splitties.init.appCtx
+import java.util.concurrent.Future
 import kotlin.text.trim
 
 internal data class AudioPlayUrlKey(
@@ -92,6 +94,39 @@ internal class AudioPlayUrlPreloadStore {
     }
 }
 
+internal class AudioReadTimeTracker {
+
+    private var record = ReadRecord()
+    private var activeRecord: ReadRecord? = null
+    private var startedAt: Long? = null
+
+    @Synchronized
+    fun setRecord(record: ReadRecord) {
+        this.record = record
+    }
+
+    @Synchronized
+    fun start(now: Long) {
+        if (startedAt == null) {
+            activeRecord = record
+            startedAt = now
+        }
+    }
+
+    @Synchronized
+    fun stop(now: Long, lastRead: Long): ReadRecord? {
+        val start = startedAt ?: return null
+        val record = activeRecord ?: return null
+        activeRecord = null
+        startedAt = null
+        val elapsed = (now - start).coerceAtLeast(0)
+        if (elapsed == 0L) return null
+        record.readTime += elapsed
+        record.lastRead = lastRead
+        return record.copy()
+    }
+}
+
 @SuppressLint("StaticFieldLeak")
 @Suppress("unused")
 object AudioPlay : CoroutineScope by MainScope() {
@@ -134,8 +169,9 @@ object AudioPlay : CoroutineScope by MainScope() {
         private set
     val loadingChapters = arrayListOf<Int>()
     private val playUrlPreloadStore = AudioPlayUrlPreloadStore()
-    private val readRecord = ReadRecord()
-    var readStartTime: Long = System.currentTimeMillis()
+    private val readTimeTracker = AudioReadTimeTracker()
+    @Volatile
+    private var readTimeWrite: Future<*>? = null
     val executor = globalExecutor
 
     fun changePlayMode() {
@@ -167,8 +203,7 @@ object AudioPlay : CoroutineScope by MainScope() {
         stop()
         playUrlPreloadStore.reset()
         AudioPlay.book = book
-        readRecord.bookName = book.name
-        readRecord.readTime = appDb.readRecordDao.getReadTime(book.name) ?: 0
+        resetReadRecord(book)
         chapterSize = appDb.bookChapterDao.getChapterCount(book.bookUrl)
         simulatedChapterSize = if (book.readSimulating()) {
             book.simulatedTotalChapterNum()
@@ -193,21 +228,48 @@ object AudioPlay : CoroutineScope by MainScope() {
         postEvent(EventBus.AUDIO_BUFFER_PROGRESS, 0)
     }
 
+    @Synchronized
+    fun replaceBook(book: Book) {
+        AudioPlay.book = book
+        resetReadRecord(book, resumeIfPlaying = true)
+    }
+
+    @Synchronized
+    private fun resetReadRecord(book: Book, resumeIfPlaying: Boolean = false) {
+        upReadTime()
+        kotlin.runCatching { readTimeWrite?.get() }.onFailure {
+            AppLog.put("保存听书时长失败\n${it.localizedMessage}", it)
+        }
+        readTimeTracker.setRecord(
+            ReadRecord(
+                bookName = book.name,
+                readTime = appDb.readRecordDao.getReadTime(book.name) ?: 0,
+            )
+        )
+        if (resumeIfPlaying && AudioPlayService.isPlaying) {
+            markReadTimeStart()
+        }
+    }
+
     fun setBookSource(source: BookSource?) {
         bookSource = source
         playUrlPreloadStore.reset()
     }
 
+    @Synchronized
+    fun markReadTimeStart() {
+        if (AppConfig.enableReadRecord) {
+            readTimeTracker.start(SystemClock.elapsedRealtime())
+        }
+    }
+
+    @Synchronized
     fun upReadTime() {
-        if (!AppConfig.enableReadRecord) {
-            return
-        }
-        executor.execute {
-            readRecord.readTime = readRecord.readTime + System.currentTimeMillis() - readStartTime
-            readStartTime = System.currentTimeMillis()
-            readRecord.lastRead = System.currentTimeMillis()
-            appDb.readRecordDao.insert(readRecord)
-        }
+        val record = readTimeTracker.stop(
+            now = SystemClock.elapsedRealtime(),
+            lastRead = System.currentTimeMillis(),
+        ) ?: return
+        readTimeWrite = executor.submit { appDb.readRecordDao.insert(record) }
     }
 
     private fun addLoading(index: Int): Boolean {
@@ -379,7 +441,6 @@ object AudioPlay : CoroutineScope by MainScope() {
 
     fun pause(context: Context) {
         if (AudioPlayService.isRun) {
-            readStartTime = System.currentTimeMillis()
             context.startService<AudioPlayService> {
                 action = IntentAction.pause
             }
@@ -456,7 +517,6 @@ object AudioPlay : CoroutineScope by MainScope() {
 
     fun next() {
         stopPlay()
-        upReadTime()
         when (playMode) {
             PlayMode.LIST_END_STOP -> {
                 if (durChapterIndex + 1 < simulatedChapterSize) {

--- a/app/src/main/java/io/legado/app/service/AudioPlayService.kt
+++ b/app/src/main/java/io/legado/app/service/AudioPlayService.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.SharedPreferences
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.media.AudioManager
@@ -30,6 +31,7 @@ import io.legado.app.constant.AppLog
 import io.legado.app.constant.EventBus
 import io.legado.app.constant.IntentAction
 import io.legado.app.constant.NotificationId
+import io.legado.app.constant.PreferKey
 import io.legado.app.constant.Status
 import io.legado.app.exception.NoStackTraceException
 import io.legado.app.help.MediaHelp
@@ -44,6 +46,7 @@ import io.legado.app.receiver.MediaButtonReceiver
 import io.legado.app.ui.book.audio.AudioPlayActivity
 import io.legado.app.utils.activityPendingIntent
 import io.legado.app.utils.broadcastPendingIntent
+import io.legado.app.utils.defaultSharedPreferences
 import io.legado.app.utils.isJsonArray
 import io.legado.app.utils.postEvent
 import io.legado.app.utils.printOnDebug
@@ -65,7 +68,8 @@ import splitties.systemservices.wifiManager
  */
 class AudioPlayService : BaseService(),
     AudioManager.OnAudioFocusChangeListener,
-    Player.Listener {
+    Player.Listener,
+    SharedPreferences.OnSharedPreferenceChangeListener {
 
     companion object {
         @JvmStatic
@@ -74,6 +78,11 @@ class AudioPlayService : BaseService(),
 
         @JvmStatic
         var pause = true
+            private set
+
+        @JvmStatic
+        @Volatile
+        var isPlaying = false
             private set
 
         @JvmStatic
@@ -144,6 +153,7 @@ class AudioPlayService : BaseService(),
             timeMinute = 0
         }
         exoPlayer.addListener(this)
+        defaultSharedPreferences.registerOnSharedPreferenceChangeListener(this)
         AudioPlay.registerService(this)
         initMediaSession()
         initBroadcastReceiver()
@@ -212,6 +222,9 @@ class AudioPlayService : BaseService(),
 
     override fun onDestroy() {
         super.onDestroy()
+        isPlaying = false
+        AudioPlay.upReadTime()
+        defaultSharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
         if (useWakeLock) {
             wakeLock.release()
             wifiLock?.release()
@@ -419,6 +432,28 @@ class AudioPlayService : BaseService(),
         upAudioPlayNotification()
     }
 
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        super.onIsPlayingChanged(isPlaying)
+        AudioPlayService.isPlaying = isPlaying
+        if (isPlaying) {
+            AudioPlay.markReadTimeStart()
+        } else {
+            AudioPlay.upReadTime()
+        }
+    }
+
+    override fun onSharedPreferenceChanged(
+        sharedPreferences: SharedPreferences?,
+        key: String?,
+    ) {
+        if (key != PreferKey.enableReadRecord) return
+        if (AppConfig.enableReadRecord && exoPlayer.isPlaying) {
+            AudioPlay.markReadTimeStart()
+        } else {
+            AudioPlay.upReadTime()
+        }
+    }
+
     private fun upMediaMetadata() {
         val metadata = MediaMetadataCompat.Builder()
             .putBitmap(MediaMetadataCompat.METADATA_KEY_ART, cover)
@@ -435,6 +470,7 @@ class AudioPlayService : BaseService(),
      */
     override fun onPlayerError(error: PlaybackException) {
         super.onPlayerError(error)
+        AudioPlay.upReadTime()
         AudioPlay.status = Status.STOP
         postEvent(EventBus.AUDIO_STATE, Status.STOP)
         AudioPlay.upLoading(false)

--- a/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayViewModel.kt
@@ -107,7 +107,7 @@ class AudioPlayViewModel(application: Application) : BaseViewModel(application) 
             book.removeType(BookType.updateError)
             AudioPlay.book?.delete()
             appDb.bookDao.insert(book)
-            AudioPlay.book = book
+            AudioPlay.replaceBook(book)
             AudioPlay.setBookSource(source)
             appDb.bookChapterDao.insert(*toc.toTypedArray())
             AudioPlay.upDurChapter()

--- a/app/src/test/java/io/legado/app/model/AudioReadTimeTrackerTest.kt
+++ b/app/src/test/java/io/legado/app/model/AudioReadTimeTrackerTest.kt
@@ -1,0 +1,80 @@
+package io.legado.app.model
+
+import io.legado.app.data.entities.ReadRecord
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class AudioReadTimeTrackerTest {
+
+    @Test
+    fun `duplicate starts and stops count each playing interval once`() {
+        val tracker = AudioReadTimeTracker()
+        tracker.setRecord(ReadRecord(bookName = "book", readTime = 100))
+
+        tracker.start(1_000)
+        tracker.start(1_500)
+        assertEquals(1_100L, tracker.stop(2_000, 10_000)?.readTime)
+        assertNull(tracker.stop(2_500, 11_000))
+
+        tracker.start(3_000)
+        assertEquals(1_600L, tracker.stop(3_500, 12_000)?.readTime)
+    }
+
+    @Test
+    fun `an active interval remains assigned to its original book`() {
+        val tracker = AudioReadTimeTracker()
+        tracker.setRecord(ReadRecord(bookName = "first"))
+        tracker.start(100)
+        tracker.setRecord(ReadRecord(bookName = "second"))
+
+        assertEquals("first", tracker.stop(200, 1_000)?.bookName)
+        tracker.start(300)
+        assertEquals("second", tracker.stop(450, 2_000)?.bookName)
+    }
+
+    @Test
+    fun `service records only actual playing state`() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/service/AudioPlayService.kt"
+        ).readText()
+        val callback = source.substringAfter("override fun onIsPlayingChanged(isPlaying: Boolean)")
+            .substringBefore("override fun onPlayerError")
+            .replace(Regex("\\s+"), " ")
+
+        assertTrue(
+            callback.contains(
+                "if (isPlaying) { AudioPlay.markReadTimeStart() } else { AudioPlay.upReadTime() }"
+            )
+        )
+
+        val preferenceCallback = source.substringAfter("override fun onSharedPreferenceChanged(")
+            .substringBefore("private fun upMediaMetadata")
+            .replace(Regex("\\s+"), " ")
+        assertTrue(preferenceCallback.contains("key != PreferKey.enableReadRecord"))
+        assertTrue(
+            preferenceCallback.contains(
+                "if (AppConfig.enableReadRecord && exoPlayer.isPlaying)"
+            )
+        )
+
+        val model = projectFile("src/main/java/io/legado/app/model/AudioPlay.kt")
+            .readText()
+            .replace(Regex("\\s+"), " ")
+        assertTrue(model.contains("@Synchronized fun upReadTime()"))
+        assertTrue(model.contains("readTimeWrite = executor.submit"))
+
+        val viewModel = projectFile(
+            "src/main/java/io/legado/app/ui/book/audio/AudioPlayViewModel.kt"
+        ).readText()
+        assertTrue(viewModel.contains("AudioPlay.replaceBook(book)"))
+    }
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+    }
+}


### PR DESCRIPTION
## 修改
- 根据 Media3 的实际 isPlaying 状态开始和结算听书时长，排除缓冲、暂停和播放抑制
- 使用单调时钟记录播放片段，重复状态回调不会重复计时
- 切书和有声书换源前等待最近一次记录写入，避免快速切换覆盖新时长
- 播放中切换“记录阅读时长”时即时结算或重新开始
- 增加计时幂等、连续片段、书籍归属和 Service 接线回归测试

## 测试
- ./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.model.AudioReadTimeTrackerTest --no-daemon
- ./gradlew.bat :app:testAppReleaseUnitTest --no-daemon

## 参考
- https://github.com/skybbk1001/legadoT/commit/04707cd46871fca560526c1182ce5588492a161f