### PR TITLE
修复未入书架书籍从目录进入阅读

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt
@@ -129,23 +129,13 @@ class BookInfoActivity :
 
     private val tocActivityResult = registerForActivityResult(TocActivityResult()) {
         it?.let {
-            viewModel.getBook(false)?.let { book ->
-                lifecycleScope.launch {
-                    withContext(IO) {
-                        val durChapterIndex = it[0] as Int
-                        val durChapterPos = it[1] as Int
-                        val durVolumeIndex = it[3] as Int
-                        val chapterInVolumeIndex = it[4] as Int
-                        book.durChapterIndex = durChapterIndex
-                        book.durChapterPos = durChapterPos
-                        chapterChanged = it[2] as Boolean
-                        book.durVolumeIndex = durVolumeIndex
-                        book.chapterInVolumeIndex = chapterInVolumeIndex
-                        appDb.bookDao.update(book)
-                    }
-                    startReadActivity(book)
-                }
-            }
+            readFromChapter(
+                index = it[0] as Int,
+                pos = it[1] as Int,
+                changed = it[2] as Boolean,
+                volumeIndex = it[3] as Int,
+                chapterInVolumeIndex = it[4] as Int,
+            )
         } ?: let {
             if (!viewModel.inBookshelf) {
                 viewModel.delBook() //进目录会保存book，此时退出目录触发的book删除，不通知书源回调
@@ -1160,6 +1150,37 @@ class BookInfoActivity :
     private fun openChapterList() {
         viewModel.getBook()?.let {
             tocActivityResult.launch(it.bookUrl)
+        }
+    }
+
+    private fun readFromChapter(
+        index: Int,
+        pos: Int,
+        changed: Boolean,
+        volumeIndex: Int,
+        chapterInVolumeIndex: Int,
+    ) {
+        viewModel.getBook(false)?.let { book ->
+            book.durChapterIndex = index
+            book.durChapterPos = pos
+            chapterChanged = changed
+            book.durVolumeIndex = volumeIndex
+            book.chapterInVolumeIndex = chapterInVolumeIndex
+            if (!viewModel.inBookshelf) {
+                book.addType(BookType.notShelf)
+                viewModel.saveBook(book) {
+                    viewModel.saveChapterList {
+                        startReadActivity(book)
+                    }
+                }
+            } else {
+                lifecycleScope.launch {
+                    withContext(IO) {
+                        appDb.bookDao.update(book)
+                    }
+                    startReadActivity(book)
+                }
+            }
         }
     }
 

--- a/app/src/test/java/io/legado/app/ui/book/info/BookInfoTocEntryTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/info/BookInfoTocEntryTest.kt
@@ -46,6 +46,41 @@ class BookInfoTocEntryTest {
         )
     }
 
+    @Test
+    fun `toc result saves temporary books before reading and preserves all progress`() {
+        val activity = readProjectFile(
+            "src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt"
+        )
+        val callback = activity
+            .substringAfter("private val tocActivityResult")
+            .substringBefore("private val localBookTreeSelect")
+        val readFlow = activity
+            .substringAfter("private fun readFromChapter(")
+            .substringBefore("private fun showWebFileDownloadAlert")
+        val notShelfFlow = readFlow
+            .substringAfter("if (!viewModel.inBookshelf) {")
+            .substringBefore("} else {")
+        val shelfFlow = readFlow.substringAfter("} else {")
+
+        assertTrue(callback.contains("index = it[0] as Int"))
+        assertTrue(callback.contains("pos = it[1] as Int"))
+        assertTrue(callback.contains("changed = it[2] as Boolean"))
+        assertTrue(callback.contains("volumeIndex = it[3] as Int"))
+        assertTrue(callback.contains("chapterInVolumeIndex = it[4] as Int"))
+        assertTrue(readFlow.contains("book.durChapterIndex = index"))
+        assertTrue(readFlow.contains("book.durChapterPos = pos"))
+        assertTrue(readFlow.contains("chapterChanged = changed"))
+        assertTrue(readFlow.contains("book.durVolumeIndex = volumeIndex"))
+        assertTrue(readFlow.contains("book.chapterInVolumeIndex = chapterInVolumeIndex"))
+        assertTrue(notShelfFlow.contains("book.addType(BookType.notShelf)"))
+        assertTrue(notShelfFlow.contains("viewModel.saveBook(book)"))
+        assertTrue(notShelfFlow.contains("viewModel.saveChapterList"))
+        assertTrue(notShelfFlow.contains("startReadActivity(book)"))
+        assertTrue(shelfFlow.contains("withContext(IO)"))
+        assertTrue(shelfFlow.contains("appDb.bookDao.update(book)"))
+        assertTrue(shelfFlow.contains("startReadActivity(book)"))
+    }
+
     private fun readProjectFile(pathInApp: String): String {
         val file = sequenceOf(File(pathInApp), File("app/$pathInApp"))
             .firstOrNull(File::isFile)


### PR DESCRIPTION
## 内容

- 未入书架书籍从详情页目录选择章节时，标记为临时书籍并依次保存书籍、目录后进入阅读。
- 完整保留章节索引、章节位置、章节变化和分卷进度；书架内书籍仍在 IO 线程更新。
- 补充目录进入阅读的回归测试。

## 验证

- `:app:testAppDebugUnitTest --tests io.legado.app.ui.book.info.BookInfoTocEntryTest`：3 项通过，0 失败。