### PR TITLE
显示听书当前集数和总集数

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayActivity.kt
@@ -386,6 +386,17 @@ class AudioPlayActivity :
         }
         observeEventSticky<String>(EventBus.AUDIO_SUB_TITLE) {
             binding.tvSubTitle.text = it
+            val chapterSize = AudioPlay.simulatedChapterSize
+            if (chapterSize > 0) {
+                binding.tvChapterIndex.text = getString(
+                    R.string.audio_chapter_progress,
+                    AudioPlay.durChapterIndex + 1,
+                    chapterSize,
+                )
+                binding.tvChapterIndex.visible()
+            } else {
+                binding.tvChapterIndex.gone()
+            }
             binding.ivSkipPrevious.isEnabled = AudioPlay.durChapterIndex > 0
             binding.ivSkipNext.isEnabled =
                 AudioPlay.durChapterIndex < AudioPlay.simulatedChapterSize - 1

--- a/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayViewModel.kt
@@ -110,7 +110,7 @@ class AudioPlayViewModel(application: Application) : BaseViewModel(application) 
             AudioPlay.replaceBook(book)
             AudioPlay.setBookSource(source)
             appDb.bookChapterDao.insert(*toc.toTypedArray())
-            AudioPlay.upDurChapter()
+            AudioPlay.upData(book)
         }.onFinally {
             postEvent(EventBus.SOURCE_CHANGED, book.bookUrl)
         }

--- a/app/src/main/res/layout-land/activity_audio_play.xml
+++ b/app/src/main/res/layout-land/activity_audio_play.xml
@@ -86,15 +86,35 @@
 
     <TextView
         android:id="@+id/tv_sub_title"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:maxLines="2"
+        android:paddingStart="24dp"
+        android:paddingTop="8dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="2dp"
+        android:textColor="@color/md_white_1000"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/ll_player_progress"
+        app:layout_constraintEnd_toStartOf="@+id/tv_chapter_index"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_chapter_index"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:paddingStart="16dp"
-        android:paddingTop="6dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="6dp"
-        android:textColor="@color/md_white_1000"
-        app:layout_constraintBottom_toTopOf="@+id/ll_player_progress" />
+        android:paddingEnd="24dp"
+        android:textColor="@color/md_dark_secondary"
+        android:textSize="12sp"
+        android:visibility="gone"
+        app:layout_constraintBaseline_toBaselineOf="@+id/tv_sub_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:text="第 12 集 · 共 320 集"
+        tools:visibility="visible" />
 
     <LinearLayout
         android:id="@+id/ll_player_progress"

--- a/app/src/main/res/layout/activity_audio_play.xml
+++ b/app/src/main/res/layout/activity_audio_play.xml
@@ -86,13 +86,33 @@
         android:id="@+id/tv_sub_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:ellipsize="end"
         android:gravity="center"
-        android:paddingStart="16dp"
-        android:paddingTop="6dp"
-        android:paddingEnd="16dp"
-        android:paddingBottom="6dp"
+        android:maxLines="2"
+        android:paddingStart="24dp"
+        android:paddingTop="8dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="2dp"
         android:textColor="@color/md_white_1000"
-        app:layout_constraintBottom_toTopOf="@+id/ll_player_progress" />
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/tv_chapter_index" />
+
+    <TextView
+        android:id="@+id/tv_chapter_index"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="6dp"
+        android:textColor="@color/md_dark_secondary"
+        android:textSize="12sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/ll_player_progress"
+        app:layout_constraintTop_toBottomOf="@+id/tv_sub_title"
+        tools:text="第 12 集 · 共 320 集"
+        tools:visibility="visible" />
 
     <LinearLayout
         android:id="@+id/ll_player_progress"

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -174,6 +174,7 @@
     <string name="sleep_timer_by_episode">按集数</string>
     <string name="sleep_timer_chapters">%d 章</string>
     <string name="audio_stop_chapters">听完 %d 集</string>
+    <string name="audio_chapter_progress">第 %1$d 集 · 共 %2$d 集</string>
     <string name="ps_hide_navigation_bar">阅读界面隐藏虚拟按键</string>
     <string name="pt_hide_navigation_bar">隐藏导航栏</string>
     <string name="re_navigation_bar_color">导航栏颜色</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,6 +176,7 @@
     <string name="sleep_timer_by_episode">Chapters</string>
     <string name="sleep_timer_chapters">%d chapters</string>
     <string name="audio_stop_chapters">Stop after %d chapters</string>
+    <string name="audio_chapter_progress">Chapter %1$d / %2$d</string>
     <string name="ps_hide_navigation_bar">Hide virtual buttons when reading</string>
     <string name="pt_hide_navigation_bar">Hide navigation bar</string>
     <string name="re_navigation_bar_color">Navigation bar color</string>

--- a/app/src/test/java/io/legado/app/ui/book/audio/AudioEpisodeUnitTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/audio/AudioEpisodeUnitTest.kt
@@ -17,6 +17,8 @@ class AudioEpisodeUnitTest {
         assertEquals("听完 %d 集", chineseString("audio_stop_chapters"))
         assertEquals("按集数", chineseString("sleep_timer_by_episode"))
         assertEquals("Chapters", defaultString("sleep_timer_by_episode"))
+        assertEquals("第 %1\$d 集 · 共 %2\$d 集", chineseString("audio_chapter_progress"))
+        assertEquals("Chapter %1\$d / %2\$d", defaultString("audio_chapter_progress"))
     }
 
     @Test
