### PR TITLE
书签列表项改为卡片样式

### DIFF
--- a/app/src/main/res/layout/item_bookmark.xml
+++ b/app/src/main/res/layout/item_bookmark.xml
@@ -1,32 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="8dp"
-    android:background="?android:attr/selectableItemBackground">
+    android:layout_marginStart="10dp"
+    android:layout_marginTop="3dp"
+    android:layout_marginEnd="10dp"
+    android:layout_marginBottom="3dp"
+    android:foreground="?android:attr/selectableItemBackground"
+    app:cardBackgroundColor="@color/background_card"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="0dp"
+    app:cardUseCompatPadding="false">
 
-    <TextView
-        android:id="@+id/tv_chapter_name"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="4dp"
-        android:singleLine="true" />
+        android:orientation="vertical"
+        android:padding="12dp">
 
-    <TextView
-        android:id="@+id/tv_book_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="4dp"
-        android:textSize="12sp"
-        android:singleLine="true" />
+        <TextView
+            android:id="@+id/tv_chapter_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textColor="@color/primaryText"
+            android:textSize="14sp" />
 
-    <TextView
-        android:id="@+id/tv_content"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="4dp"
-        android:textSize="12sp"
-        android:singleLine="true" />
+        <TextView
+            android:id="@+id/tv_book_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textColor="@color/secondaryText"
+            android:textSize="12sp" />
 
-</LinearLayout>
+        <TextView
+            android:id="@+id/tv_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textColor="@color/secondaryText"
+            android:textSize="12sp" />
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/test/java/io/legado/app/ui/book/toc/BookmarkItemLayoutTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/toc/BookmarkItemLayoutTest.kt
@@ -1,0 +1,71 @@
+package io.legado.app.ui.book.toc
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class BookmarkItemLayoutTest {
+
+    @Test
+    fun `bookmark item keeps bindings and card presentation`() {
+        val root = DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = true
+        }.newDocumentBuilder()
+            .parse(projectFile("src/main/res/layout/item_bookmark.xml"))
+            .documentElement
+
+        assertEquals("androidx.cardview.widget.CardView", root.tagName)
+        assertEquals("10dp", root.androidAttribute("layout_marginStart"))
+        assertEquals("3dp", root.androidAttribute("layout_marginTop"))
+        assertEquals("10dp", root.androidAttribute("layout_marginEnd"))
+        assertEquals("3dp", root.androidAttribute("layout_marginBottom"))
+        assertEquals("?android:attr/selectableItemBackground", root.androidAttribute("foreground"))
+        assertEquals("@color/background_card", root.appAttribute("cardBackgroundColor"))
+        assertEquals("8dp", root.appAttribute("cardCornerRadius"))
+        assertEquals("0dp", root.appAttribute("cardElevation"))
+
+        val content = root.firstChildElement()
+        assertEquals("LinearLayout", content.tagName)
+        assertEquals("12dp", content.androidAttribute("padding"))
+
+        val fields = content.childElements().associateBy { it.androidAttribute("id") }
+        assertEquals(
+            setOf("@+id/tv_chapter_name", "@+id/tv_book_text", "@+id/tv_content"),
+            fields.keys
+        )
+        assertEquals("14sp", fields.getValue("@+id/tv_chapter_name").androidAttribute("textSize"))
+        assertEquals("@color/primaryText", fields.getValue("@+id/tv_chapter_name").androidAttribute("textColor"))
+        listOf("@+id/tv_book_text", "@+id/tv_content").forEach { id ->
+            assertEquals("12sp", fields.getValue(id).androidAttribute("textSize"))
+            assertEquals("@color/secondaryText", fields.getValue(id).androidAttribute("textColor"))
+        }
+        fields.values.forEach { field ->
+            assertEquals("true", field.androidAttribute("singleLine"))
+        }
+    }
+
+    private fun projectFile(pathInApp: String): File =
+        listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+
+    private fun Element.androidAttribute(name: String): String =
+        getAttributeNS(androidNamespace, name)
+
+    private fun Element.appAttribute(name: String): String =
+        getAttributeNS(appNamespace, name)
+
+    private fun Element.firstChildElement(): Element = childElements().single()
+
+    private fun Element.childElements(): List<Element> =
+        (0 until childNodes.length)
+            .map { childNodes.item(it) }
+            .filterIsInstance<Element>()
+
+    private companion object {
+        const val androidNamespace = "http://schemas.android.com/apk/res/android"
+        const val appNamespace = "http://schemas.android.com/apk/res-auto"
+    }
+}


### PR DESCRIPTION
## 变更

- 书签列表项使用轻量圆角卡片，统一目录抽屉与书签列表的显示。
- 保留原有点击、长按和三项文本绑定。
- 补充布局契约测试。

## 验证

- `BookmarkItemLayoutTest`：1 项通过，0 失败。
- `git diff --check`。