### PR TITLE
修复旧书源段评加载兼容

### DIFF
--- a/app/src/main/assets/updateLog.md
+++ b/app/src/main/assets/updateLog.md
@@ -2,8 +2,10 @@
 
 ## cronet版本: 151.0.7922.29
 
-**2026/07/20**
+**2026/07/22**
 - 恢复旧版 JavaScript 书源的块内 `const` 作用域兼容，修复部分段评页面持续加载的问题
+
+**2026/07/20**
 - 修复动态登录表单初始化时脚本反向读取登录信息导致 Rhino 递归溢出的问题
 - 恢复 JavaScript 规则中 `java.getElements(...)` 返回结果的 Jsoup 链式调用兼容，支持继续使用 `attr`、`text`、`html` 等旧式写法
 - 恢复旧版 JavaScript 源对 `with` 作用域、E4X XML 后代选择和嵌套 `eval` Java 方法调用的兼容

--- a/app/src/main/assets/updateLog.md
+++ b/app/src/main/assets/updateLog.md
@@ -3,6 +3,7 @@
 ## cronet版本: 151.0.7922.29
 
 **2026/07/20**
+- 恢复旧版 JavaScript 书源的块内 `const` 作用域兼容，修复部分段评页面持续加载的问题
 - 修复动态登录表单初始化时脚本反向读取登录信息导致 Rhino 递归溢出的问题
 - 恢复 JavaScript 规则中 `java.getElements(...)` 返回结果的 Jsoup 链式调用兼容，支持继续使用 `attr`、`text`、`html` 等旧式写法
 - 恢复旧版 JavaScript 源对 `with` 作用域、E4X XML 后代选择和嵌套 `eval` Java 方法调用的兼容

--- a/app/src/test/java/io/legado/app/JsEngineCapabilitiesTest.kt
+++ b/app/src/test/java/io/legado/app/JsEngineCapabilitiesTest.kt
@@ -1,5 +1,6 @@
 package io.legado.app
 
+import com.script.CompiledScript
 import com.script.ScriptBindings
 import com.script.rhino.ProtectedNativeJavaClass
 import com.script.rhino.ReadOnlyJavaObject
@@ -72,6 +73,98 @@ class JsEngineCapabilitiesTest {
 
         Assert.assertEquals(
             "first:1|second:2|left",
+            RhinoScriptEngine.eval(script, ScriptBindings()),
+        )
+    }
+
+    @Test
+    fun legacyNestedConstReadAfterBlockRemainsVisible() {
+        val script = """
+            with ({}) {}
+            function getParagraphsReviewByPage(comments) {
+                var html = '';
+                var refferContent = '';
+                if (comments.length > 0) {
+                    const paraContent = comments[0].expand.para_src_content || '';
+                    refferContent = paraContent;
+                }
+                return JSON.stringify({
+                    html: html,
+                    paraContent: paraContent,
+                    refferContent: refferContent
+                });
+            }
+            getParagraphsReviewByPage([{
+                expand: { para_src_content: 'paragraph' }
+            }]);
+        """.trimIndent()
+
+        Assert.assertEquals(
+            """{"html":"","paraContent":"paragraph","refferContent":"paragraph"}""",
+            RhinoScriptEngine.eval(script, ScriptBindings()),
+        )
+    }
+
+    @Test
+    fun legacyConstDoesNotShadowRuntimeBindings() {
+        val bindings = ScriptBindings().apply {
+            this["book"] = "global"
+        }
+        val script = """
+            with ({}) {}
+            function readBook() {
+                if (false) {
+                    const book = 'local';
+                }
+                return book;
+            }
+            readBook();
+        """.trimIndent()
+
+        Assert.assertEquals("global", RhinoScriptEngine.eval(script, bindings))
+    }
+
+    @Test
+    fun cachedCompilationDoesNotCaptureCallerBindings() {
+        val bridge = CompileBridge()
+        val compileScope = ScriptBindings().apply {
+            this["bridge"] = bridge
+            this["source"] = """
+                with ({}) {}
+                function readBook() {
+                    if (false) {
+                        const book = 'local';
+                    }
+                    return book;
+                }
+                readBook();
+            """.trimIndent()
+        }
+        RhinoScriptEngine.eval("bridge.compile(source)", compileScope)
+
+        val runScope = ScriptBindings().apply {
+            this["book"] = "global"
+        }
+        Assert.assertEquals("global", bridge.compiled.eval(runScope))
+    }
+
+    @Test
+    fun legacyConstRewriteSkipsResolvedAndNonValueNames() {
+        val script = """
+            with ({}) {}
+            function scopedValues() {
+                let value = 'outer';
+                if (true) {
+                    const value = 'inner';
+                    const hidden = 'block';
+                }
+                return ({value: 1}).value + ':' + value + ':' + typeof (hidden);
+            }
+            scopedValues();
+        """.trimIndent()
+
+        Assert.assertEquals(
+            "1:outer:undefined",
             RhinoScriptEngine.eval(script, ScriptBindings()),
         )
     }
