### PR TITLE
feat: 卡片化书内搜索结果

### DIFF
--- a/app/src/main/res/layout/item_search_list.xml
+++ b/app/src/main/res/layout/item_search_list.xml
@@ -1,19 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?android:attr/selectableItemBackground"
-    android:padding="12dp">
+    android:layout_marginStart="10dp"
+    android:layout_marginTop="3dp"
+    android:layout_marginEnd="10dp"
+    android:layout_marginBottom="3dp"
+    android:foreground="?android:attr/selectableItemBackground"
+    app:cardBackgroundColor="@color/background_card"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="0dp"
+    app:cardUseCompatPadding="false">
 
-    <TextView
-        android:id="@+id/tv_search_result"
-        android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:singleLine="false"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:background="?android:attr/selectableItemBackground"
+        android:padding="12dp">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/tv_search_result"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:singleLine="false"
+            android:textSize="14sp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/test/java/io/legado/app/ui/book/searchContent/SearchContentLayoutTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/searchContent/SearchContentLayoutTest.kt
@@ -3,6 +3,7 @@ package io.legado.app.ui.book.searchContent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Test
+import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.io.File
 import javax.xml.parsers.DocumentBuilderFactory
@@ -14,24 +15,51 @@ class SearchContentLayoutTest {
         val view = searchResultView()
 
         assertEquals("0dp", view.getAttributeNS(ANDROID_NS, "layout_width"))
+        assertEquals("wrap_content", view.getAttributeNS(ANDROID_NS, "layout_height"))
+        assertEquals("false", view.getAttributeNS(ANDROID_NS, "singleLine"))
+        assertEquals("14sp", view.getAttributeNS(ANDROID_NS, "textSize"))
         assertEquals("parent", view.getAttributeNS(APP_NS, "layout_constraintStart_toStartOf"))
         assertEquals("parent", view.getAttributeNS(APP_NS, "layout_constraintEnd_toEndOf"))
         assertFalse(view.hasAttributeNS(APP_NS, "layout_constraintRight_toLeftOf"))
     }
 
+    @Test
+    fun searchResultItemUsesFlatClickableCard() {
+        val card = searchResultLayout().documentElement
+        val content = card.getElementsByTagName("androidx.constraintlayout.widget.ConstraintLayout")
+            .item(0) as Element
+
+        assertEquals("androidx.cardview.widget.CardView", card.tagName)
+        assertEquals("match_parent", card.getAttributeNS(ANDROID_NS, "layout_width"))
+        assertEquals("wrap_content", card.getAttributeNS(ANDROID_NS, "layout_height"))
+        assertEquals("10dp", card.getAttributeNS(ANDROID_NS, "layout_marginStart"))
+        assertEquals("3dp", card.getAttributeNS(ANDROID_NS, "layout_marginTop"))
+        assertEquals("10dp", card.getAttributeNS(ANDROID_NS, "layout_marginEnd"))
+        assertEquals("3dp", card.getAttributeNS(ANDROID_NS, "layout_marginBottom"))
+        assertEquals("?android:attr/selectableItemBackground", card.getAttributeNS(ANDROID_NS, "foreground"))
+        assertEquals("@color/background_card", card.getAttributeNS(APP_NS, "cardBackgroundColor"))
+        assertEquals("8dp", card.getAttributeNS(APP_NS, "cardCornerRadius"))
+        assertEquals("0dp", card.getAttributeNS(APP_NS, "cardElevation"))
+        assertEquals("12dp", content.getAttributeNS(ANDROID_NS, "padding"))
+        assertEquals("?android:attr/selectableItemBackground", content.getAttributeNS(ANDROID_NS, "background"))
+    }
+
     private fun searchResultView(): Element {
-        val layout = listOf(
-            File("src/main/res/layout/item_search_list.xml"),
-            File("app/src/main/res/layout/item_search_list.xml"),
-        ).firstOrNull { it.isFile } ?: error("item_search_list.xml not found")
-        val document = DocumentBuilderFactory.newInstance().apply {
-            isNamespaceAware = true
-        }.newDocumentBuilder().parse(layout)
-        val textViews = document.getElementsByTagName("TextView")
+        val textViews = searchResultLayout().getElementsByTagName("TextView")
         return (0 until textViews.length)
             .asSequence()
             .map { textViews.item(it) as Element }
             .first { it.getAttributeNS(ANDROID_NS, "id") == "@+id/tv_search_result" }
+    }
+
+    private fun searchResultLayout(): Document {
+        val layout = listOf(
+            File("src/main/res/layout/item_search_list.xml"),
+            File("app/src/main/res/layout/item_search_list.xml"),
+        ).firstOrNull { it.isFile } ?: error("item_search_list.xml not found")
+        return DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = true
+        }.newDocumentBuilder().parse(layout)
     }
 
     companion object {


### PR DESCRIPTION
## 变更

- 将书内搜索结果改为低海拔 `CardView` 卡片，保留现有 Start/End 约束、多行文本和适配器整项点击。
- 增加根与内容层点击反馈、背景色、间距和字号。
- 扩展 `SearchContentLayoutTest` 校验布局契约。

## 验证

- `git diff --check`
- 原生 XML 解析与静态属性检查
- `build (app, release)`
- `build (app, releaseA)`