### PR TITLE
书架增加统计与继续阅读入口

### DIFF
--- a/app/src/main/java/io/legado/app/data/dao/BookDao.kt
+++ b/app/src/main/java/io/legado/app/data/dao/BookDao.kt
@@ -138,6 +138,14 @@ interface BookDao {
     @get:Query("SELECT * FROM books where type & ${BookType.text} > 0 ORDER BY durChapterTime DESC limit 1")
     val lastReadBook: Book?
 
+    @get:Query(
+        "SELECT * FROM books where type & ${BookType.text} > 0 " +
+            "and type & ${BookType.notShelf} = 0 " +
+            "ORDER BY (durChapterIndex > 0 OR durChapterPos > 0) DESC, " +
+            "durChapterTime DESC limit 1"
+    )
+    val lastReadBookOnShelf: Book?
+
     @get:Query("SELECT bookUrl FROM books")
     val allBookUrls: List<String>
 
@@ -146,6 +154,16 @@ interface BookDao {
 
     @get:Query("SELECT COUNT(*) FROM books")
     val allBookCount: Int
+
+    @Query("SELECT COUNT(*) FROM books where type & ${BookType.notShelf} = 0")
+    fun flowShelfBookCount(): Flow<Int>
+
+    @get:Query(
+        "SELECT count(*) FROM books where " +
+            "(durChapterIndex > 0 OR durChapterPos > 0) " +
+            "and type & ${BookType.notShelf} = 0"
+    )
+    val readingCount: Int
 
     @get:Query("select min(`order`) from books")
     val minOrder: Int

--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/BaseBookshelfFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/BaseBookshelfFragment.kt
@@ -1,22 +1,29 @@
 package io.legado.app.ui.main.bookshelf
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import androidx.core.view.indices
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.lifecycleScope
 import io.legado.app.R
 import io.legado.app.base.VMBaseFragment
+import io.legado.app.constant.AppLog
 import io.legado.app.constant.EventBus
+import io.legado.app.data.AppDatabase
 import io.legado.app.data.appDb
 import io.legado.app.data.entities.Book
 import io.legado.app.data.entities.BookGroup
 import io.legado.app.databinding.DialogBookshelfConfigBinding
 import io.legado.app.databinding.DialogEditTextBinding
+import io.legado.app.databinding.ViewBookshelfHeaderBinding
 import io.legado.app.help.DirectLinkUpload
+import io.legado.app.help.book.readProgress
 import io.legado.app.help.config.AppConfig
 import io.legado.app.lib.dialogs.alert
 import io.legado.app.ui.about.AppLogDialog
@@ -24,6 +31,7 @@ import io.legado.app.ui.book.cache.CacheActivity
 import io.legado.app.ui.book.group.GroupManageDialog
 import io.legado.app.ui.book.import.local.ImportBookActivity
 import io.legado.app.ui.book.import.remote.RemoteBookActivity
+import io.legado.app.ui.book.info.BookInfoActivity
 import io.legado.app.ui.book.manage.BookshelfManageActivity
 import io.legado.app.ui.book.search.SearchActivity
 import io.legado.app.ui.file.HandleFileContract
@@ -31,14 +39,25 @@ import io.legado.app.ui.main.MainFragmentInterface
 import io.legado.app.ui.main.MainViewModel
 import io.legado.app.ui.widget.dialog.WaitDialog
 import io.legado.app.utils.checkByIndex
+import io.legado.app.utils.flowWithLifecycleAndDatabaseChangeFirst
 import io.legado.app.utils.getCheckedIndex
+import io.legado.app.utils.gone
 import io.legado.app.utils.isAbsUrl
 import io.legado.app.utils.postEvent
 import io.legado.app.utils.readText
 import io.legado.app.utils.sendToClip
 import io.legado.app.utils.showDialogFragment
 import io.legado.app.utils.startActivity
+import io.legado.app.utils.startActivityForBook
 import io.legado.app.utils.toastOnUi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.roundToInt
 
 abstract class BaseBookshelfFragment(layoutId: Int) : VMBaseFragment<BookshelfViewModel>(layoutId),
     MainFragmentInterface {
@@ -83,6 +102,73 @@ abstract class BaseBookshelfFragment(layoutId: Int) : VMBaseFragment<BookshelfVi
             setOnCancelListener {
                 viewModel.addBookJob?.cancel()
             }
+        }
+    }
+
+    private var shelfHeaderBinding: ViewBookshelfHeaderBinding? = null
+    private var continueBook: Book? = null
+    private var shelfHeaderFlowJob: Job? = null
+
+    override fun onDestroyView() {
+        shelfHeaderFlowJob?.cancel()
+        shelfHeaderFlowJob = null
+        shelfHeaderBinding = null
+        continueBook = null
+        super.onDestroyView()
+    }
+
+    fun bindShelfHeader(header: ViewBookshelfHeaderBinding) {
+        shelfHeaderBinding = header
+        header.continueReading.setOnClickListener {
+            continueBook?.let { startActivityForBook(it) }
+        }
+        header.continueReading.setOnLongClickListener {
+            continueBook?.let { book ->
+                startActivity(
+                    Intent(requireContext(), BookInfoActivity::class.java).apply {
+                        putExtra("name", book.name)
+                        putExtra("author", book.author)
+                    }
+                )
+                true
+            } ?: false
+        }
+        subscribeShelfHeaderRefresh()
+    }
+
+    private fun subscribeShelfHeaderRefresh() {
+        shelfHeaderFlowJob?.cancel()
+        shelfHeaderFlowJob = viewLifecycleOwner.lifecycleScope.launch {
+            appDb.bookDao.flowShelfBookCount()
+                .flowWithLifecycleAndDatabaseChangeFirst(
+                    viewLifecycleOwner.lifecycle,
+                    Lifecycle.State.RESUMED,
+                    AppDatabase.BOOK_TABLE_NAME
+                )
+                .catch { AppLog.put("书架头部刷新出错", it) }
+                .conflate()
+                .flowOn(Dispatchers.Default)
+                .collect { bookCount ->
+                    val header = shelfHeaderBinding ?: return@collect
+                    val (book, readingCount) = withContext(Dispatchers.IO) {
+                        appDb.bookDao.lastReadBookOnShelf to appDb.bookDao.readingCount
+                    }
+                    if (shelfHeaderBinding !== header) return@collect
+                    continueBook = book
+                    header.tvShelfStats.text =
+                        getString(R.string.bookshelf_stats, bookCount, readingCount)
+                    if (book == null) {
+                        header.continueReading.gone()
+                        return@collect
+                    }
+                    header.continueReading.visibility = View.VISIBLE
+                    header.tvContinueName.text = book.name
+                    header.tvContinueChapter.text = book.durChapterTitle
+                        .takeIf { it?.isNotBlank() == true }
+                        ?: getString(R.string.read_not_started)
+                    header.tvContinuePercent.text =
+                        "${((book.readProgress() ?: 0f) * 100).roundToInt().coerceIn(0, 100)}%"
+                }
         }
     }
 

--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/style1/BookshelfFragment1.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/style1/BookshelfFragment1.kt
@@ -60,6 +60,7 @@ class BookshelfFragment1() : BaseBookshelfFragment(R.layout.fragment_bookshelf1)
     override var onlyUpdateRead = false
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
         setSupportToolbar(binding.titleBar.toolbar)
+        bindShelfHeader(binding.shelfHeader)
         initView()
         initBookGroupData()
     }