@@ -392,6 +485,14 @@ class JsEngineCapabilitiesTest {
         fun factoryChild() = FactoryBridge()
 
         fun hidden(): Any = HiddenClassLoader()
+    }
+
+    class CompileBridge {
+        lateinit var compiled: CompiledScript
+
+        fun compile(source: String) {
+            compiled = RhinoScriptEngine.compile(source)
+        }
     }
 
     class ThrowingChild {

--- a/modules/rhino/src/main/java/com/script/rhino/RhinoContext.kt
+++ b/modules/rhino/src/main/java/com/script/rhino/RhinoContext.kt
@@ -11,12 +11,25 @@ import org.htmlunit.corejs.javascript.Function
 import org.htmlunit.corejs.javascript.FunctionCompileSpec
 import org.htmlunit.corejs.javascript.Parser
 import org.htmlunit.corejs.javascript.Script
+import org.htmlunit.corejs.javascript.ScriptRuntime
+import org.htmlunit.corejs.javascript.ScriptableObject
+import org.htmlunit.corejs.javascript.Token
 import org.htmlunit.corejs.javascript.TopLevel
 import org.htmlunit.corejs.javascript.VarScope
 import org.htmlunit.corejs.javascript.ast.AstNode
+import org.htmlunit.corejs.javascript.ast.BreakStatement
 import org.htmlunit.corejs.javascript.ast.CatchClause
+import org.htmlunit.corejs.javascript.ast.ContinueStatement
+import org.htmlunit.corejs.javascript.ast.FunctionNode
+import org.htmlunit.corejs.javascript.ast.Name
 import org.htmlunit.corejs.javascript.ast.NodeVisitor
+import org.htmlunit.corejs.javascript.ast.ObjectProperty
+import org.htmlunit.corejs.javascript.ast.ParenthesizedExpression
+import org.htmlunit.corejs.javascript.ast.PropertyGet
+import org.htmlunit.corejs.javascript.ast.Scope
+import org.htmlunit.corejs.javascript.ast.UnaryExpression
 import org.htmlunit.corejs.javascript.ast.VariableDeclaration
+import org.htmlunit.corejs.javascript.ast.VariableInitializer
 import org.htmlunit.corejs.javascript.ast.WithStatement
 import org.htmlunit.corejs.javascript.xml.XMLLib
 import org.htmlunit.corejs.javascript.xmlimpl.XMLLoaderImpl
@@ -28,6 +41,8 @@ class RhinoContext(factory: ContextFactory) : Context(factory) {
     var coroutineContext: CoroutineContext? = null
     var allowScriptRun = false
     var recursiveCount = 0
+    private var compatibilityScope: VarScope? = null
+    private var compatibilityScopeSpecified = false
 
     override fun initStandardObjects(scope: TopLevel?, sealedScope: Boolean): TopLevel {
         return super.initStandardObjects(scope, sealedScope).also {
@@ -55,6 +70,7 @@ class RhinoContext(factory: ContextFactory) : Context(factory) {
             resolvedSourceName,
             lineno,
             compilationErrorReporter ?: errorReporter,
+            if (compatibilityScopeSpecified) compatibilityScope else currentRuntimeScope(),
         )
         return super.compileString(
             normalizedSource,
@@ -84,6 +100,7 @@ class RhinoContext(factory: ContextFactory) : Context(factory) {
                     resolvedSourceName,
                     lineno,
                     compilationErrorReporter ?: errorReporter,
+                    scope,
                 ),
                 scope,
             )
@@ -101,7 +118,19 @@ class RhinoContext(factory: ContextFactory) : Context(factory) {
         source: String,
         sourceName: String,
         lineNumber: Int,
-    ): Script = compileString(source, sourceName, lineNumber, null)
+        scope: VarScope? = null,
+    ): Script {
+        val previousScope = compatibilityScope
+        val previousScopeSpecified = compatibilityScopeSpecified
+        compatibilityScope = scope
+        compatibilityScopeSpecified = true
+        return try {
+            compileString(source, sourceName, lineNumber, null)
+        } finally {
+            compatibilityScope = previousScope
+            compatibilityScopeSpecified = previousScopeSpecified
+        }
+    }
 
     private fun compatibilityProcessor(
         delegate: Consumer<CompilerEnvirons>?,
@@ -115,6 +144,7 @@ class RhinoContext(factory: ContextFactory) : Context(factory) {
         sourceName: String,
         lineNumber: Int,
         reporter: ErrorReporter,
+        runtimeScope: VarScope?,
     ): String {
         if (!source.contains("with") || !source.contains("const")) return source
 
@@ -122,7 +152,10 @@ class RhinoContext(factory: ContextFactory) : Context(factory) {
             initFromContext(this@RhinoContext)
             setXmlAvailable(true)
         }
-        val positions = ArrayList<Int>()
+        val root = Parser(environs, reporter).parse(source, sourceName, lineNumber)
+        val positions = linkedSetOf<Int>()
+        val declarations = arrayListOf<LegacyConstDeclaration>()
+        val references = arrayListOf<Name>()
         val visitor = object : NodeVisitor {
             override fun visit(node: AstNode): Boolean {
                 if (node is CatchClause) {
@@ -138,10 +171,53 @@ class RhinoContext(factory: ContextFactory) : Context(factory) {
                             .forEach { positions.add(it.absolutePosition) }
                     }
                 }
+                if (runtimeScope != null && node is VariableDeclaration) {
+                    val position = node.absolutePosition
+                    val scope = node.parent as? Scope
+                    val function = node.enclosingFunction
+                    val names = node.variables.mapNotNull {
+                        (it.target as? Name)?.identifier
+                    }.toSet()
+                    if (
+                        scope?.type == Token.BLOCK &&
+                        function != null &&
+                        names.isNotEmpty() &&
+                        position >= 0 &&
+                        source.regionMatches(position, "const", 0, 5)
+                    ) {
+                        declarations += LegacyConstDeclaration(position, scope, function, names)
+                    }
+                }
+                if (
+                    runtimeScope != null &&
+                    node is Name &&
+                    node.definingScope == null &&
+                    node.enclosingFunction != null &&
+                    node.isRequiredReference()
+                ) {
+                    references += node
+                }
                 return true
             }
         }
-        Parser(environs, reporter).parse(source, sourceName, lineNumber).visit(visitor)
+        root.visit(visitor)
+        // 旧 Rhino 将 const 放在函数作用域；仅在块外真实读取无法解析时恢复该行为。
+        references.forEach { reference ->
+            if (runtimeScope != null &&
+                ScriptableObject.hasProperty(runtimeScope, reference.identifier)
+            ) {
+                return@forEach
+            }
+            val matches = declarations.filter { declaration ->
+                declaration.function === reference.enclosingFunction &&
+                    reference.identifier in declaration.names &&
+                    reference.absolutePosition >
+                        declaration.scope.absolutePosition + declaration.scope.length
+            }
+            if (matches.size == 1) {
+                positions.add(matches.single().position)
+            }
+        }
         if (positions.isEmpty()) return source
 
         val result = source.toCharArray()
@@ -151,6 +227,36 @@ class RhinoContext(factory: ContextFactory) : Context(factory) {
             }
         }
         return result.concatToString()
+    }
+
+    private fun currentRuntimeScope(): VarScope? {
+        return if (ScriptRuntime.hasTopCall(this)) ScriptRuntime.getTopCallScope(this) else null
+    }
+
+    private data class LegacyConstDeclaration(
+        val position: Int,
+        val scope: Scope,
+        val function: FunctionNode,
+        val names: Set<String>,
+    )
+
+    private fun Name.isRequiredReference(): Boolean {
+        var expression: AstNode = this
+        var owner = parent
+        while (owner is ParenthesizedExpression) {
+            expression = owner
+            owner = owner.parent
+        }
+        if (owner is UnaryExpression && owner.type == Token.TYPEOF && owner.operand === expression) {
+            return false
+        }
+        return when (val directOwner = parent) {
+            is VariableInitializer -> directOwner.target !== this
+            is PropertyGet -> directOwner.property !== this
+            is ObjectProperty -> directOwner.value === this
+            is FunctionNode, is BreakStatement, is ContinueStatement -> false
+            else -> true
+        }
     }
 
     @Throws(RhinoInterruptError::class)

--- a/modules/rhino/src/main/java/com/script/rhino/RhinoScriptEngine.kt
+++ b/modules/rhino/src/main/java/com/script/rhino/RhinoScriptEngine.kt
@@ -72,7 +72,7 @@ object RhinoScriptEngine {
         try {
             cx.checkRecursive()
             val source = reader.readText()
-            val script = cx.compileWithCompatibility(source, SOURCE_NAME, 1)
+            val script = cx.compileWithCompatibility(source, SOURCE_NAME, 1, scope)
             ret = script.exec(cx, scope, Undefined.SCRIPTABLE_UNDEFINED)
         } catch (re: RhinoException) {
             val line = if (re.lineNumber() == 0) -1 else re.lineNumber()
@@ -111,7 +111,7 @@ object RhinoScriptEngine {
             try {
                 cx.checkRecursive()
                 val source = reader.readText()
-                val script = cx.compileWithCompatibility(source, SOURCE_NAME, 1)
+                val script = cx.compileWithCompatibility(source, SOURCE_NAME, 1, scope)
                 try {
                     ret = cx.executeScriptWithContinuations(script, scope)
                 } catch (e: ContinuationPending) {


### PR DESCRIPTION
## 问题

旧版 Rhino 会让普通块内声明的 `const` 在函数作用域中可见。切换到 HtmlUnit Rhino 后，旧书源在块外读取该值会抛出 `ReferenceError`，表现为段评页面持续加载；章评路径不受影响。

## 修改

- 扩展现有 `with`/`const` 旧书源兼容编译，仅在同一函数的块外存在未解析真实读取时恢复旧作用域行为
- 保留正常块作用域、循环声明、`typeof`、属性名和运行时注入绑定
- 隔离缓存编译与调用方作用域，避免缓存脚本受首个调用者影响
- 增加段评结构、作用域边界和缓存隔离回归测试
- 在当前更新日志中记录段评页面兼容修复

## 验证

- `:app:testReleaseUnitTest --no-daemon --max-workers=2`：655 项测试，0 失败，0 错误，2 跳过
- `:app:assembleRelease -ParmOnly=true --no-daemon --max-workers=2`：ARM Release/R8 构建通过
- `.github/scripts/test-extract-latest-update.sh`：发布说明提取测试通过