### PR TITLE
为 JavaScript 书源模板补充 Jsoup 别名

### DIFF
--- a/app/src/main/assets/js_source_template.js
+++ b/app/src/main/assets/js_source_template.js
@@ -17,6 +17,8 @@ var config = {
     lastUpdateTime: 0
 };
 
+var Jsoup = org.jsoup.Jsoup;
+
 // config.loginUi 非空时必须提供。
 function login() {
     var loginInfo = JSON.parse(source.getLoginInfo() || "{}");

--- a/app/src/test/java/io/legado/app/model/jsSource/JsSourceAuthorGuideTest.kt
+++ b/app/src/test/java/io/legado/app/model/jsSource/JsSourceAuthorGuideTest.kt
@@ -24,6 +24,7 @@ class JsSourceAuthorGuideTest {
         val source = JsSourceConfig.extract(script)
 
         assertTrue(script.contains("var config ="))
+        assertTrue(script.contains("var Jsoup = org.jsoup.Jsoup;"))
         assertEquals("https://example.com", source.bookSourceUrl)
         assertEquals("示例 JS 书源", source.bookSourceName)
     }


### PR DESCRIPTION
## 修改
- 在内置 JavaScript 书源模板顶层提供 Jsoup 别名
- 保留主线模板的 var 语法和现有配置结构
- 补充模板导入回归断言

## 测试
- node --check app/src/main/assets/js_source_template.js
- ./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.model.jsSource.JsSourceAuthorGuideTest --no-daemon

## 参考
- https://github.com/skybbk1001/legadoT/commit/cefdfe783