--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/style2/BookshelfFragment2.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/style2/BookshelfFragment2.kt
@@ -78,6 +78,7 @@ class BookshelfFragment2() : BaseBookshelfFragment(R.layout.fragment_bookshelf2)
 
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
         setSupportToolbar(binding.titleBar.toolbar)
+        bindShelfHeader(binding.shelfHeader)
         initRecyclerView()
         initBookGroupData()
         initBooksData()

--- a/app/src/main/res/layout/fragment_bookshelf1.xml
+++ b/app/src/main/res/layout/fragment_bookshelf1.xml
@@ -13,9 +13,16 @@
         app:contentLayout="@layout/view_tab_layout_min"
         app:title="@string/bookshelf" />
 
+    <include
+        android:id="@+id/shelf_header"
+        layout="@layout/view_bookshelf_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <androidx.viewpager.widget.ViewPager
         android:id="@+id/view_pager_bookshelf"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_bookshelf2.xml
+++ b/app/src/main/res/layout/fragment_bookshelf2.xml
@@ -14,11 +14,18 @@
         app:layout_constraintTop_toTopOf="parent"
         app:title="@string/bookshelf" />
 
+    <include
+        android:id="@+id/shelf_header"
+        layout="@layout/view_bookshelf_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/title_bar" />
+
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/refresh_layout"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@+id/title_bar"
+        app:layout_constraintTop_toBottomOf="@+id/shelf_header"
         app:layout_constraintBottom_toBottomOf="parent">
 
         <io.legado.app.ui.widget.recycler.RecyclerViewAtPager2
@@ -42,7 +49,7 @@
         android:gravity="center"
         android:text="@string/bookshelf_empty"
         android:visibility="gone"
