### PR TITLE
fix: 加固分享口令编解码边界

### DIFF
--- a/app/src/main/java/io/legado/app/help/SourceSharePassphrase.kt
+++ b/app/src/main/java/io/legado/app/help/SourceSharePassphrase.kt
@@ -1,5 +1,6 @@
 package io.legado.app.help
 
+import java.net.URI
 import kotlin.random.Random
 
 object SourceSharePassphrase {
@@ -9,6 +10,7 @@ object SourceSharePassphrase {
     private const val EXPIRY_PRECISION = 1_000_000L
     private const val HTTPS_MARKER = "#L:"
     private const val HTTP_MARKER = "#L0:"
+    private const val PREFIX = "复制口令到阅读导入"
     private const val CUSTOM_WORD = "Legado"
 
     private val mappings = linkedMapOf(
@@ -34,6 +36,7 @@ object SourceSharePassphrase {
     private val reverseMappings = mappings.flatMap { (original, replacements) ->
         replacements.map { replacement -> replacement to original }
     }.sortedByDescending { it.first.length }
+    private val unsafeUrlTokens = mappings.values.flatten() + listOf("！", "©", "¥", "^")
 
     enum class Type(val code: String) {
         BOOK_SOURCE("sy"),
@@ -62,13 +65,17 @@ object SourceSharePassphrase {
         data object Expired : DecodeResult
     }
 
+    fun canEncode(url: String): Boolean {
+        return isSupportedUrl(url) && unsafeUrlTokens.none(url::contains)
+    }
+
     fun encode(
         url: String,
         type: Type,
         expiryDays: Int,
         time: Long = System.currentTimeMillis(),
     ): String {
-        require(isSupportedUrl(url)) { "Only HTTP and HTTPS links can be shared" }
+        require(canEncode(url)) { "URL cannot be safely shared as a passphrase" }
         val random = Random(time)
         val encodedUrl = buildString {
             var index = 0
@@ -91,20 +98,23 @@ object SourceSharePassphrase {
             time + safeExpiryDays * MILLIS_PER_DAY
         }
         val expiryToken = expiresAt.toString().take(7)
-        return "复制口令到阅读导入${encodedUrl}！${type.code}©${expiryToken}¥${CUSTOM_WORD}^"
+        return "$PREFIX${encodedUrl}！${type.code}©${expiryToken}¥${CUSTOM_WORD}^"
     }
 
     fun decode(
         text: String,
         time: Long = System.currentTimeMillis(),
     ): DecodeResult {
-        val markerIndex = listOf(HTTP_MARKER, HTTPS_MARKER)
-            .map { text.indexOf(it) }
-            .filter { it >= 0 }
-            .minOrNull()
-            ?: return DecodeResult.NotFound
-        val typeSeparator = text.indexOf('！', markerIndex)
-        if (typeSeparator <= markerIndex) return DecodeResult.Invalid
+        val prefixIndex = text.indexOf(PREFIX)
+        if (prefixIndex < 0) return DecodeResult.NotFound
+        val urlStart = prefixIndex + PREFIX.length
+        if (!text.startsWith(HTTPS_MARKER, urlStart) &&
+            !text.startsWith(HTTP_MARKER, urlStart)
+        ) {
+            return DecodeResult.Invalid
+        }
+        val typeSeparator = text.indexOf('！', urlStart)
+        if (typeSeparator <= urlStart) return DecodeResult.Invalid
         val metadataSeparator = text.indexOf('©', typeSeparator + 1)
         if (metadataSeparator <= typeSeparator + 1) return DecodeResult.Invalid
         val expirySeparator = text.indexOf('¥', metadataSeparator + 1)
@@ -115,12 +125,15 @@ object SourceSharePassphrase {
         val type = Type.fromCode(text.substring(typeSeparator + 1, metadataSeparator))
             ?: return DecodeResult.Invalid
         val expiryToken = text.substring(metadataSeparator + 1, expirySeparator)
-        val expiresAt = expiryToken.toLongOrNull()?.let {
-            runCatching { Math.multiplyExact(it, EXPIRY_PRECISION) }.getOrNull()
-        } ?: return DecodeResult.Invalid
+        if (expiryToken != "0" &&
+            (expiryToken.length != 7 || expiryToken.any { it !in '0'..'9' })
+        ) {
+            return DecodeResult.Invalid
+        }
+        val expiresAt = expiryToken.toLong() * EXPIRY_PRECISION
         if (expiresAt > 0 && expiresAt < time) return DecodeResult.Expired
 
-        val url = decodeUrl(text.substring(markerIndex, typeSeparator))
+        val url = decodeUrl(text.substring(urlStart, typeSeparator))
         if (!isSupportedUrl(url)) return DecodeResult.Invalid
         return DecodeResult.Success(
             Value(
@@ -147,7 +160,7 @@ object SourceSharePassphrase {
     }
 
     private fun isSupportedUrl(url: String): Boolean {
-        return url.startsWith("https://") && url.length > "https://".length ||
-            url.startsWith("http://") && url.length > "http://".length
+        if (!url.startsWith("https://") && !url.startsWith("http://")) return false
+        return runCatching { URI(url).toURL().host.isNotBlank() }.getOrDefault(false)
     }
 }

--- a/app/src/main/java/io/legado/app/lib/dialogs/SourceSharePassphraseDialog.kt
+++ b/app/src/main/java/io/legado/app/lib/dialogs/SourceSharePassphraseDialog.kt
@@ -13,6 +13,7 @@ fun AlertBuilder<DialogInterface>.sourceSharePassphraseButton(
     url: String,
     type: SourceSharePassphrase.Type,
 ) {
+    if (!SourceSharePassphrase.canEncode(url)) return
     neutralButton(R.string.shibboleth) {
         val passphrase = SourceSharePassphrase.encode(
             url = url,

--- a/app/src/test/java/io/legado/app/help/SourceSharePassphraseTest.kt
+++ b/app/src/test/java/io/legado/app/help/SourceSharePassphraseTest.kt
@@ -1,23 +1,45 @@
 package io.legado.app.help
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SourceSharePassphraseTest {
 
+    private val mappingHeavyUrl = "https://example.com/path/file.json?key=4%2F5"
+    private val fixedTime = 1_789_344_000_000L
+
     @Test
-    fun decodesExistingHttpsPassphraseFormat() {
-        val result = SourceSharePassphrase.decode(
-            "复制口令到阅读导入#L:example电🛜1杠rules电串！sy©0¥Legado^"
+    fun decodesLegadoTFixturesForAllSupportedTypes() {
+        val expiresAt = 1_800_000_000_000L
+        val fixtures = mapOf(
+            SourceSharePassphrase.Type.BOOK_SOURCE to
+                "复制口令到阅读导入#L:example店🛜1刚path钢file店串?key=🕓拜2F五！sy©1800000¥Sigma^",
+            SourceSharePassphrase.Type.RSS_SOURCE to
+                "复制口令到阅读导入#L:example店🛜1刚path钢file店串?key=🕓拜2F五！dy©1800000¥Sigma^",
+            SourceSharePassphrase.Type.DICT_RULE to
+                "复制口令到阅读导入#L:example店🛜1刚path钢file店串?key=🕓拜2F五！zd©1800000¥Sigma^",
+            SourceSharePassphrase.Type.REPLACE_RULE to
+                "复制口令到阅读导入#L:example店🛜1刚path钢file店串?key=🕓拜2F五！jh©1800000¥Sigma^",
+            SourceSharePassphrase.Type.TOC_RULE to
+                "复制口令到阅读导入#L:example店🛜1刚path钢file店串?key=🕓拜2F五！ml©1800000¥Sigma^",
+            SourceSharePassphrase.Type.TTS_RULE to
+                "复制口令到阅读导入#L:example店🛜1刚path钢file店串?key=🕓拜2F五！ld©1800000¥Sigma^",
         )
 
-        assertTrue(result is SourceSharePassphrase.DecodeResult.Success)
-        val value = (result as SourceSharePassphrase.DecodeResult.Success).value
-        assertEquals("https://example.com/rules.json", value.url)
-        assertEquals(SourceSharePassphrase.Type.BOOK_SOURCE, value.type)
-        assertEquals(0L, value.expiresAt)
-        assertEquals("Legado", value.customWord)
+        fixtures.forEach { (type, fixture) ->
+            assertEquals(
+                fixture.replace("©1800000¥Sigma^", "©0¥Legado^"),
+                SourceSharePassphrase.encode(mappingHeavyUrl, type, 0, fixedTime),
+            )
+            assertEquals(
+                SourceSharePassphrase.DecodeResult.Success(
+                    SourceSharePassphrase.Value(mappingHeavyUrl, type, expiresAt, "Sigma")
+                ),
+                SourceSharePassphrase.decode(fixture, fixedTime),
+            )
+        }
     }
 
     @Test
@@ -94,5 +116,84 @@ class SourceSharePassphraseTest {
                 "复制口令到阅读导入#L:example电🛜1！xx©0¥Legado^"
             ),
         )
+    }
+
+    @Test
+    fun canEncodeRequiresSupportedSchemeAndHost() {
+        assertTrue(SourceSharePassphrase.canEncode("https://example.com/path"))
+        assertTrue(SourceSharePassphrase.canEncode("http://example.com/path"))
+        assertFalse(SourceSharePassphrase.canEncode("https:///missing-host"))
+        assertFalse(SourceSharePassphrase.canEncode("http:///missing-host"))
+        assertFalse(SourceSharePassphrase.canEncode("https://example.com:bad/path"))
+        assertFalse(SourceSharePassphrase.canEncode("HTTPS://example.com/path"))
+        assertFalse(SourceSharePassphrase.canEncode("not a url"))
+    }
+
+    @Test
+    fun canEncodeAndRoundTripInternationalizedHost() {
+        val url = "https://例子.测试/path"
+
+        assertTrue(SourceSharePassphrase.canEncode(url))
+        assertEquals(
+            SourceSharePassphrase.DecodeResult.Success(
+                SourceSharePassphrase.Value(
+                    url,
+                    SourceSharePassphrase.Type.BOOK_SOURCE,
+                    0,
+                    "Legado",
+                )
+            ),
+            SourceSharePassphrase.decode(
+                SourceSharePassphrase.encode(
+                    url,
+                    SourceSharePassphrase.Type.BOOK_SOURCE,
+                    0,
+                    fixedTime,
+                ),
+                fixedTime,
+            ),
+        )
+    }
+
+    @Test
+    fun canEncodeRejectsAmbiguousMappingTokens() {
+        listOf(
+            "https://example.com/path/电",
+            "https://example.com/path/🛜1",
+            "https://example.com/path#L:",
+        ).forEach { url ->
+            assertFalse(SourceSharePassphrase.canEncode(url))
+        }
+    }
+
+    @Test
+    fun canEncodeRejectsStructuralDelimiters() {
+        listOf("！", "©", "¥", "^").forEach { delimiter ->
+            assertFalse(SourceSharePassphrase.canEncode("https://example.com/path$delimiter"))
+        }
+    }
+
+    @Test
+    fun decodeRequiresFullPrefix() {
+        assertEquals(
+            SourceSharePassphrase.DecodeResult.NotFound,
+            SourceSharePassphrase.decode("#L:example电🛜1！sy©0¥Legado^"),
+        )
+        assertEquals(
+            SourceSharePassphrase.DecodeResult.NotFound,
+            SourceSharePassphrase.decode("口令到阅读导入#L:example电🛜1！sy©0¥Legado^"),
+        )
+    }
+
+    @Test
+    fun decodeRejectsInvalidExpiryTokens() {
+        listOf("", "00", "123456", "12345678", "abc", "١٢٣٤٥٦٧").forEach { expiry ->
+            assertEquals(
+                SourceSharePassphrase.DecodeResult.Invalid,
+                SourceSharePassphrase.decode(
+                    "复制口令到阅读导入#L:example电🛜1！sy©$expiry¥Legado^"
+                ),
+            )
+        }
     }
 }


### PR DESCRIPTION
## 变更
- 严格校验分享口令 URL 的协议、主机、映射歧义字符和结构分隔符
- 无法安全编码的链接不再显示口令按钮，避免点击时抛出异常
- 解码要求完整口令前缀，并校验有效期为 0 或 7 位数字
- 补充六类 LegadoT 固定样例、IDN 域名、HTTP 与异常边界回归测试

## 测试
- `:app:testReleaseUnitTest --tests io.legado.app.help.SourceSharePassphraseTest`（11 项通过）