### PR TITLE
重构阅读边距设置面板

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/config/PaddingConfigDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/PaddingConfigDialog.kt
@@ -1,124 +1,403 @@
 package io.legado.app.ui.book.read.config
 
+import android.animation.ValueAnimator
 import android.content.DialogInterface
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
+import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import android.widget.TextView
+import androidx.appcompat.widget.TooltipCompat
 import io.legado.app.R
 import io.legado.app.base.BaseDialogFragment
 import io.legado.app.constant.EventBus
 import io.legado.app.databinding.DialogReadPaddingBinding
 import io.legado.app.help.config.ReadBookConfig
+import io.legado.app.lib.dialogs.alert
+import io.legado.app.lib.theme.bottomBackground
+import io.legado.app.lib.theme.getPrimaryTextColor
+import io.legado.app.ui.book.read.ReadBookActivity
+import io.legado.app.utils.ColorUtils
+import io.legado.app.utils.dpToPx
 import io.legado.app.utils.postEvent
-import io.legado.app.utils.setLayout
+import io.legado.app.utils.throttle
 import io.legado.app.utils.viewbindingdelegate.viewBinding
 
 class PaddingConfigDialog : BaseDialogFragment(R.layout.dialog_read_padding) {
 
     private val binding by viewBinding(DialogReadPaddingBinding::bind)
+    private val defaultConfig = ReadBookConfig.Config()
+    private var curRegion = Region.BODY
+    private var trackingRegion: Region? = null
+    private var activeTrackingCount = 0
+    private var lockLR = false
+    private var textColor = 0
+    private var bgColor = 0
+    private var pendingBodyEdit: PaddingEdit? = null
+    private var alphaAnimator: ValueAnimator? = null
+    private val bodyThrottle = throttle<Unit>(150, leading = false) {
+        val edit = pendingBodyEdit
+        pendingBodyEdit = null
+        if (edit != null) applyEdit(edit)
+    }
+
+    private enum class Region(val titleRes: Int) {
+        HEADER(R.string.header),
+        BODY(R.string.main_body),
+        FOOTER(R.string.footer),
+    }
+
+    private enum class Side { TOP, BOTTOM, LEFT, RIGHT }
+
+    private data class PaddingEdit(
+        val region: Region,
+        val side: Side,
+        val value: Int,
+        val linkSides: Boolean,
+    )
 
     override fun onStart() {
         super.onStart()
-        dialog?.window?.let {
-            it.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
-            val attr = it.attributes
-            attr.dimAmount = 0.0f
-            it.attributes = attr
+        dialog?.window?.run {
+            clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+            setBackgroundDrawableResource(android.R.color.transparent)
+            decorView.setPadding(0, 0, 0, 0)
+            attributes = attributes.apply {
+                dimAmount = 0.0f
+                gravity = Gravity.BOTTOM
+            }
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         }
-        setLayout(0.9f, ViewGroup.LayoutParams.WRAP_CONTENT)
     }
 
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
-        initData()
+        (activity as ReadBookActivity).bottomDialog++
         initView()
+        bindRegion(Region.BODY)
+    }
+
+    override fun onDestroyView() {
+        finishPendingBodyEdit()
+        activeTrackingCount = 0
+        trackingRegion = null
+        alphaAnimator?.cancel()
+        restoreWindowAlpha()
+        super.onDestroyView()
     }
 
     override fun onDismiss(dialog: DialogInterface) {
-        super.onDismiss(dialog)
+        finishPendingBodyEdit()
         ReadBookConfig.save()
-    }
-
-    private fun initData() = binding.run {
-        //正文
-        dsbPaddingTop.progress = ReadBookConfig.paddingTop
-        dsbPaddingBottom.progress = ReadBookConfig.paddingBottom
-        dsbPaddingLeft.progress = ReadBookConfig.paddingLeft
-        dsbPaddingRight.progress = ReadBookConfig.paddingRight
-        //页眉
-        dsbHeaderPaddingTop.progress = ReadBookConfig.headerPaddingTop
-        dsbHeaderPaddingBottom.progress = ReadBookConfig.headerPaddingBottom
-        dsbHeaderPaddingLeft.progress = ReadBookConfig.headerPaddingLeft
-        dsbHeaderPaddingRight.progress = ReadBookConfig.headerPaddingRight
-        //页脚
-        dsbFooterPaddingTop.progress = ReadBookConfig.footerPaddingTop
-        dsbFooterPaddingBottom.progress = ReadBookConfig.footerPaddingBottom
-        dsbFooterPaddingLeft.progress = ReadBookConfig.footerPaddingLeft
-        dsbFooterPaddingRight.progress = ReadBookConfig.footerPaddingRight
-        cbShowTopLine.isChecked = ReadBookConfig.showHeaderLine
-        cbShowBottomLine.isChecked = ReadBookConfig.showFooterLine
+        (activity as ReadBookActivity).bottomDialog--
+        super.onDismiss(dialog)
     }
 
     private fun initView() = binding.run {
-        //正文
-        dsbPaddingTop.onChanged = {
-            ReadBookConfig.paddingTop = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(10, 5))
+        bgColor = requireContext().bottomBackground
+        textColor = requireContext().getPrimaryTextColor(ColorUtils.isColorLight(bgColor))
+        val radius = 8.dpToPx().toFloat()
+        rootView.background = GradientDrawable().apply {
+            cornerRadii = floatArrayOf(radius, radius, radius, radius, 0f, 0f, 0f, 0f)
+            setColor(bgColor)
         }
-        dsbPaddingBottom.onChanged = {
-            ReadBookConfig.paddingBottom = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(10, 5))
+        swLockLr.setTextColor(textColor)
+        swShowLine.setTextColor(textColor)
+        ivReset.setColorFilter(textColor)
+        TooltipCompat.setTooltipText(ivReset, getString(R.string.restore_default))
+
+        arrayOf(dsbTop, dsbBottom, dsbLeft, dsbRight).forEach { seekBar ->
+            seekBar.onTrackingStart = { startTracking() }
+            seekBar.onTrackingStop = { stopTracking() }
         }
-        dsbPaddingLeft.onChanged = {
-            ReadBookConfig.paddingLeft = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(10, 5))
+        dsbTop.onDragging = { liveApply(Side.TOP, it) }
+        dsbBottom.onDragging = { liveApply(Side.BOTTOM, it) }
+        dsbLeft.onDragging = { liveApply(Side.LEFT, it) }
+        dsbRight.onDragging = { liveApply(Side.RIGHT, it) }
+        dsbTop.onChanged = { finalApply(Side.TOP, it) }
+        dsbBottom.onChanged = { finalApply(Side.BOTTOM, it) }
+        dsbLeft.onChanged = { finalApply(Side.LEFT, it) }
+        dsbRight.onChanged = { finalApply(Side.RIGHT, it) }
+
+        btnRegionHeader.setOnClickListener { bindRegion(Region.HEADER) }
+        btnRegionBody.setOnClickListener { bindRegion(Region.BODY) }
+        btnRegionFooter.setOnClickListener { bindRegion(Region.FOOTER) }
+        ivReset.setOnClickListener { askResetRegion() }
+        swLockLr.setOnUserCheckedChangeListener { isChecked ->
+            finishPendingBodyEdit()
+            lockLR = isChecked
         }
-        dsbPaddingRight.onChanged = {
-            ReadBookConfig.paddingRight = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(10, 5))
-        }
-        //页眉
-        dsbHeaderPaddingTop.onChanged = {
-            ReadBookConfig.headerPaddingTop = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
-        }
-        dsbHeaderPaddingBottom.onChanged = {
-            ReadBookConfig.headerPaddingBottom = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
-        }
-        dsbHeaderPaddingLeft.onChanged = {
-            ReadBookConfig.headerPaddingLeft = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
-        }
-        dsbHeaderPaddingRight.onChanged = {
-            ReadBookConfig.headerPaddingRight = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
-        }
-        //页脚
-        dsbFooterPaddingTop.onChanged = {
-            ReadBookConfig.footerPaddingTop = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
-        }
-        dsbFooterPaddingBottom.onChanged = {
-            ReadBookConfig.footerPaddingBottom = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
-        }
-        dsbFooterPaddingLeft.onChanged = {
-            ReadBookConfig.footerPaddingLeft = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
-        }
-        dsbFooterPaddingRight.onChanged = {
-            ReadBookConfig.footerPaddingRight = it
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
-        }
-        cbShowTopLine.onCheckedChangeListener = { _, isChecked ->
-            ReadBookConfig.showHeaderLine = isChecked
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
-        }
-        cbShowBottomLine.onCheckedChangeListener = { _, isChecked ->
-            ReadBookConfig.showFooterLine = isChecked
-            postEvent(EventBus.UP_CONFIG, arrayListOf(2))
+        swShowLine.setOnUserCheckedChangeListener { isChecked ->
+            when (curRegion) {
+                Region.HEADER -> ReadBookConfig.showHeaderLine = isChecked
+                Region.FOOTER -> ReadBookConfig.showFooterLine = isChecked
+                Region.BODY -> return@setOnUserCheckedChangeListener
+            }
+            postRegionEvent(curRegion)
         }
     }
 
+    private fun bindRegion(region: Region) = binding.run {
+        finishPendingBodyEdit()
+        curRegion = region
+        dsbTop.progress = getPadding(region, Side.TOP)
+        dsbBottom.progress = getPadding(region, Side.BOTTOM)
+        dsbLeft.progress = getPadding(region, Side.LEFT)
+        dsbRight.progress = getPadding(region, Side.RIGHT)
+        when (region) {
+            Region.BODY -> swShowLine.visibility = View.INVISIBLE
+            Region.HEADER -> {
+                swShowLine.visibility = View.VISIBLE
+                swShowLine.isChecked = ReadBookConfig.showHeaderLine
+            }
+
+            Region.FOOTER -> {
+                swShowLine.visibility = View.VISIBLE
+                swShowLine.isChecked = ReadBookConfig.showFooterLine
+            }
+        }
+        lockLR = getPadding(region, Side.LEFT) == getPadding(region, Side.RIGHT)
+        swLockLr.isChecked = lockLR
+        upRegionStyles()
+    }
+
+    private fun upRegionStyles() = binding.run {
+        mapOf(
+            Region.HEADER to btnRegionHeader,
+            Region.BODY to btnRegionBody,
+            Region.FOOTER to btnRegionFooter,
+        ).forEach { (region, button) ->
+            val selected = region == curRegion
+            button.isSelected = selected
+            button.setTextColor(if (selected) bgColor else textColor)
+            button.backgroundTintList = null
+            button.background = regionBackground(selected)
+        }
+    }
+
+    private fun regionBackground(selected: Boolean) = GradientDrawable().apply {
+        cornerRadius = 8.dpToPx().toFloat()
+        setColor(if (selected) textColor else Color.TRANSPARENT)
+        setStroke(1.dpToPx(), textColor)
+    }
+
+    private fun startTracking() {
+        if (activeTrackingCount++ == 0) {
+            trackingRegion = curRegion
+            setPanelActionsEnabled(false)
+            ghostWindow(true)
+        }
+    }
+
+    private fun stopTracking() {
+        activeTrackingCount = (activeTrackingCount - 1).coerceAtLeast(0)
+        if (activeTrackingCount == 0) {
+            ghostWindow(false)
+            trackingRegion = null
+            setPanelActionsEnabled(true)
+        }
+    }
+
+    private fun setPanelActionsEnabled(enabled: Boolean) = binding.run {
+        val alpha = if (enabled) 1f else 0.38f
+        regionButtons().forEach {
+            it.isEnabled = enabled
+            it.alpha = alpha
+        }
+        ivReset.isEnabled = enabled
+        ivReset.alpha = alpha
+        swLockLr.isEnabled = enabled
+        swLockLr.alpha = alpha
+    }
+
+    private fun regionButtons(): List<TextView> = binding.run {
+        listOf(btnRegionHeader, btnRegionBody, btnRegionFooter)
+    }
+
+    private fun liveApply(side: Side, value: Int) {
+        val edit = paddingEdit(side, value)
+        if (edit.region == Region.BODY) {
+            finishPendingBodyEditIfDifferent(edit)
+            upCurrentSeekBar(edit)
+            pendingBodyEdit = edit
+            bodyThrottle()
+        } else {
+            applyEdit(edit)
+        }
+    }
+
+    private fun finalApply(side: Side, value: Int) {
+        val edit = paddingEdit(side, value)
+        finishPendingBodyEditIfDifferent(edit)
+        cancelPendingBodyEdit()
+        applyEdit(edit)
+    }
+
+    private fun paddingEdit(side: Side, value: Int): PaddingEdit {
+        val region = trackingRegion ?: curRegion
+        return PaddingEdit(region, side, value, lockLR && region == curRegion)
+    }
+
+    private fun applyEdit(edit: PaddingEdit) {
+        upCurrentSeekBar(edit)
+        setPadding(edit.region, edit.side, edit.value)
+        if (edit.linkSides && (edit.side == Side.LEFT || edit.side == Side.RIGHT)) {
+            val other = if (edit.side == Side.LEFT) Side.RIGHT else Side.LEFT
+            setPadding(edit.region, other, edit.value)
+            if (edit.region == curRegion) {
+                val otherBar = if (other == Side.LEFT) binding.dsbLeft else binding.dsbRight
+                if (otherBar.progress != edit.value) otherBar.progress = edit.value
+            }
+        }
+        postRegionEvent(edit.region)
+    }
+
+    private fun upCurrentSeekBar(edit: PaddingEdit) {
+        if (edit.region != curRegion) return
+        val seekBar = binding.run {
+            when (edit.side) {
+                Side.TOP -> dsbTop
+                Side.BOTTOM -> dsbBottom
+                Side.LEFT -> dsbLeft
+                Side.RIGHT -> dsbRight
+            }
+        }
+        if (seekBar.progress != edit.value) seekBar.progress = edit.value
+    }
+
+    private fun cancelPendingBodyEdit() {
+        bodyThrottle.cancel()
+        pendingBodyEdit = null
+    }
+
+    private fun finishPendingBodyEdit() {
+        val edit = pendingBodyEdit
+        cancelPendingBodyEdit()
+        if (edit != null) applyEdit(edit)
+    }
+
+    private fun finishPendingBodyEditIfDifferent(edit: PaddingEdit) {
+        pendingBodyEdit?.let { pending ->
+            if (pending.region != edit.region || pending.side != edit.side) {
+                finishPendingBodyEdit()
+            }
+        }
+    }
+
+    private fun postRegionEvent(region: Region) {
+        postEvent(
+            EventBus.UP_CONFIG,
+            if (region == Region.BODY) arrayListOf(10, 5) else arrayListOf(2),
+        )
+    }
+
+    private fun ghostWindow(ghost: Boolean) {
+        val window = dialog?.window ?: return
+        alphaAnimator?.cancel()
+        alphaAnimator = ValueAnimator.ofFloat(window.attributes.alpha, if (ghost) 0.25f else 1f)
+            .apply {
+                duration = 120
+                addUpdateListener { animation ->
+                    window.attributes = window.attributes.apply {
+                        alpha = animation.animatedValue as Float
+                    }
+                }
+                start()
+            }
+    }
+
+    private fun restoreWindowAlpha() {
+        dialog?.window?.let { window ->
+            window.attributes = window.attributes.apply { alpha = 1f }
+        }
+    }
+
+    private fun askResetRegion() {
+        val region = curRegion
+        alert(R.string.restore_default) {
+            setMessage(getString(R.string.reset_region_padding_confirm, getString(region.titleRes)))
+            yesButton {
+                cancelPendingBodyEdit()
+                Side.entries.forEach { side ->
+                    setPadding(region, side, defaultPadding(region, side))
+                }
+                bindRegion(region)
+                postRegionEvent(region)
+            }
+            noButton()
+        }
+    }
+
+    private fun getPadding(region: Region, side: Side): Int = when (region) {
+        Region.HEADER -> when (side) {
+            Side.TOP -> ReadBookConfig.headerPaddingTop
+            Side.BOTTOM -> ReadBookConfig.headerPaddingBottom
+            Side.LEFT -> ReadBookConfig.headerPaddingLeft
+            Side.RIGHT -> ReadBookConfig.headerPaddingRight
+        }
+
+        Region.BODY -> when (side) {
+            Side.TOP -> ReadBookConfig.paddingTop
+            Side.BOTTOM -> ReadBookConfig.paddingBottom
+            Side.LEFT -> ReadBookConfig.paddingLeft
+            Side.RIGHT -> ReadBookConfig.paddingRight
+        }
+
+        Region.FOOTER -> when (side) {
+            Side.TOP -> ReadBookConfig.footerPaddingTop
+            Side.BOTTOM -> ReadBookConfig.footerPaddingBottom
+            Side.LEFT -> ReadBookConfig.footerPaddingLeft
+            Side.RIGHT -> ReadBookConfig.footerPaddingRight
+        }
+    }
+
+    private fun setPadding(region: Region, side: Side, value: Int) {
+        when (region) {
+            Region.HEADER -> when (side) {
+                Side.TOP -> ReadBookConfig.headerPaddingTop = value
+                Side.BOTTOM -> ReadBookConfig.headerPaddingBottom = value
+                Side.LEFT -> ReadBookConfig.headerPaddingLeft = value
+                Side.RIGHT -> ReadBookConfig.headerPaddingRight = value
+            }
+
+            Region.BODY -> when (side) {
+                Side.TOP -> ReadBookConfig.paddingTop = value
+                Side.BOTTOM -> ReadBookConfig.paddingBottom = value
+                Side.LEFT -> ReadBookConfig.paddingLeft = value
+                Side.RIGHT -> ReadBookConfig.paddingRight = value
+            }
+
+            Region.FOOTER -> when (side) {
+                Side.TOP -> ReadBookConfig.footerPaddingTop = value
+                Side.BOTTOM -> ReadBookConfig.footerPaddingBottom = value
+                Side.LEFT -> ReadBookConfig.footerPaddingLeft = value
+                Side.RIGHT -> ReadBookConfig.footerPaddingRight = value
+            }
+        }
+    }
+
+    private fun defaultPadding(region: Region, side: Side): Int = when (region) {
+        Region.HEADER -> when (side) {
+            Side.TOP -> defaultConfig.headerPaddingTop
+            Side.BOTTOM -> defaultConfig.headerPaddingBottom
+            Side.LEFT -> defaultConfig.headerPaddingLeft
+            Side.RIGHT -> defaultConfig.headerPaddingRight
+        }
+
+        Region.BODY -> when (side) {
+            Side.TOP -> defaultConfig.paddingTop
+            Side.BOTTOM -> defaultConfig.paddingBottom
+            Side.LEFT -> defaultConfig.paddingLeft
+            Side.RIGHT -> defaultConfig.paddingRight
+        }
+
+        Region.FOOTER -> when (side) {
+            Side.TOP -> defaultConfig.footerPaddingTop
+            Side.BOTTOM -> defaultConfig.footerPaddingBottom
+            Side.LEFT -> defaultConfig.footerPaddingLeft
+            Side.RIGHT -> defaultConfig.footerPaddingRight
+        }
+    }
 }