-        app:layout_constraintTop_toBottomOf="@+id/title_bar"
+        app:layout_constraintTop_toBottomOf="@+id/shelf_header"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/layout/view_bookshelf_header.xml
+++ b/app/src/main/res/layout/view_bookshelf_header.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingLeft="16dp"
+    android:paddingTop="8dp"
+    android:paddingRight="16dp"
+    android:paddingBottom="12dp">
+
+    <TextView
+        android:id="@+id/tv_shelf_stats"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/tv_text_summary"
+        android:textSize="@dimen/font_size_normal"
+        tools:text="128 books · 23 reading" />
+
+    <LinearLayout
+        android:id="@+id/continue_reading"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:background="?attr/selectableItemBackground"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:minHeight="48dp"
+        android:orientation="horizontal"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <TextView
+            android:id="@+id/tv_continue_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/continue_read"
+            android:textColor="@color/tv_text_summary"
+            android:textSize="@dimen/font_size_normal"
+            android:singleLine="true" />
+
+        <TextView
+            android:id="@+id/tv_continue_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textColor="@color/primaryText"
+            android:textSize="@dimen/font_size_normal"
+            tools:text="A book" />
+
+        <TextView
+            android:id="@+id/tv_continue_chapter"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textColor="@color/tv_text_summary"
+            android:textSize="@dimen/font_size_normal"
+            tools:text="Chapter 60" />
+
+        <TextView
+            android:id="@+id/tv_continue_percent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:singleLine="true"
+            android:textColor="@color/tv_text_summary"
+            android:textSize="@dimen/font_size_normal"
+            tools:text="59%" />
+
+        <ImageView
+            android:id="@+id/iv_continue_arrow"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginStart="4dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_arrow_right"
+            app:tint="@color/tv_text_summary" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -421,6 +421,8 @@
     <string name="add_loaded_books_to_bookshelf_in_progress">正在批量加入书架</string>
     <string name="no_loaded_books_to_add">暂无已加载的书籍</string>
     <string name="continue_read">继续阅读</string>
+    <string name="bookshelf_stats">共 %1$d 本 · 在读 %2$d 本</string>
+    <string name="read_not_started">尚未开始阅读</string>
     <string name="cover_path">封面地址</string>
     <string name="page_anim_cover">覆盖</string>
     <string name="page_anim_slide">滑动</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -424,6 +424,8 @@
     <string name="add_loaded_books_to_bookshelf_in_progress">Loaded books are already being added</string>
     <string name="no_loaded_books_to_add">No loaded books to add</string>
     <string name="continue_read">Continue reading</string>
+    <string name="bookshelf_stats">%1$d books · %2$d reading</string>
+    <string name="read_not_started">Not started</string>
     <string name="cover_path">Cover path</string>
     <string name="page_anim_cover">Cover</string>
     <string name="page_anim_slide">Slide</string>

--- a/app/src/test/java/io/legado/app/ui/main/bookshelf/BookshelfReadProgressTest.kt
+++ b/app/src/test/java/io/legado/app/ui/main/bookshelf/BookshelfReadProgressTest.kt
@@ -82,6 +82,43 @@ class BookshelfReadProgressTest {
         )
     }
 
+    @Test
+    fun `bookshelf layouts expose the shared header and keep content below it`() {
+        val header = parseProjectXml("src/main/res/layout/view_bookshelf_header.xml")
+        assertEquals(
+            "gone",
+            header.findElementById("@+id/continue_reading").androidAttribute("visibility"),
+        )
+        listOf("tv_shelf_stats", "tv_continue_name", "tv_continue_chapter", "tv_continue_percent")
+            .forEach { id -> header.findElementById("@+id/$id") }
+        listOf("tv_continue_name", "tv_continue_chapter").forEach { id ->
+            val text = header.findElementById("@+id/$id")
+            assertEquals("0dp", text.androidAttribute("layout_width"))
+            assertEquals("1", text.androidAttribute("layout_weight"))
+        }
+
+        val style1 = parseProjectXml("src/main/res/layout/fragment_bookshelf1.xml")
+        assertEquals(
+            "@layout/view_bookshelf_header",
+            style1.findElementById("@+id/shelf_header").getAttribute("layout"),
+        )
+        val viewPager = style1.findElementById("@+id/view_pager_bookshelf")
+        assertEquals("0dp", viewPager.androidAttribute("layout_height"))
+        assertEquals("1", viewPager.androidAttribute("layout_weight"))
+
+        val style2 = parseProjectXml("src/main/res/layout/fragment_bookshelf2.xml")
+        assertEquals(
+            "@+id/shelf_header",
+            style2.findElementById("@+id/refresh_layout")
+                .appAttribute("layout_constraintTop_toBottomOf"),
+        )
+        assertEquals(
+            "@+id/shelf_header",
+            style2.findElementById("@+id/tv_empty_msg")
+                .appAttribute("layout_constraintTop_toBottomOf"),
+        )
+    }
+
     private fun parseProjectXml(pathInApp: String): Document {
         val file = listOf(File(pathInApp), File("app/$pathInApp"))
             .firstOrNull { it.isFile }


### PR DESCRIPTION
## 变更内容
- 两种书架布局在标题栏下增加书架总数、在读数量和继续阅读入口
- 继续阅读优先显示已有进度的最近阅读书籍，并排除未正式入架的临时书籍
- 点击继续阅读，长按进入书籍详情；数据随书籍表变化自动刷新
- 使用标量 Room Flow 监听书架变化，避免为头部刷新完整加载全部书籍

## 验证
- `:app:testAppDebugUnitTest --tests io.legado.app.ui.main.bookshelf.BookshelfReadProgressTest`
- 7 tests passed
- 已完成资源合并、Data Binding、Room/KSP 和 Kotlin 编译