### PR TITLE
增加定时停止快捷预设

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -154,6 +154,8 @@ object PreferKey {
     const val sourceEditMaxLine = "sourceEditMaxLine"
     const val ttsTimer = "ttsTimer"
     const val sleepTimerPreferChapter = "sleepTimerPreferChapter"
+    const val lastSleepTimer = "lastSleepTimer"
+    const val lastSleepChapter = "lastSleepChapter"
     const val noAnimScrollPage = "noAnimScrollPage"
     const val webDavDeviceName = "webDavDeviceName"
     const val webServiceWakeLock = "webServiceWakeLock"

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/SleepTimerDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/SleepTimerDialog.kt
@@ -3,15 +3,22 @@ package io.legado.app.ui.widget.dialog
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
-import android.widget.SeekBar
+import android.view.inputmethod.EditorInfo
+import android.widget.TextView
+import androidx.core.view.isVisible
 import io.legado.app.R
 import io.legado.app.base.BaseDialogFragment
+import io.legado.app.constant.PreferKey
 import io.legado.app.databinding.DialogSleepTimerBinding
 import io.legado.app.help.config.AppConfig
 import io.legado.app.service.MAX_CHAPTER_STOP_COUNT
-import io.legado.app.ui.widget.seekbar.SeekBarChangeListener
+import io.legado.app.utils.getPrefInt
+import io.legado.app.utils.putPrefInt
 import io.legado.app.utils.setLayout
+import io.legado.app.utils.showSoftInput
+import io.legado.app.utils.toastOnUi
 import io.legado.app.utils.viewbindingdelegate.viewBinding
+import io.legado.app.utils.visible
 
 class SleepTimerDialog : BaseDialogFragment(R.layout.dialog_sleep_timer) {
 
@@ -25,8 +32,14 @@ class SleepTimerDialog : BaseDialogFragment(R.layout.dialog_sleep_timer) {
         get() = (parentFragment as? CallBack) ?: (activity as? CallBack)
     private var minute = 0
     private var chapter = 0
-    private var chapterMode = false
     private var useEpisodes = false
+    private var customChapterMode = false
+
+    private val timeOptions: List<TextView>
+        get() = binding.run { listOf(tvTimeP1, tvTimeP2, tvTimeP3, tvTimeP4) }
+
+    private val chapterOptions: List<TextView>
+        get() = binding.run { listOf(tvChapterP1, tvChapterP2, tvChapterP3, tvChapterP4) }
 
     override fun onStart() {
         super.onStart()
@@ -37,60 +50,123 @@ class SleepTimerDialog : BaseDialogFragment(R.layout.dialog_sleep_timer) {
         minute = arguments?.getInt(ARG_MINUTE)?.coerceIn(0, MAX_MINUTES) ?: 0
         chapter = arguments?.getInt(ARG_CHAPTER)?.coerceIn(0, MAX_CHAPTER_STOP_COUNT) ?: 0
         useEpisodes = arguments?.getBoolean(ARG_EPISODES) == true
-        chapterMode = chapter > 0
 
         binding.run {
-            rbChapter.setText(
+            tvChapterLabel.setText(
                 if (useEpisodes) R.string.sleep_timer_by_episode
                 else R.string.sleep_timer_by_chapter
             )
-            rbTime.isChecked = !chapterMode
-            rbChapter.isChecked = chapterMode
-            rgMode.setOnCheckedChangeListener { _, checkedId ->
-                bindMode(checkedId == R.id.rb_chapter)
+            timeOptions.forEachIndexed { index, option ->
+                val value = TIME_PRESETS[index]
+                option.text = getString(R.string.sleep_timer_minute_short, value)
+                option.setOnClickListener { applyMinute(value, save = false) }
             }
-            seekValue.setOnSeekBarChangeListener(object : SeekBarChangeListener {
-                override fun onProgressChanged(
-                    seekBar: SeekBar,
-                    progress: Int,
-                    fromUser: Boolean,
-                ) {
-                    if (chapterMode) chapter = progress else minute = progress
-                    upValueText()
-                }
-            })
-            tvCancel.setOnClickListener { dismissAllowingStateLoss() }
-            tvOk.setOnClickListener {
-                if (chapterMode) {
-                    if (chapter > 0) AppConfig.sleepTimerPreferChapter = true
-                    callBack?.onSleepTimerChapter(chapter)
+            chapterOptions.forEachIndexed { index, option ->
+                val value = CHAPTER_PRESETS[index]
+                option.text = getString(
+                    if (useEpisodes) R.string.sleep_timer_episode_short
+                    else R.string.sleep_timer_chapter_short,
+                    value,
+                )
+                option.setOnClickListener { applyChapter(value, save = false) }
+            }
+            tvTimeCustom.setOnClickListener { showCustomInput(chapterMode = false) }
+            tvChapterCustom.setOnClickListener { showCustomInput(chapterMode = true) }
+            tvCustomOk.setOnClickListener { applyCustomInput() }
+            etCustom.setOnEditorActionListener { _, actionId, _ ->
+                if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    applyCustomInput()
+                    true
                 } else {
-                    if (minute > 0) AppConfig.sleepTimerPreferChapter = false
-                    callBack?.onSleepTimerMinute(minute)
+                    false
                 }
-                dismissAllowingStateLoss()
+            }
+            ivOff.setOnClickListener { applyMinute(0, save = false) }
+        }
+        bindCurrentState()
+    }
+
+    private fun bindCurrentState() = binding.run {
+        val selected = when {
+            chapter > 0 -> {
+                tvStatus.text = getString(
+                    if (useEpisodes) R.string.audio_stop_chapters
+                    else R.string.sleep_timer_chapters,
+                    chapter,
+                )
+                chapterOptions.getOrNull(CHAPTER_PRESETS.indexOf(chapter)) ?: tvChapterCustom
+            }
+
+            minute > 0 -> {
+                tvStatus.text = getString(R.string.sleep_timer_status_time, minute)
+                timeOptions.getOrNull(TIME_PRESETS.indexOf(minute)) ?: tvTimeCustom
+            }
+
+            else -> {
+                tvStatus.setText(R.string.sleep_timer_status_none)
+                null
             }
         }
-        bindMode(chapterMode)
+        selectOption(selected)
+        ivOff.isEnabled = selected != null
+        ivOff.alpha = if (selected == null) 0.38f else 1f
     }
 
-    private fun bindMode(useChapter: Boolean) = binding.run {
-        chapterMode = useChapter
-        seekValue.max = if (chapterMode) MAX_CHAPTER_STOP_COUNT else MAX_MINUTES
-        seekValue.progress = if (chapterMode) chapter else minute
-        upValueText()
-    }
-
-    private fun upValueText() {
-        binding.tvValue.text = if (chapterMode) {
-            getString(
-                if (useEpisodes) R.string.audio_stop_chapters
-                else R.string.sleep_timer_chapters,
-                chapter,
-            )
-        } else {
-            getString(R.string.timer_m, minute)
+    private fun showCustomInput(chapterMode: Boolean) = binding.run {
+        if (llCustomInput.isVisible && customChapterMode == chapterMode) {
+            etCustom.showSoftInput()
+            return@run
         }
+        customChapterMode = chapterMode
+        selectOption(if (chapterMode) tvChapterCustom else tvTimeCustom)
+        llCustomInput.visible()
+        etCustom.setHint(
+            when {
+                chapterMode && useEpisodes -> R.string.sleep_timer_episode_hint
+                chapterMode -> R.string.sleep_timer_chapter_hint
+                else -> R.string.sleep_timer_minute_hint
+            }
+        )
+        val prefKey = if (chapterMode) PreferKey.lastSleepChapter else PreferKey.lastSleepTimer
+        val current = if (chapterMode) chapter else minute
+        val value = requireContext().getPrefInt(prefKey, 0).takeIf { it > 0 }
+            ?: current.takeIf { it > 0 }
+        etCustom.setText(value?.toString().orEmpty())
+        etCustom.setSelection(etCustom.text?.length ?: 0)
+        etCustom.showSoftInput()
+    }
+
+    private fun applyCustomInput() {
+        val value = binding.etCustom.text.toString().toIntOrNull()
+        val max = if (customChapterMode) MAX_CHAPTER_STOP_COUNT else MAX_MINUTES
+        if (value == null || value !in 1..max) {
+            requireContext().toastOnUi(getString(R.string.sleep_timer_range_hint, max))
+            return
+        }
+        if (customChapterMode) {
+            applyChapter(value, save = true)
+        } else {
+            applyMinute(value, save = true)
+        }
+    }
+
+    private fun selectOption(selected: TextView?) {
+        (timeOptions + chapterOptions + listOf(binding.tvTimeCustom, binding.tvChapterCustom))
+            .forEach { it.isSelected = it === selected }
+    }
+
+    private fun applyMinute(minute: Int, save: Boolean) {
+        if (minute > 0) AppConfig.sleepTimerPreferChapter = false
+        if (save) requireContext().putPrefInt(PreferKey.lastSleepTimer, minute)
+        callBack?.onSleepTimerMinute(minute)
+        dismissAllowingStateLoss()
+    }
+
+    private fun applyChapter(chapter: Int, save: Boolean) {
+        if (chapter > 0) AppConfig.sleepTimerPreferChapter = true
+        if (save) requireContext().putPrefInt(PreferKey.lastSleepChapter, chapter)
+        callBack?.onSleepTimerChapter(chapter)
+        dismissAllowingStateLoss()
     }
 
     companion object {
@@ -98,6 +174,8 @@ class SleepTimerDialog : BaseDialogFragment(R.layout.dialog_sleep_timer) {
         private const val ARG_CHAPTER = "chapter"
         private const val ARG_EPISODES = "episodes"
         private const val MAX_MINUTES = 180
+        private val TIME_PRESETS = intArrayOf(15, 30, 45, 60)
+        private val CHAPTER_PRESETS = intArrayOf(1, 2, 3, 5)
 
         fun newInstance(
             minute: Int,

--- a/app/src/main/res/drawable/selector_sleep_timer_option.xml
+++ b/app/src/main/res/drawable/selector_sleep_timer_option.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/btn_bg_press" />
+            <stroke
+                android:width="1dp"
+                android:color="@color/accent" />
+        </shape>
+    </item>
+
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/btn_bg_press" />
+        </shape>
+    </item>
+
+    <item android:state_focused="true">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/btn_bg_press" />
+        </shape>
+    </item>
+
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@android:color/transparent" />
+            <stroke
+                android:width="1dp"
+                android:color="@color/secondaryText" />
+        </shape>
+    </item>
+
+</selector>

--- a/app/src/main/res/layout/dialog_sleep_timer.xml
+++ b/app/src/main/res/layout/dialog_sleep_timer.xml
@@ -1,83 +1,173 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="16dp">
-
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="@string/sleep_timer_title"
-        android:textColor="@color/primaryText"
-        android:textSize="18sp" />
-
-    <RadioGroup
-        android:id="@+id/rg_mode"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="12dp"
-        android:gravity="center"
-        android:orientation="horizontal">
-
-        <io.legado.app.lib.theme.view.ThemeRadioButton
-            android:id="@+id/rb_time"
-            android:layout_width="wrap_content"
-            android:layout_height="48dp"
-            android:layout_marginEnd="16dp"
-            android:gravity="center_vertical"
-            android:text="@string/sleep_timer_by_time" />
-
-        <io.legado.app.lib.theme.view.ThemeRadioButton
-            android:id="@+id/rb_chapter"
-            android:layout_width="wrap_content"
-            android:layout_height="48dp"
-            android:gravity="center_vertical"
-            android:text="@string/sleep_timer_by_chapter" />
-
-    </RadioGroup>
-
-    <TextView
-        android:id="@+id/tv_value"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:minHeight="32dp"
-        android:textColor="@color/secondaryText"
-        android:textSize="14sp" />
-
-    <io.legado.app.lib.theme.view.ThemeSeekBar
-        android:id="@+id/seek_value"
-        android:layout_width="match_parent"
-        android:layout_height="48dp" />
+    android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="end"
-        android:orientation="horizontal">
+        android:orientation="vertical"
+        android:padding="16dp">
 
         <TextView
-            android:id="@+id/tv_cancel"
-            android:layout_width="wrap_content"
-            android:layout_height="48dp"
-            android:background="?android:attr/selectableItemBackground"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:gravity="center"
-            android:minWidth="72dp"
-            android:text="@string/cancel"
-            android:textColor="@color/primaryText" />
+            android:text="@string/sleep_timer_title"
+            android:textColor="@color/primaryText"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/shape_fillet_btn_press"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tv_status"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:minHeight="48dp"
+                android:paddingHorizontal="12dp"
+                android:textColor="@color/primaryText"
+                tools:text="30 分钟后停止" />
+
+            <io.legado.app.ui.widget.image.ImageButton
+                android:id="@+id/iv_off"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/sleep_timer_off"
+                android:padding="12dp"
+                android:src="@drawable/ic_baseline_close"
+                app:tint="@color/accent" />
+
+        </LinearLayout>
 
         <TextView
-            android:id="@+id/tv_ok"
             android:layout_width="wrap_content"
-            android:layout_height="48dp"
-            android:background="?android:attr/selectableItemBackground"
-            android:gravity="center"
-            android:minWidth="72dp"
-            android:text="@string/confirm"
-            android:textColor="@color/accent" />
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:paddingVertical="4dp"
+            android:text="@string/sleep_timer_by_time"
+            android:textColor="@color/secondaryText"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tv_time_p1"
+                style="@style/SleepTimerOption" />
+
+            <TextView
+                android:id="@+id/tv_time_p2"
+                style="@style/SleepTimerOption" />
+
+            <TextView
+                android:id="@+id/tv_time_p3"
+                style="@style/SleepTimerOption" />
+
+            <TextView
+                android:id="@+id/tv_time_p4"
+                style="@style/SleepTimerOption" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tv_time_custom"
+            style="@style/SleepTimerOption"
+            android:layout_width="match_parent"
+            android:layout_weight="0"
+            android:layout_marginTop="4dp"
+            android:text="@string/sleep_timer_custom"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/tv_chapter_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:paddingVertical="4dp"
+            android:text="@string/sleep_timer_by_chapter"
+            android:textColor="@color/secondaryText"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tv_chapter_p1"
+                style="@style/SleepTimerOption" />
+
+            <TextView
+                android:id="@+id/tv_chapter_p2"
+                style="@style/SleepTimerOption" />
+
+            <TextView
+                android:id="@+id/tv_chapter_p3"
+                style="@style/SleepTimerOption" />
+
+            <TextView
+                android:id="@+id/tv_chapter_p4"
+                style="@style/SleepTimerOption" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tv_chapter_custom"
+            style="@style/SleepTimerOption"
+            android:layout_width="match_parent"
+            android:layout_weight="0"
+            android:layout_marginTop="4dp"
+            android:text="@string/sleep_timer_custom"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:id="@+id/ll_custom_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <io.legado.app.lib.theme.view.ThemeEditText
+                android:id="@+id/et_custom"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:autofillHints="@null"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:maxLength="3"
+                android:maxLines="1" />
+
+            <TextView
+                android:id="@+id/tv_custom_ok"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:background="?android:attr/selectableItemBackground"
+                android:gravity="center"
+                android:minWidth="72dp"
+                android:text="@string/confirm"
+                android:textColor="@color/accent" />
+
+        </LinearLayout>
 
     </LinearLayout>
 
-</LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -175,6 +175,17 @@
     <string name="sleep_timer_chapters">%d 章</string>
     <string name="audio_stop_chapters">听完 %d 集</string>
     <string name="audio_chapter_progress">第 %1$d 集 · 共 %2$d 集</string>
+    <string name="sleep_timer_minute_short">%d分</string>
+    <string name="sleep_timer_chapter_short">%d章</string>
+    <string name="sleep_timer_episode_short">%d集</string>
+    <string name="sleep_timer_custom">自定义</string>
+    <string name="sleep_timer_minute_hint">自定义分钟</string>
+    <string name="sleep_timer_chapter_hint">自定义章节数</string>
+    <string name="sleep_timer_episode_hint">自定义集数</string>
+    <string name="sleep_timer_status_time">%d 分钟后停止</string>
+    <string name="sleep_timer_status_none">未设置</string>
+    <string name="sleep_timer_off">关闭定时</string>
+    <string name="sleep_timer_range_hint">请输入 1 到 %d</string>
     <string name="ps_hide_navigation_bar">阅读界面隐藏虚拟按键</string>
     <string name="pt_hide_navigation_bar">隐藏导航栏</string>
     <string name="re_navigation_bar_color">导航栏颜色</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,6 +177,17 @@
     <string name="sleep_timer_chapters">%d chapters</string>
     <string name="audio_stop_chapters">Stop after %d chapters</string>
     <string name="audio_chapter_progress">Chapter %1$d / %2$d</string>
+    <string name="sleep_timer_minute_short">%dm</string>
+    <string name="sleep_timer_chapter_short">%d ch</string>
+    <string name="sleep_timer_episode_short">%d ch</string>
+    <string name="sleep_timer_custom">Custom</string>
+    <string name="sleep_timer_minute_hint">Custom minutes</string>
+    <string name="sleep_timer_chapter_hint">Custom chapters</string>
+    <string name="sleep_timer_episode_hint">Custom chapters</string>
+    <string name="sleep_timer_status_time">Stop in %d min</string>
+    <string name="sleep_timer_status_none">Not set</string>
+    <string name="sleep_timer_off">Turn off</string>
+    <string name="sleep_timer_range_hint">Enter a value from 1 to %d</string>
     <string name="ps_hide_navigation_bar">Hide virtual buttons when reading</string>
     <string name="pt_hide_navigation_bar">Hide navigation bar</string>
     <string name="re_navigation_bar_color">Navigation bar color</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -132,4 +132,20 @@
         <item name="android:windowNoTitle">true</item>
     </style>
 
+    <style name="SleepTimerOption" parent="android:Widget.TextView">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:layout_marginHorizontal">2dp</item>
+        <item name="android:background">@drawable/selector_sleep_timer_option</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">true</item>
+        <item name="android:gravity">center</item>
+        <item name="android:maxLines">1</item>
+        <item name="android:minHeight">48dp</item>
+        <item name="android:paddingHorizontal">2dp</item>
+        <item name="android:textColor">@color/primaryText</item>
+        <item name="android:textSize">12sp</item>
+    </style>
+
 </resources>

--- a/app/src/test/java/io/legado/app/ui/widget/dialog/SleepTimerDialogWiringTest.kt
+++ b/app/src/test/java/io/legado/app/ui/widget/dialog/SleepTimerDialogWiringTest.kt
@@ -1,0 +1,141 @@
+package io.legado.app.ui.widget.dialog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class SleepTimerDialogWiringTest {
+
+    @Test
+    fun presetsAndCustomInputKeepMainlineTimerContracts() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/ui/widget/dialog/SleepTimerDialog.kt"
+        ).readText()
+        val preferKey = projectFile(
+            "src/main/java/io/legado/app/constant/PreferKey.kt"
+        ).readText()
+
+        assertTrue(source.contains("TIME_PRESETS = intArrayOf(15, 30, 45, 60)"))
+        assertTrue(source.contains("CHAPTER_PRESETS = intArrayOf(1, 2, 3, 5)"))
+        assertTrue(source.contains("value !in 1..max"))
+        assertTrue(source.contains("MAX_CHAPTER_STOP_COUNT"))
+        assertTrue(source.contains("private const val MAX_MINUTES = 180"))
+        assertTrue(source.contains("if (chapter > 0) AppConfig.sleepTimerPreferChapter = true"))
+        assertTrue(source.contains("if (minute > 0) AppConfig.sleepTimerPreferChapter = false"))
+        assertTrue(source.contains("PreferKey.lastSleepTimer"))
+        assertTrue(source.contains("PreferKey.lastSleepChapter"))
+        assertTrue(source.contains("llCustomInput.isVisible && customChapterMode == chapterMode"))
+        assertTrue(source.contains("arguments?.getInt(ARG_MINUTE)"))
+        assertTrue(source.contains("arguments?.getInt(ARG_CHAPTER)"))
+        assertTrue(source.contains("arguments?.getBoolean(ARG_EPISODES)"))
+        assertFalse(source.contains("AudioPlayService"))
+        assertFalse(source.contains("BaseReadAloudService"))
+        assertTrue(preferKey.contains("const val lastSleepTimer = \"lastSleepTimer\""))
+        assertTrue(preferKey.contains("const val lastSleepChapter = \"lastSleepChapter\""))
+    }
+
+    @Test
+    fun layoutProvidesEqualAccessibleOptionsAndOneCustomInput() {
+        val document = parseProjectXml("src/main/res/layout/dialog_sleep_timer.xml")
+        val presetIds = listOf(
+            "@+id/tv_time_p1",
+            "@+id/tv_time_p2",
+            "@+id/tv_time_p3",
+            "@+id/tv_time_p4",
+            "@+id/tv_chapter_p1",
+            "@+id/tv_chapter_p2",
+            "@+id/tv_chapter_p3",
+            "@+id/tv_chapter_p4",
+        )
+
+        presetIds.forEach { id ->
+            val option = findViewById(document, id)
+            assertEquals(id, "@style/SleepTimerOption", option.getAttribute("style"))
+        }
+
+        listOf("@+id/tv_time_custom", "@+id/tv_chapter_custom").forEach { id ->
+            val option = findViewById(document, id)
+            assertEquals(id, "@style/SleepTimerOption", option.getAttribute("style"))
+            assertEquals(id, "match_parent", option.getAttributeNS(androidNamespace, "layout_width"))
+            assertEquals(id, "0", option.getAttributeNS(androidNamespace, "layout_weight"))
+        }
+
+        val styles = parseProjectXml("src/main/res/values/styles.xml")
+        val optionStyle = findStyle(styles, "SleepTimerOption")
+        assertEquals("0dp", styleItem(optionStyle, "android:layout_width"))
+        assertEquals("1", styleItem(optionStyle, "android:layout_weight"))
+        assertEquals("48dp", styleItem(optionStyle, "android:minHeight"))
+        assertEquals("true", styleItem(optionStyle, "android:clickable"))
+        assertEquals("true", styleItem(optionStyle, "android:focusable"))
+
+        val customRow = findViewById(document, "@+id/ll_custom_input")
+        val customInput = findViewById(document, "@+id/et_custom")
+        val off = findViewById(document, "@+id/iv_off")
+        assertEquals("gone", customRow.getAttributeNS(androidNamespace, "visibility"))
+        assertEquals("number", customInput.getAttributeNS(androidNamespace, "inputType"))
+        assertEquals("3", customInput.getAttributeNS(androidNamespace, "maxLength"))
+        assertEquals(
+            "@string/sleep_timer_off",
+            off.getAttributeNS(androidNamespace, "contentDescription"),
+        )
+    }
+
+    @Test
+    fun chineseResourcesKeepChapterAndEpisodeUnitsSeparate() {
+        assertEquals("%d章", chineseString("sleep_timer_chapter_short"))
+        assertEquals("%d集", chineseString("sleep_timer_episode_short"))
+    }
+
+    private fun chineseString(name: String): String {
+        val document = parseProjectXml("src/main/res/values-zh/strings.xml")
+        return document.getElementsByTagName("string").let { nodes ->
+            (0 until nodes.length)
+                .map { nodes.item(it) as Element }
+                .single { it.getAttribute("name") == name }
+                .textContent
+        }
+    }
+
+    private fun findViewById(document: Document, id: String): Element {
+        val nodes = document.getElementsByTagName("*")
+        return (0 until nodes.length)
+            .map { nodes.item(it) as Element }
+            .single { it.getAttributeNS(androidNamespace, "id") == id }
+    }
+
+    private fun findStyle(document: Document, name: String): Element {
+        val nodes = document.getElementsByTagName("style")
+        return (0 until nodes.length)
+            .map { nodes.item(it) as Element }
+            .single { it.getAttribute("name") == name }
+    }
+
+    private fun styleItem(style: Element, name: String): String {
+        val nodes = style.getElementsByTagName("item")
+        return (0 until nodes.length)
+            .map { nodes.item(it) as Element }
+            .single { it.getAttribute("name") == name }
+            .textContent
+    }
+
+    private fun parseProjectXml(pathInApp: String): Document {
+        return DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = true
+        }.newDocumentBuilder().parse(projectFile(pathInApp))
+    }
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+    }
+
+    private companion object {
+        const val androidNamespace = "http://schemas.android.com/apk/res/android"
+    }
+}


### PR DESCRIPTION
## 变更

- 参考 https://github.com/skybbk1001/legadoT/commit/787b32656b92f4b8f46df6e64942ebdf379a2752
- 停止设置增加 15/30/45/60 分钟和 1/2/3/5 章或集快捷项，点击后立即生效
- 使用共享自定义输入，分别记忆上次分钟与章节值，并保留 180 分钟、99 章的上限校验
- 显示当前设置、选中状态和关闭入口，窄屏下将自定义按钮独立为全宽操作
- 保留听书“集”与朗读“章”的文案分流、现有回调参数和通知栏停止模式偏好
- 增加预设、布局、记忆键、范围和单位回归测试

## 验证

- `./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.ui.widget.dialog.SleepTimerDialogWiringTest --tests io.legado.app.service.ChapterStopTimerTest --tests io.legado.app.ui.book.audio.AudioEpisodeUnitTest --no-daemon`
- `./gradlew.bat :app:testAppReleaseUnitTest --no-daemon`（651 项，0 失败，0 错误，2 跳过）