--- a/app/src/main/java/io/legado/app/ui/widget/DetailSeekBar.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/DetailSeekBar.kt
@@ -27,6 +27,9 @@ class DetailSeekBar @JvmOverloads constructor(
 
     var valueFormat: ((progress: Int) -> String)? = null
     var onChanged: ((progress: Int) -> Unit)? = null
+    var onTrackingStart: (() -> Unit)? = null
+    var onTrackingStop: (() -> Unit)? = null
+    var onDragging: ((progress: Int) -> Unit)? = null
     var progress: Int
         get() = binding.seekBar.progress
         set(value) {
@@ -79,14 +82,16 @@ class DetailSeekBar @JvmOverloads constructor(
 
     override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
         upValue(progress)
+        if (fromUser) onDragging?.invoke(progress)
     }
 
     override fun onStartTrackingTouch(seekBar: SeekBar) {
-
+        onTrackingStart?.invoke()
     }
 
     override fun onStopTrackingTouch(seekBar: SeekBar) {
         onChanged?.invoke(binding.seekBar.progress)
+        onTrackingStop?.invoke()
     }
 
 }

--- a/app/src/main/res/layout/dialog_read_padding.xml
+++ b/app/src/main/res/layout/dialog_read_padding.xml
@@ -1,115 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_view"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:fillViewport="true"
+    android:overScrollMode="never">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="10dp">
-
-        <LinearLayout
-            android:id="@+id/ll_header_padding"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:paddingBottom="10dp">
-
-                <io.legado.app.ui.widget.text.AccentTextView
-                    android:id="@+id/tv_header_padding"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/header"
-                    android:textSize="18sp" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/showLine" />
-
-                <io.legado.app.ui.widget.checkbox.SmoothCheckBox
-                    android:id="@+id/cb_show_top_line"
-                    android:layout_width="20dp"
-                    android:layout_height="20dp"
-                    android:layout_margin="6dp" />
-
-            </LinearLayout>
-
-            <io.legado.app.ui.widget.DetailSeekBar
-                android:id="@+id/dsb_header_padding_top"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:max="400"
-                app:title="@string/padding_top" />
-
-            <io.legado.app.ui.widget.DetailSeekBar
-                android:id="@+id/dsb_header_padding_bottom"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:max="400"
-                app:title="@string/padding_bottom" />
-
-            <io.legado.app.ui.widget.DetailSeekBar
-                android:id="@+id/dsb_header_padding_left"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:max="100"
-                app:title="@string/padding_left" />
-
-            <io.legado.app.ui.widget.DetailSeekBar
-                android:id="@+id/dsb_header_padding_right"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:max="100"
-                app:title="@string/padding_right" />
-
-        </LinearLayout>
-
-        <io.legado.app.ui.widget.text.AccentTextView
-            android:id="@+id/tv_body_padding"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="10dp"
-            android:paddingBottom="10dp"
-            android:text="@string/main_body"
-            android:textSize="18sp" />
-
-        <io.legado.app.ui.widget.DetailSeekBar
-            android:id="@+id/dsb_padding_top"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:max="400"
-            app:title="@string/padding_top" />
-
-        <io.legado.app.ui.widget.DetailSeekBar
-            android:id="@+id/dsb_padding_bottom"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:max="400"
-            app:title="@string/padding_bottom" />
-
-        <io.legado.app.ui.widget.DetailSeekBar
-            android:id="@+id/dsb_padding_left"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:max="100"
-            app:title="@string/padding_left" />
-
-        <io.legado.app.ui.widget.DetailSeekBar
-            android:id="@+id/dsb_padding_right"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:max="100"
-            app:title="@string/padding_right" />
+        android:paddingStart="16dp"
+        android:paddingTop="8dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="8dp">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -117,55 +23,128 @@
             android:gravity="center_vertical"
             android:orientation="horizontal">
 
-            <io.legado.app.ui.widget.text.AccentTextView
+            <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:paddingTop="10dp"
-                android:paddingBottom="10dp"
-                android:text="@string/footer"
-                android:textSize="18sp" />
+                android:orientation="horizontal">
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/showLine" />
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_region_header"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_marginHorizontal="2dp"
+                    android:layout_weight="1"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?android:attr/selectableItemBackground"
+                    android:gravity="center"
+                    android:ellipsize="end"
+                    android:maxLines="2"
+                    android:minWidth="0dp"
+                    android:paddingHorizontal="4dp"
+                    android:text="@string/header"
+                    android:textAllCaps="false"
+                    android:textColor="@color/primaryText"
+                    android:textSize="14sp" />
 
-            <io.legado.app.ui.widget.checkbox.SmoothCheckBox
-                android:id="@+id/cb_show_bottom_line"
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:layout_margin="6dp" />
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_region_body"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_marginHorizontal="2dp"
+                    android:layout_weight="1"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?android:attr/selectableItemBackground"
+                    android:gravity="center"
+                    android:ellipsize="end"
+                    android:maxLines="2"
+                    android:minWidth="0dp"
+                    android:paddingHorizontal="4dp"
+                    android:text="@string/main_body"
+                    android:textAllCaps="false"
+                    android:textColor="@color/primaryText"
+                    android:textSize="14sp"
+                    tools:selected="true" />
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_region_footer"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_marginHorizontal="2dp"
+                    android:layout_weight="1"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?android:attr/selectableItemBackground"
+                    android:gravity="center"
+                    android:ellipsize="end"
+                    android:maxLines="2"
+                    android:minWidth="0dp"
+                    android:paddingHorizontal="4dp"
+                    android:text="@string/footer"
+                    android:textAllCaps="false"
+                    android:textColor="@color/primaryText"
+                    android:textSize="14sp" />
+
+            </LinearLayout>
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/iv_reset"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/restore_default"
+                android:padding="12dp"
+                android:src="@drawable/ic_restore" />
 
         </LinearLayout>
 
         <io.legado.app.ui.widget.DetailSeekBar
-            android:id="@+id/dsb_footer_padding_top"
+            android:id="@+id/dsb_top"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:isBottomBackground="true"
             app:max="400"
             app:title="@string/padding_top" />
 
         <io.legado.app.ui.widget.DetailSeekBar
-            android:id="@+id/dsb_footer_padding_bottom"
+            android:id="@+id/dsb_bottom"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:isBottomBackground="true"
             app:max="400"
             app:title="@string/padding_bottom" />
 
         <io.legado.app.ui.widget.DetailSeekBar
-            android:id="@+id/dsb_footer_padding_left"
+            android:id="@+id/dsb_left"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:isBottomBackground="true"
             app:max="100"
             app:title="@string/padding_left" />
 
         <io.legado.app.ui.widget.DetailSeekBar
-            android:id="@+id/dsb_footer_padding_right"
+            android:id="@+id/dsb_right"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:isBottomBackground="true"
             app:max="100"
             app:title="@string/padding_right" />
+
+        <io.legado.app.lib.theme.view.ThemeSwitch
+            android:id="@+id/sw_lock_lr"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="@string/lock_left_right_padding" />
+
+        <io.legado.app.lib.theme.view.ThemeSwitch
+            android:id="@+id/sw_show_line"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="@string/showLine" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -530,6 +530,8 @@
     <string name="select_file">選擇文件</string>
     <string name="no_find">沒有發現，可以在書源裏添加。</string>
     <string name="restore_default">恢復默認</string>
+    <string name="reset_region_padding_confirm">確定恢復%s的預設邊距嗎？</string>
+    <string name="lock_left_right_padding">左右邊距聯動</string>
     <string name="set_download_per">自定義緩存路徑需要存儲權限</string>
     <string name="black">黑色</string>
     <string name="content_empty">文章內容為空</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -538,6 +538,8 @@
     <string name="select_file">選擇文件</string>
     <string name="no_find">沒有發現，可以在書源裡新增。</string>
     <string name="restore_default">復原預設</string>
+    <string name="reset_region_padding_confirm">確定恢復%s的預設邊距嗎？</string>
+    <string name="lock_left_right_padding">左右邊距聯動</string>
     <string name="set_download_per">自訂快取路徑需要儲存權限</string>
     <string name="black">黑色</string>
     <string name="content_empty">文章內容為空</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -570,6 +570,8 @@
     <string name="select_file">选择文件</string>
     <string name="no_find">没有发现，可以在书源里添加。</string>
     <string name="restore_default">恢复默认</string>
+    <string name="reset_region_padding_confirm">确定恢复%s的默认边距吗？</string>
+    <string name="lock_left_right_padding">左右边距联动</string>
     <string name="set_download_per">自定义缓存路径需要存储权限</string>
     <string name="black">黑色</string>
     <string name="content_empty">文章内容为空</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,6 +572,8 @@
     <string name="select_file">Select a file</string>
     <string name="no_find">No Discovery, you can add it in BookSource</string>
     <string name="restore_default">Restore default</string>
+    <string name="reset_region_padding_confirm">Restore default paddings of %s?</string>
+    <string name="lock_left_right_padding">Sync left and right padding</string>
     <string name="set_download_per">Custom cache path requires Storage permission</string>
     <string name="black">Black</string>
     <string name="content_empty">No content</string>

--- a/app/src/test/java/io/legado/app/ui/book/read/ReadPaddingBehaviorSourceTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/ReadPaddingBehaviorSourceTest.kt
@@ -1,0 +1,60 @@
+package io.legado.app.ui.book.read
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ReadPaddingBehaviorSourceTest {
+
+    @Test
+    fun `detail seek bar preserves final callback order`() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/ui/widget/DetailSeekBar.kt"
+        ).readText().normalizeLines()
+
+        assertTrue(source.contains("if (fromUser) onDragging?.invoke(progress)"))
+        assertTrue(source.contains("onTrackingStart?.invoke()"))
+        val stopBlock = source.substringAfter("override fun onStopTrackingTouch")
+            .substringBefore("\n    }")
+        assertTrue(stopBlock.indexOf("onChanged?.invoke") < stopBlock.indexOf("onTrackingStop?.invoke"))
+    }
+
+    @Test
+    fun `pending body edits stay scoped and are not discarded`() {
+        val source = paddingDialogSource()
+
+        assertTrue(source.contains("val region: Region"))
+        assertTrue(source.contains("private var pendingBodyEdit: PaddingEdit?"))
+        assertTrue(source.contains("private val bodyThrottle = throttle<Unit>(150, leading = false)"))
+        assertTrue(source.contains("finishPendingBodyEditIfDifferent(edit)"))
+        assertTrue(source.contains("finishPendingBodyEdit()\n        curRegion = region"))
+        assertTrue(source.contains("override fun onDestroyView() {\n        finishPendingBodyEdit()"))
+        assertTrue(source.contains("override fun onDismiss(dialog: DialogInterface) {\n        finishPendingBodyEdit()"))
+    }
+
+    @Test
+    fun `tracking blocks region actions and reset uses config defaults`() {
+        val source = paddingDialogSource()
+
+        assertTrue(source.contains("setPanelActionsEnabled(false)"))
+        assertTrue(source.contains("setPanelActionsEnabled(true)"))
+        assertTrue(source.contains("private var activeTrackingCount = 0"))
+        assertTrue(source.contains("private val defaultConfig = ReadBookConfig.Config()"))
+        assertTrue(source.contains("lockLR && region == curRegion"))
+        assertTrue(source.contains("ReadBookConfig.save()"))
+        assertTrue(source.contains("bottomDialog++"))
+        assertTrue(source.contains("bottomDialog--"))
+    }
+
+    private fun paddingDialogSource(): String = projectFile(
+        "src/main/java/io/legado/app/ui/book/read/config/PaddingConfigDialog.kt"
+    ).readText().normalizeLines()
+
+    private fun String.normalizeLines(): String = replace("\r\n", "\n")
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+    }
+}