@@ -30,8 +32,16 @@ class AudioEpisodeUnitTest {
         val dialog = projectFile(
             "src/main/java/io/legado/app/ui/widget/dialog/SleepTimerDialog.kt"
         ).readText()
+        val viewModel = projectFile(
+            "src/main/java/io/legado/app/ui/book/audio/AudioPlayViewModel.kt"
+        ).readText()
 
         assertTrue(activity.contains("R.string.audio_stop_chapters"))
+        assertTrue(activity.contains("R.string.audio_chapter_progress"))
+        assertTrue(activity.contains("AudioPlay.durChapterIndex + 1"))
+        assertTrue(activity.contains("binding.tvChapterIndex.visible()"))
+        assertTrue(activity.contains("binding.tvChapterIndex.gone()"))
+        assertEquals(2, Regex("AudioPlay\\.upData\\(book\\)").findAll(viewModel).count())
         assertTrue(
             Regex(
                 "SleepTimerDialog\\.newInstance\\(\\s*" +

--- a/app/src/test/java/io/legado/app/ui/book/audio/AudioPlayLayoutTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/audio/AudioPlayLayoutTest.kt
@@ -37,6 +37,63 @@ class AudioPlayLayoutTest {
         assertEquals("#FFFFFFFF", vectorFillColor("ic_pause_24dp.xml"))
     }
 
+    @Test
+    fun chapterInfoIsBoundedAndPresentInBothOrientations() {
+        val portraitPath = "src/main/res/layout/activity_audio_play.xml"
+        val landscapePath = "src/main/res/layout-land/activity_audio_play.xml"
+        val layouts = listOf(portraitPath, landscapePath).associateWith(::parseProjectXml)
+
+        layouts.forEach { (path, document) ->
+            val title = findViewById(document, "@+id/tv_sub_title")
+            val chapterIndex = findViewById(document, "@+id/tv_chapter_index")
+
+            assertEquals(path, "end", title.getAttributeNS(androidNamespace, "ellipsize"))
+            assertEquals(path, "2", title.getAttributeNS(androidNamespace, "maxLines"))
+            assertEquals(path, "bold", title.getAttributeNS(androidNamespace, "textStyle"))
+            assertEquals(path, "gone", chapterIndex.getAttributeNS(androidNamespace, "visibility"))
+            assertEquals(path, "12sp", chapterIndex.getAttributeNS(androidNamespace, "textSize"))
+            assertEquals(
+                path,
+                "@color/md_dark_secondary",
+                chapterIndex.getAttributeNS(androidNamespace, "textColor"),
+            )
+        }
+
+        val portraitTitle = findViewById(layouts.getValue(portraitPath), "@+id/tv_sub_title")
+        val portraitIndex = findViewById(layouts.getValue(portraitPath), "@+id/tv_chapter_index")
+        assertEquals(
+            "@+id/tv_chapter_index",
+            portraitTitle.getAttributeNS(appNamespace, "layout_constraintBottom_toTopOf"),
+        )
+        assertEquals(
+            "@+id/tv_sub_title",
+            portraitIndex.getAttributeNS(appNamespace, "layout_constraintTop_toBottomOf"),
+        )
+        assertEquals(
+            "@+id/ll_player_progress",
+            portraitIndex.getAttributeNS(appNamespace, "layout_constraintBottom_toTopOf"),
+        )
+
+        val landscapeTitle = findViewById(layouts.getValue(landscapePath), "@+id/tv_sub_title")
+        val landscapeIndex = findViewById(layouts.getValue(landscapePath), "@+id/tv_chapter_index")
+        assertEquals(
+            "@+id/ll_player_progress",
+            landscapeTitle.getAttributeNS(appNamespace, "layout_constraintBottom_toTopOf"),
+        )
+        assertEquals(
+            "@+id/tv_chapter_index",
+            landscapeTitle.getAttributeNS(appNamespace, "layout_constraintEnd_toStartOf"),
+        )
+        assertEquals(
+            "@+id/tv_sub_title",
+            landscapeIndex.getAttributeNS(appNamespace, "layout_constraintBaseline_toBaselineOf"),
+        )
+        assertEquals(
+            "parent",
+            landscapeIndex.getAttributeNS(appNamespace, "layout_constraintEnd_toEndOf"),
+        )
+    }
+
     private fun findPlayButton(document: Document): Element {
         return document.getElementsByTagName(
             "com.google.android.material.floatingactionbutton.FloatingActionButton"
@@ -45,6 +102,13 @@ class AudioPlayLayoutTest {
                 .map { nodes.item(it) as Element }
                 .single { it.getAttributeNS(androidNamespace, "id") == "@+id/fab_play_stop" }
         }
+    }
+
+    private fun findViewById(document: Document, id: String): Element {
+        val nodes = document.getElementsByTagName("*")
+        return (0 until nodes.length)
+            .map { nodes.item(it) as Element }
+            .single { it.getAttributeNS(androidNamespace, "id") == id }
     }
 
     private fun vectorFillColor(fileName: String): String {


### PR DESCRIPTION
## 变更

- 参考 https://github.com/skybbk1001/legadoT/commit/feaf6d7a3640efd2534ef36684fd1c76e83f7a60
- 听书页显示当前集数与总集数，目录总数未知时隐藏
- 章节标题限制为两行并突出显示，竖屏保留歌词链路，横屏标题与集数同行
- 换源完成后重新计算章节总数，避免沿用旧来源的上下集状态
- 增加横竖屏布局、中文集数单位和换源更新回归测试

## 验证

- `./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.ui.book.audio.AudioEpisodeUnitTest --tests io.legado.app.ui.book.audio.AudioPlayLayoutTest --no-daemon`
- `./gradlew.bat :app:testAppReleaseUnitTest --no-daemon`（648 项，0 失败，0 错误，2 跳过）