### PR TITLE
修复卷名分隔页正文显示

### DIFF
--- a/app/src/main/assets/web/help/md/jsHelp.md
+++ b/app/src/main/assets/web/help/md/jsHelp.md
@@ -828,7 +828,7 @@ function getBookInfo(book) {
 `isPay`、`resourceUrl`、`tag` 和 `wordCount`。
 
 卷名行推荐设置 `isVolume: true`，并令 `url` 与 `title` 完全相同。应用不会为这种行补全
-URL，打开时直接使用 `tag` 作为内容，不调用 `getContent`。
+URL，打开时作为空正文的卷名分隔页显示，不调用 `getContent`。
 
 #### getContent
 

--- a/app/src/main/java/io/legado/app/model/jsSource/JsSourceBook.kt
+++ b/app/src/main/java/io/legado/app/model/jsSource/JsSourceBook.kt
@@ -114,7 +114,7 @@ object JsSourceBook {
     ): String {
         if (chapter.isVolume && chapter.url.startsWith(chapter.title)) {
             Debug.log(source.bookSourceUrl, "⇒一级目录正文不解析")
-            return chapter.tag.orEmpty()
+            return ""
         }
         val engine = JsSourceEngine(source, coroutineContext)
         val content = engine.callFunction(

--- a/app/src/main/java/io/legado/app/model/webBook/WebBook.kt
+++ b/app/src/main/java/io/legado/app/model/webBook/WebBook.kt
@@ -412,7 +412,7 @@ object WebBook {
         }
         if (bookChapter.isVolume && bookChapter.url.startsWith(bookChapter.title)) {
             Debug.log(bookSource.bookSourceUrl, "⇒一级目录正文不解析规则")
-            return bookChapter.tag ?: ""
+            return ""
         }
         return if (bookChapter.url == book.bookUrl && !book.tocHtml.isNullOrEmpty()) {
             BookContent.analyzeContent(


### PR DESCRIPTION
## 修改
- Web 书源和 JS 书源遇到卷名占位章节时返回空正文
- 保留“不调用正文解析”的现有行为，避免章节 `tag` 或更新时间显示成正文
- 更新 JS 书源帮助中的卷名分隔页说明

## 验证
- `.\gradlew.bat :app:compileAppReleaseKotlin --offline --no-daemon --max-workers=1 --console=plain "-Pkotlin.compiler.execution.strategy=in-process"`
- `git diff --check`
