### PR TITLE
优化书源导入空态显示

### DIFF
--- a/app/src/main/java/io/legado/app/ui/association/ImportBookSourceDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/association/ImportBookSourceDialog.kt
@@ -105,6 +105,7 @@ class ImportBookSourceDialog() : BaseDialogFragment(R.layout.dialog_recycler_vie
         }
         viewModel.errorLiveData.observe(viewLifecycleOwner) {
             binding.rotateLoading.gone()
+            binding.ivEmpty.visible()
             binding.tvMsg.apply {
                 text = it
                 visible()
@@ -114,10 +115,13 @@ class ImportBookSourceDialog() : BaseDialogFragment(R.layout.dialog_recycler_vie
             binding.rotateLoading.gone()
             if (it > 0) {
                 sourceListReady = true
+                binding.ivEmpty.gone()
+                binding.tvMsg.gone()
                 adapter.setItems(viewModel.allSources)
                 upSelectText()
                 updateInteractionState()
             } else {
+                binding.ivEmpty.visible()
                 binding.tvMsg.apply {
                     setText(R.string.wrong_format)
                     visible()

--- a/app/src/main/res/drawable/ic_description.xml
+++ b/app/src/main/res/drawable/ic_description.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M14,2H6C4.9,2 4.01,2.9 4.01,4L4,20c0,1.1 0.89,2 1.99,2H18c1.1,0 2,-0.9 2,-2V8L14,2zM16,18H8v-2h8V18zM16,14H8v-2h8V14zM13,9V3.5L18.5,9H13z" />
+</vector>

--- a/app/src/main/res/layout/dialog_recycler_view.xml
+++ b/app/src/main/res/layout/dialog_recycler_view.xml
@@ -35,14 +35,30 @@
             android:layout_gravity="center"
             app:loading_width="2dp" />
 
-        <TextView
-            android:id="@+id/tv_msg"
+        <LinearLayout
+            android:id="@+id/ll_empty"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="16dp"
             android:layout_gravity="center"
-            android:visibility="gone"
-            android:textColor="@color/secondaryText" />
+            android:gravity="center_horizontal"
+            android:orientation="vertical">
+
+            <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/iv_empty"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:src="@drawable/ic_description"
+                android:visibility="gone"
+                app:tint="@color/secondaryText" />
+
+            <TextView
+                android:id="@+id/tv_msg"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp"
+                android:visibility="gone"
+                android:textColor="@color/secondaryText" />
+        </LinearLayout>
 
     </FrameLayout>
 

--- a/app/src/test/java/io/legado/app/ui/association/ImportBookSourceStateTest.kt
+++ b/app/src/test/java/io/legado/app/ui/association/ImportBookSourceStateTest.kt
@@ -60,6 +60,35 @@ class ImportBookSourceStateTest {
         assertTrue(directImport.contains("JsSourceConfig.extract(mText, coroutineContext)"))
     }
 
+    @Test
+    fun `book source import shows icon for empty states and hides it for results`() {
+        val dialog = readProjectFile(
+            "src/main/java/io/legado/app/ui/association/ImportBookSourceDialog.kt"
+        )
+        val errorState = dialog.substringAfter("viewModel.errorLiveData.observe")
+            .substringBefore("viewModel.successLiveData.observe")
+        assertTrue(errorState.contains("binding.ivEmpty.visible()"))
+        val successState = dialog.substringAfter("viewModel.successLiveData.observe")
+            .substringBefore("viewModel.sourceUpdatePending.observe")
+        val populatedState = successState.substringAfter("if (it > 0)")
+            .substringBefore("} else {")
+        assertTrue(populatedState.contains("binding.ivEmpty.gone()"))
+        assertTrue(populatedState.contains("binding.tvMsg.gone()"))
+        assertTrue(successState.substringAfter("} else {").contains("binding.ivEmpty.visible()"))
+
+        val layout = readProjectFile("src/main/res/layout/dialog_recycler_view.xml")
+        assertTrue(layout.contains("@+id/ll_empty"))
+        val emptyIcon = layout.substringAfter("@+id/iv_empty").substringBefore("/>")
+        assertTrue(emptyIcon.contains("@drawable/ic_description"))
+        assertTrue(emptyIcon.contains("android:visibility=\"gone\""))
+        val message = layout.substringAfter("@+id/tv_msg").substringBefore("/>")
+        assertTrue(message.contains("android:layout_width=\"match_parent\""))
+        assertTrue(message.contains("android:visibility=\"gone\""))
+
+        val icon = readProjectFile("src/main/res/drawable/ic_description.xml")
+        assertTrue(icon.contains("android:pathData="))
+    }
+
     private fun readProjectFile(pathInApp: String): String {
         val file = sequenceOf(File(pathInApp), File("app/$pathInApp"))
             .firstOrNull(File::isFile)


### PR DESCRIPTION
## 变更

- 书源导入失败或结果为空时显示说明图标和原有消息。
- 导入成功后隐藏空态图标和消息，避免状态残留。
- 共享列表弹窗保留 `tv_msg` 默认隐藏和全宽行为。

## 验证

- `:app:testAppDebugUnitTest --tests io.legado.app.ui.association.ImportBookSourceStateTest`
- 5 个测试通过，0 failure，0 error