--- a/app/src/test/java/io/legado/app/ui/book/read/ReadPaddingLayoutTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/ReadPaddingLayoutTest.kt
@@ -10,6 +10,21 @@ import javax.xml.parsers.DocumentBuilderFactory
 class ReadPaddingLayoutTest {
 
     @Test
+    fun `padding panel uses four shared controls`() {
+        val document = readPaddingLayout()
+
+        assertEquals(
+            "androidx.core.widget.NestedScrollView",
+            document.documentElement.tagName,
+        )
+        assertEquals("true", document.documentElement.androidAttribute("fillViewport"))
+        assertEquals(
+            4,
+            document.getElementsByTagName("io.legado.app.ui.widget.DetailSeekBar").length,
+        )
+    }
+
+    @Test
     fun `vertical padding supports the extended range`() {
         val document = readPaddingLayout()
         verticalPaddingIds.forEach { id ->
@@ -23,6 +38,35 @@ class ReadPaddingLayoutTest {
         horizontalPaddingIds.forEach { id ->
             assertEquals("100", document.findElementById(id).appAttribute("max"))
         }
+    }
+
+    @Test
+    fun `region controls are equal and touch sized`() {
+        val document = readPaddingLayout()
+        regionButtonIds.forEach { id ->
+            val button = document.findElementById(id)
+            assertEquals("0dp", button.androidAttribute("layout_width"))
+            assertEquals("1", button.androidAttribute("layout_weight"))
+            assertEquals("48dp", button.androidAttribute("layout_height"))
+            assertEquals("true", button.androidAttribute("clickable"))
+            assertEquals("true", button.androidAttribute("focusable"))
+        }
+
+        val reset = document.findElementById("@+id/iv_reset")
+        assertEquals("48dp", reset.androidAttribute("layout_width"))
+        assertEquals("48dp", reset.androidAttribute("layout_height"))
+        assertEquals("@string/restore_default", reset.androidAttribute("contentDescription"))
+    }
+
+    @Test
+    fun `binary options use accessible switches`() {
+        val document = readPaddingLayout()
+        val lock = document.findElementById("@+id/sw_lock_lr")
+        assertEquals("@string/lock_left_right_padding", lock.androidAttribute("text"))
+        assertEquals("48dp", lock.androidAttribute("minHeight"))
+        val showLine = document.findElementById("@+id/sw_show_line")
+        assertEquals("@string/showLine", showLine.androidAttribute("text"))
+        assertEquals("48dp", showLine.androidAttribute("minHeight"))
     }
 
     private fun readPaddingLayout(): Document {
@@ -54,21 +98,19 @@ class ReadPaddingLayoutTest {
         const val appNamespace = "http://schemas.android.com/apk/res-auto"
 
         val verticalPaddingIds = listOf(
-            "@+id/dsb_header_padding_top",
-            "@+id/dsb_header_padding_bottom",
-            "@+id/dsb_padding_top",
-            "@+id/dsb_padding_bottom",
-            "@+id/dsb_footer_padding_top",
-            "@+id/dsb_footer_padding_bottom",
+            "@+id/dsb_top",
+            "@+id/dsb_bottom",
         )
 
         val horizontalPaddingIds = listOf(
-            "@+id/dsb_header_padding_left",
-            "@+id/dsb_header_padding_right",
-            "@+id/dsb_padding_left",
-            "@+id/dsb_padding_right",
-            "@+id/dsb_footer_padding_left",
-            "@+id/dsb_footer_padding_right",
+            "@+id/dsb_left",
+            "@+id/dsb_right",
+        )
+
+        val regionButtonIds = listOf(
+            "@+id/btn_region_header",
+            "@+id/btn_region_body",
+            "@+id/btn_region_footer",
         )
     }
 }


### PR DESCRIPTION
## 说明

- 将页眉、正文、页脚边距改为分段面板，共用四个滑杆
- 增加左右边距联动、分区恢复默认值和分隔线开关
- 正文拖动使用 150ms 尾沿节流预览，页眉和页脚即时更新
- 拖动时降低面板透明度，并在多点触控期间锁定分段、重置和联动操作
- 延迟写入显式绑定区域和方向，切区、关闭及不同方向输入前提交待处理值
- 为 DetailSeekBar 增加拖动开始、拖动中和拖动结束回调

## 验证

- `.\gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.ui.book.read.ReadPaddingLayoutTest --tests io.legado.app.ui.book.read.ReadPaddingBehaviorSourceTest --no-daemon`
- `.\gradlew.bat :app:testAppReleaseUnitTest --rerun-tasks --no-daemon`
- 657 tests, 0 failures, 0 errors, 2 skipped