### PR TITLE
RSS源编辑页折叠顶部选项

### DIFF
--- a/app/src/main/java/io/legado/app/ui/rss/source/edit/RssSourceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/rss/source/edit/RssSourceEditActivity.kt
@@ -267,6 +267,7 @@ class RssSourceEditActivity :
     }
 
     private fun initView() {
+        initOptionPanel()
         binding.tabLayout.addTab(binding.tabLayout.newTab().apply {
             setText(R.string.source_tab_base)
         })
@@ -334,6 +335,41 @@ class RssSourceEditActivity :
         }
     }
 
+    private fun initOptionPanel() {
+        binding.optionsHeader.setOnClickListener {
+            updateOptionPanel(binding.optionsContent.visibility != View.VISIBLE)
+        }
+        listOf(
+            binding.cbIsEnable,
+            binding.cbSingleUrl,
+            binding.cbIsEnableCookie,
+            binding.cbIsEnablePreload
+        ).forEach { checkBox ->
+            checkBox.setOnCheckedChangeListener { _, _ -> updateOptionPanel() }
+        }
+        updateOptionPanel(false)
+    }
+
+    private fun updateOptionPanel(expanded: Boolean = binding.optionsContent.visibility == View.VISIBLE) {
+        binding.optionsContent.visibility = if (expanded) View.VISIBLE else View.GONE
+        binding.ivOptionsExpand.setImageResource(
+            if (expanded) R.drawable.ic_expand_less else R.drawable.ic_expand_more
+        )
+        val action = getString(
+            if (expanded) R.string.book_intro_collapse else R.string.book_intro_expand
+        )
+        binding.tvOptionsSummary.text = listOf(
+            getString(R.string.is_enable) to binding.cbIsEnable.isChecked,
+            getString(R.string.single_url) to binding.cbSingleUrl.isChecked,
+            getString(R.string.auto_save_cookie) to binding.cbIsEnableCookie.isChecked,
+            getString(R.string.enable_preload) to binding.cbIsEnablePreload.isChecked
+        ).joinToString(" | ") { (label, checked) ->
+            "$label: ${getString(if (checked) R.string.yes else R.string.no)}"
+        }
+        binding.optionsHeader.contentDescription =
+            "${getString(R.string.setting)}, ${binding.tvOptionsSummary.text}, $action"
+    }
+
     private fun setEditEntities(tabPosition: Int?) {
         when (tabPosition) {
             1 -> adapter.editEntities = startEntities
@@ -352,6 +388,7 @@ class RssSourceEditActivity :
             binding.cbSingleUrl.isChecked = rs.singleUrl
             binding.cbIsEnableCookie.isChecked = rs.enabledCookieJar == true
             binding.cbIsEnablePreload.isChecked = rs.preload
+            updateOptionPanel()
             if (rs.type !in 0..<binding.spType.count) {
                 rs.type = 0
             }

--- a/app/src/main/res/layout/activity_rss_source_edit.xml
+++ b/app/src/main/res/layout/activity_rss_source_edit.xml
@@ -14,54 +14,128 @@
         app:displayHomeAsUp="true"
         app:title="@string/rss_source_edit" />
 
-    <HorizontalScrollView
+    <androidx.cardview.widget.CardView
+        android:id="@+id/options_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:scrollbars="none">
+        android:layout_marginHorizontal="8dp"
+        android:layout_marginTop="4dp"
+        app:cardBackgroundColor="@color/background_card"
+        app:cardCornerRadius="8dp"
+        app:cardElevation="0dp"
+        app:cardUseCompatPadding="false">
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingHorizontal="8dp"
-            tools:ignore="VisualLintBounds">
+            android:orientation="vertical">
 
-            <io.legado.app.lib.theme.view.ThemeCheckBox
-                android:id="@+id/cb_is_enable"
-                android:layout_width="wrap_content"
+            <LinearLayout
+                android:id="@+id/options_header"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:checked="true"
-                android:text="@string/is_enable"
-                tools:ignore="TouchTargetSizeCheck" />
+                android:clickable="true"
+                android:focusable="true"
+                android:foreground="?attr/selectableItemBackground"
+                android:gravity="center_vertical"
+                android:minHeight="48dp"
+                android:orientation="horizontal"
+                android:paddingStart="12dp"
+                android:paddingEnd="4dp">
 
-            <io.legado.app.lib.theme.view.ThemeCheckBox
-                android:id="@+id/cb_single_url"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:checked="false"
-                android:text="@string/single_url"
-                tools:ignore="TouchTargetSizeCheck" />
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:paddingVertical="4dp">
 
-            <io.legado.app.lib.theme.view.ThemeCheckBox
-                android:id="@+id/cb_is_enable_cookie"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:checked="true"
-                android:text="@string/auto_save_cookie"
-                tools:ignore="TouchTargetSizeCheck" />
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/setting"
+                        android:textColor="@color/primaryText"
+                        android:textSize="16sp" />
 
-            <io.legado.app.lib.theme.view.ThemeCheckBox
-                android:id="@+id/cb_is_enable_preload"
-                android:layout_width="wrap_content"
+                    <TextView
+                        android:id="@+id/tv_options_summary"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:ellipsize="end"
+                        android:singleLine="true"
+                        android:textColor="@color/secondaryText"
+                        android:textSize="12sp"
+                        tools:text="Enable: Yes | Single URL: No | CookieJar: Yes | Preload: No" />
+
+                </LinearLayout>
+
+                <ImageView
+                    android:id="@+id/iv_options_expand"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:importantForAccessibility="no"
+                    android:padding="8dp"
+                    android:src="@drawable/ic_expand_more"
+                    app:tint="@color/secondaryText" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/options_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:checked="false"
-                android:text="@string/enable_preload"
-                tools:ignore="TouchTargetSizeCheck" />
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <com.google.android.flexbox.FlexboxLayout
+                    android:id="@+id/options_switches"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingHorizontal="8dp"
+                    android:paddingBottom="4dp"
+                    app:alignItems="center"
+                    app:flexWrap="wrap"
+                    app:justifyContent="flex_start">
+
+                    <io.legado.app.lib.theme.view.ThemeCheckBox
+                        android:id="@+id/cb_is_enable"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:minHeight="48dp"
+                        android:text="@string/is_enable" />
+
+                    <io.legado.app.lib.theme.view.ThemeCheckBox
+                        android:id="@+id/cb_single_url"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="false"
+                        android:minHeight="48dp"
+                        android:text="@string/single_url" />
+
+                    <io.legado.app.lib.theme.view.ThemeCheckBox
+                        android:id="@+id/cb_is_enable_cookie"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="true"
+                        android:minHeight="48dp"
+                        android:text="@string/auto_save_cookie" />
+
+                    <io.legado.app.lib.theme.view.ThemeCheckBox
+                        android:id="@+id/cb_is_enable_preload"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="false"
+                        android:minHeight="48dp"
+                        android:text="@string/enable_preload" />
+
+                </com.google.android.flexbox.FlexboxLayout>
+
+            </LinearLayout>
 
         </LinearLayout>
 
-    </HorizontalScrollView>
+    </androidx.cardview.widget.CardView>
 
     <HorizontalScrollView
         android:layout_width="match_parent"

--- a/app/src/test/java/io/legado/app/ui/rss/source/edit/RssSourceEditLayoutTest.kt
+++ b/app/src/test/java/io/legado/app/ui/rss/source/edit/RssSourceEditLayoutTest.kt
@@ -1,0 +1,137 @@
+package io.legado.app.ui.rss.source.edit
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class RssSourceEditLayoutTest {
+
+    @Test
+    fun `options use a compact card with a dedicated accessible header`() {
+        val document = parse(LAYOUT_PATH)
+        val card = document.elementById("options_card")
+        val header = document.elementById("options_header")
+        val summary = document.elementById("tv_options_summary")
+
+        assertEquals(CARD_VIEW, card.tagName)
+        assertEquals("@color/background_card", card.appAttribute("cardBackgroundColor"))
+        assertEquals("8dp", card.appAttribute("cardCornerRadius"))
+        assertFalse(card.hasAttributeNS(ANDROID_NAMESPACE, "clickable"))
+        assertSame(card, header.parentNode?.parentNode)
+        assertEquals("48dp", header.androidAttribute("minHeight"))
+        assertEquals("true", header.androidAttribute("clickable"))
+        assertEquals("true", header.androidAttribute("focusable"))
+        assertEquals("true", summary.androidAttribute("singleLine"))
+        assertEquals("end", summary.androidAttribute("ellipsize"))
+        val arrow = document.elementById("iv_options_expand")
+        assertEquals("@color/secondaryText", arrow.appAttribute("tint"))
+        assertEquals("no", arrow.androidAttribute("importantForAccessibility"))
+    }
+
+    @Test
+    fun `four existing switches wrap inside content that starts collapsed`() {
+        val document = parse(LAYOUT_PATH)
+        val content = document.elementById("options_content")
+        val switches = document.elementById("options_switches")
+
+        assertEquals("gone", content.androidAttribute("visibility"))
+        assertEquals(FLEXBOX, switches.tagName)
+        assertEquals("wrap", switches.appAttribute("flexWrap"))
+        assertSame(content, switches.parentNode)
+        listOf(
+            "cb_is_enable",
+            "cb_single_url",
+            "cb_is_enable_cookie",
+            "cb_is_enable_preload"
+        ).forEach { id ->
+            val checkBox = document.elementById(id)
+            assertEquals(THEME_CHECK_BOX, checkBox.tagName)
+            assertSame(switches, checkBox.parentNode)
+            assertEquals("48dp", checkBox.androidAttribute("minHeight"))
+        }
+    }
+
+    @Test
+    fun `type selectors stay outside the collapsed option card`() {
+        val document = parse(LAYOUT_PATH)
+        val card = document.elementById("options_card")
+
+        listOf("sp_type", "ly_type").forEach { id ->
+            val selector = document.elementById(id)
+            assertFalse(selector.hasAncestorWithId("options_card"))
+            assertTrue(card.compareDocumentPosition(selector).toInt() and DOCUMENT_POSITION_FOLLOWING != 0)
+        }
+    }
+
+    @Test
+    fun `activity keeps summary and accessibility state in one update path`() {
+        val source = File(repositoryRoot, ACTIVITY_PATH).readText()
+        val initPanel = source.section("private fun initOptionPanel()", "private fun updateOptionPanel(")
+        val updatePanel = source.section("private fun updateOptionPanel(", "private fun setEditEntities(")
+
+        assertTrue(Regex("optionsHeader\\.setOnClickListener\\s*\\{").containsMatchIn(initPanel))
+        CHECK_BOX_BINDINGS.forEach { binding ->
+            assertTrue("$binding must refresh the summary", initPanel.contains(binding))
+            assertTrue("$binding must be represented in the summary", updatePanel.contains(binding))
+        }
+        assertTrue(Regex("optionsContent\\.visibility\\s*=\\s*if \\(expanded\\)").containsMatchIn(updatePanel))
+        assertTrue(Regex("ivOptionsExpand\\.setImageResource\\(").containsMatchIn(updatePanel))
+        assertTrue(Regex("optionsHeader\\.contentDescription\\s*=").containsMatchIn(updatePanel))
+    }
+
+    private fun parse(path: String): Document =
+        DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = true
+        }.newDocumentBuilder().parse(File(repositoryRoot, path))
+
+    private fun Document.elementById(id: String): Element {
+        val nodes = getElementsByTagName("*")
+        return (0 until nodes.length)
+            .map { nodes.item(it) as Element }
+            .first { it.androidAttribute("id").endsWith("/$id") }
+    }
+
+    private fun Element.hasAncestorWithId(id: String): Boolean =
+        generateSequence(parentNode) { it.parentNode }
+            .filterIsInstance<Element>()
+            .any { it.androidAttribute("id").endsWith("/$id") }
+
+    private fun Element.androidAttribute(name: String): String =
+        getAttributeNS(ANDROID_NAMESPACE, name)
+
+    private fun Element.appAttribute(name: String): String =
+        getAttributeNS(APP_NAMESPACE, name)
+
+    private fun String.section(start: String, end: String): String =
+        substringAfter(start).substringBefore(end)
+
+    private val repositoryRoot: File by lazy {
+        val userDir = requireNotNull(System.getProperty("user.dir"))
+        generateSequence(File(userDir)) { it.parentFile }
+            .first { File(it, "app/src/main").isDirectory }
+    }
+
+    private companion object {
+        const val LAYOUT_PATH = "app/src/main/res/layout/activity_rss_source_edit.xml"
+        const val ACTIVITY_PATH =
+            "app/src/main/java/io/legado/app/ui/rss/source/edit/RssSourceEditActivity.kt"
+        const val CARD_VIEW = "androidx.cardview.widget.CardView"
+        const val FLEXBOX = "com.google.android.flexbox.FlexboxLayout"
+        const val THEME_CHECK_BOX = "io.legado.app.lib.theme.view.ThemeCheckBox"
+        const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
+        const val APP_NAMESPACE = "http://schemas.android.com/apk/res-auto"
+        const val DOCUMENT_POSITION_FOLLOWING = 4
+        val CHECK_BOX_BINDINGS = listOf(
+            "binding.cbIsEnable",
+            "binding.cbSingleUrl",
+            "binding.cbIsEnableCookie",
+            "binding.cbIsEnablePreload"
+        )
+    }
+}


### PR DESCRIPTION
## 变更

- 将 RSS 源编辑页顶部四个开关收纳到默认折叠的选项卡中。
- 收起时显示各开关状态摘要，展开图标和无障碍描述同步更新。
- 保留类型与正文样式选择器的原有位置和行为。

## 验证

- `:app:testReleaseUnitTest --tests io.legado.app.ui.rss.source.edit.RssSourceEditLayoutTest`
- 4 tests, 0 failures, 0 errors, 0 skipped
- `git diff --check`