### PR TITLE
修复主页恢复时分享口令识别

### DIFF
--- a/app/src/main/java/io/legado/app/help/SourceSharePassphrase.kt
+++ b/app/src/main/java/io/legado/app/help/SourceSharePassphrase.kt
@@ -107,12 +107,12 @@ object SourceSharePassphrase {
     ): DecodeResult {
         val prefixIndex = text.indexOf(PREFIX)
         if (prefixIndex < 0) return DecodeResult.NotFound
-        val urlStart = prefixIndex + PREFIX.length
-        if (!text.startsWith(HTTPS_MARKER, urlStart) &&
-            !text.startsWith(HTTP_MARKER, urlStart)
-        ) {
-            return DecodeResult.Invalid
-        }
+        val markerSearchStart = prefixIndex + PREFIX.length
+        val urlStart = listOf(HTTPS_MARKER, HTTP_MARKER)
+            .map { text.indexOf(it, markerSearchStart) }
+            .filter { it >= 0 }
+            .minOrNull()
+            ?: return DecodeResult.Invalid
         val typeSeparator = text.indexOf('！', urlStart)
         if (typeSeparator <= urlStart) return DecodeResult.Invalid
         val metadataSeparator = text.indexOf('©', typeSeparator + 1)
@@ -125,15 +125,17 @@ object SourceSharePassphrase {
         val type = Type.fromCode(text.substring(typeSeparator + 1, metadataSeparator))
             ?: return DecodeResult.Invalid
         val expiryToken = text.substring(metadataSeparator + 1, expirySeparator)
-        if (expiryToken != "0" &&
-            (expiryToken.length != 7 || expiryToken.any { it !in '0'..'9' })
-        ) {
-            return DecodeResult.Invalid
+        if (expiryToken.any { it !in '0'..'9' }) return DecodeResult.Invalid
+        val expiresAt = when (expiryToken.length) {
+            1 -> if (expiryToken == "0") 0L else return DecodeResult.Invalid
+            7 -> expiryToken.toLong() * EXPIRY_PRECISION
+            10 -> expiryToken.toLong() * 1_000L
+            13 -> expiryToken.toLong()
+            else -> return DecodeResult.Invalid
         }
-        val expiresAt = expiryToken.toLong() * EXPIRY_PRECISION
         if (expiresAt > 0 && expiresAt < time) return DecodeResult.Expired
 
-        val url = decodeUrl(text.substring(urlStart, typeSeparator))
+        val url = decodeUrl(text.substring(urlStart, typeSeparator).trim())
         if (!isSupportedUrl(url)) return DecodeResult.Invalid
         return DecodeResult.Success(
             Value(

--- a/app/src/main/java/io/legado/app/help/SourceSharePassphraseImportPolicy.kt
+++ b/app/src/main/java/io/legado/app/help/SourceSharePassphraseImportPolicy.kt
@@ -2,24 +2,22 @@ package io.legado.app.help
 
 internal object SourceSharePassphraseImportPolicy {
 
-    fun shouldScheduleOnResume(privacyPolicyOk: Boolean, activityCount: Int): Boolean {
-        return privacyPolicyOk && activityCount == 1
+    fun shouldScheduleOnResume(privacyPolicyOk: Boolean): Boolean {
+        return privacyPolicyOk
     }
 
     fun canAwaitWindowFocus(
         privacyPolicyOk: Boolean,
-        activityCount: Int,
         isFinishing: Boolean,
         isResumed: Boolean,
         isFragmentStateSaved: Boolean
     ): Boolean {
-        return shouldScheduleOnResume(privacyPolicyOk, activityCount) &&
+        return shouldScheduleOnResume(privacyPolicyOk) &&
             !isFinishing && isResumed && !isFragmentStateSaved
     }
 
     fun canReadClipboard(
         privacyPolicyOk: Boolean,
-        activityCount: Int,
         isFinishing: Boolean,
         isResumed: Boolean,
         isFragmentStateSaved: Boolean,
@@ -27,7 +25,6 @@ internal object SourceSharePassphraseImportPolicy {
     ): Boolean {
         return canAwaitWindowFocus(
             privacyPolicyOk,
-            activityCount,
             isFinishing,
             isResumed,
             isFragmentStateSaved

--- a/app/src/main/java/io/legado/app/help/SourceSharePassphraseImportPolicy.kt
+++ b/app/src/main/java/io/legado/app/help/SourceSharePassphraseImportPolicy.kt
@@ -6,12 +6,31 @@ internal object SourceSharePassphraseImportPolicy {
         return privacyPolicyOk && activityCount == 1
     }
 
-    fun canReadClipboard(
+    fun canAwaitWindowFocus(
         privacyPolicyOk: Boolean,
+        activityCount: Int,
         isFinishing: Boolean,
         isResumed: Boolean,
         isFragmentStateSaved: Boolean
     ): Boolean {
-        return privacyPolicyOk && !isFinishing && isResumed && !isFragmentStateSaved
+        return shouldScheduleOnResume(privacyPolicyOk, activityCount) &&
+            !isFinishing && isResumed && !isFragmentStateSaved
+    }
+
+    fun canReadClipboard(
+        privacyPolicyOk: Boolean,
+        activityCount: Int,
+        isFinishing: Boolean,
+        isResumed: Boolean,
+        isFragmentStateSaved: Boolean,
+        hasWindowFocus: Boolean
+    ): Boolean {
+        return canAwaitWindowFocus(
+            privacyPolicyOk,
+            activityCount,
+            isFinishing,
+            isResumed,
+            isFragmentStateSaved
+        ) && hasWindowFocus
     }
 }

--- a/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
@@ -29,7 +29,6 @@ import io.legado.app.databinding.ActivityMainBinding
 import io.legado.app.databinding.DialogEditTextBinding
 import io.legado.app.help.AppWebDav
 import io.legado.app.help.BottomBarSkinManager
-import io.legado.app.help.LifecycleHelp
 import io.legado.app.help.SourceSharePassphrase
 import io.legado.app.help.SourceSharePassphraseImportPolicy
 import io.legado.app.help.book.BookHelp
@@ -178,8 +177,7 @@ class MainActivity : VMBaseActivity<ActivityMainBinding, MainViewModel>(),
     override fun onResume() {
         super.onResume()
         if (SourceSharePassphraseImportPolicy.shouldScheduleOnResume(
-                privacyPolicyOk = LocalConfig.privacyPolicyOk,
-                activityCount = LifecycleHelp.activitySize()
+                privacyPolicyOk = LocalConfig.privacyPolicyOk
             )
         ) {
             scheduleSourceSharePassphraseRead(500)
@@ -481,7 +479,6 @@ class MainActivity : VMBaseActivity<ActivityMainBinding, MainViewModel>(),
     private fun canAwaitPassphraseWindowFocus(): Boolean {
         return SourceSharePassphraseImportPolicy.canAwaitWindowFocus(
             privacyPolicyOk = LocalConfig.privacyPolicyOk,
-            activityCount = LifecycleHelp.activitySize(),
             isFinishing = isFinishing,
             isResumed = lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED),
             isFragmentStateSaved = supportFragmentManager.isStateSaved
@@ -501,7 +498,6 @@ class MainActivity : VMBaseActivity<ActivityMainBinding, MainViewModel>(),
             }
             if (!SourceSharePassphraseImportPolicy.canReadClipboard(
                     privacyPolicyOk = LocalConfig.privacyPolicyOk,
-                    activityCount = LifecycleHelp.activitySize(),
                     isFinishing = isFinishing,
                     isResumed = lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED),
                     isFragmentStateSaved = supportFragmentManager.isStateSaved,

--- a/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/main/MainActivity.kt
@@ -112,6 +112,8 @@ class MainActivity : VMBaseActivity<ActivityMainBinding, MainViewModel>(),
     }
     private var onUpBooksBadgeView: BadgeView? = null
     private var lastPassphraseText: String? = null
+    private var pendingPassphraseRead = false
+    private var passphraseReadGeneration = 0
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         upBottomMenu()
@@ -159,7 +161,7 @@ class MainActivity : VMBaseActivity<ActivityMainBinding, MainViewModel>(),
             binding.viewPagerMain.postDelayed(1000) {
                 viewModel.ruleSubsUp()
             }
-            readSourceSharePassphrase(1500)
+            scheduleSourceSharePassphraseRead(1500)
             //自动更新书籍
             val isAutoRefreshedBook = savedInstanceState?.getBoolean("isAutoRefreshedBook") ?: false
             if (AppConfig.autoRefreshBook && !isAutoRefreshedBook) {
@@ -180,7 +182,22 @@ class MainActivity : VMBaseActivity<ActivityMainBinding, MainViewModel>(),
                 activityCount = LifecycleHelp.activitySize()
             )
         ) {
-            readSourceSharePassphrase(500)
+            scheduleSourceSharePassphraseRead(500)
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        pendingPassphraseRead = false
+        passphraseReadGeneration++
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus && pendingPassphraseRead && canAwaitPassphraseWindowFocus()) {
+            readSourceSharePassphrase(200)
+        } else if (hasFocus) {
+            pendingPassphraseRead = false
         }
     }
 
@@ -453,13 +470,42 @@ class MainActivity : VMBaseActivity<ActivityMainBinding, MainViewModel>(),
         adapter.notifyDataSetChanged()
     }
 
-    private fun readSourceSharePassphrase(delayMillis: Long) {
+    private fun scheduleSourceSharePassphraseRead(delayMillis: Long) {
+        passphraseReadGeneration++
+        pendingPassphraseRead = true
+        if (hasWindowFocus()) {
+            readSourceSharePassphrase(delayMillis, passphraseReadGeneration)
+        }
+    }
+
+    private fun canAwaitPassphraseWindowFocus(): Boolean {
+        return SourceSharePassphraseImportPolicy.canAwaitWindowFocus(
+            privacyPolicyOk = LocalConfig.privacyPolicyOk,
+            activityCount = LifecycleHelp.activitySize(),
+            isFinishing = isFinishing,
+            isResumed = lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED),
+            isFragmentStateSaved = supportFragmentManager.isStateSaved
+        )
+    }
+
+    private fun readSourceSharePassphrase(
+        delayMillis: Long,
+        generation: Int = passphraseReadGeneration
+    ) {
+        pendingPassphraseRead = false
         binding.viewPagerMain.postDelayed(delayMillis) {
+            if (generation != passphraseReadGeneration) return@postDelayed
+            val hasWindowFocus = hasWindowFocus()
+            if (!hasWindowFocus) {
+                pendingPassphraseRead = canAwaitPassphraseWindowFocus()
+            }
             if (!SourceSharePassphraseImportPolicy.canReadClipboard(
                     privacyPolicyOk = LocalConfig.privacyPolicyOk,
+                    activityCount = LifecycleHelp.activitySize(),
                     isFinishing = isFinishing,
                     isResumed = lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED),
-                    isFragmentStateSaved = supportFragmentManager.isStateSaved
+                    isFragmentStateSaved = supportFragmentManager.isStateSaved,
+                    hasWindowFocus = hasWindowFocus
                 )
             ) {
                 return@postDelayed

--- a/app/src/test/java/io/legado/app/help/SourceSharePassphraseImportPolicyTest.kt
+++ b/app/src/test/java/io/legado/app/help/SourceSharePassphraseImportPolicyTest.kt
@@ -3,6 +3,7 @@ package io.legado.app.help
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 
 class SourceSharePassphraseImportPolicyTest {
 
@@ -15,46 +16,77 @@ class SourceSharePassphraseImportPolicyTest {
     }
 
     @Test
-    fun delayedReadRequiresActiveUnsavedActivity() {
-        assertTrue(
-            SourceSharePassphraseImportPolicy.canReadClipboard(
-                privacyPolicyOk = true,
-                isFinishing = false,
-                isResumed = true,
-                isFragmentStateSaved = false
-            )
+    fun focusRetryRequiresOnlyActiveMainActivity() {
+        assertTrue(canAwaitWindowFocus())
+        assertFalse(canAwaitWindowFocus(activityCount = 2))
+        assertFalse(canAwaitWindowFocus(isResumed = false))
+    }
+
+    @Test
+    fun clipboardReadRequiresFocusedActiveUnsavedActivity() {
+        assertTrue(canReadClipboard())
+        assertFalse(canReadClipboard(privacyPolicyOk = false))
+        assertFalse(canReadClipboard(isFinishing = true))
+        assertFalse(canReadClipboard(isResumed = false))
+        assertFalse(canReadClipboard(isFragmentStateSaved = true))
+        assertFalse(canReadClipboard(hasWindowFocus = false))
+    }
+
+    @Test
+    fun pausedActivityInvalidatesQueuedRead() {
+        val source = sequenceOf(
+            File("src/main/java/io/legado/app/ui/main/MainActivity.kt"),
+            File("app/src/main/java/io/legado/app/ui/main/MainActivity.kt")
+        ).firstOrNull(File::isFile)?.readText().orEmpty()
+        val onPause = source.section(
+            "override fun onPause()",
+            "override fun onWindowFocusChanged"
         )
-        assertFalse(
-            SourceSharePassphraseImportPolicy.canReadClipboard(
-                privacyPolicyOk = false,
-                isFinishing = false,
-                isResumed = true,
-                isFragmentStateSaved = false
-            )
+        val delayedRead = source.section(
+            "private fun readSourceSharePassphrase(",
+            "private fun upBottomBarSkin()"
         )
-        assertFalse(
-            SourceSharePassphraseImportPolicy.canReadClipboard(
-                privacyPolicyOk = true,
-                isFinishing = true,
-                isResumed = true,
-                isFragmentStateSaved = false
-            )
-        )
-        assertFalse(
-            SourceSharePassphraseImportPolicy.canReadClipboard(
-                privacyPolicyOk = true,
-                isFinishing = false,
-                isResumed = false,
-                isFragmentStateSaved = false
-            )
-        )
-        assertFalse(
-            SourceSharePassphraseImportPolicy.canReadClipboard(
-                privacyPolicyOk = true,
-                isFinishing = false,
-                isResumed = true,
-                isFragmentStateSaved = true
-            )
-        )
+
+        assertTrue(onPause.contains("pendingPassphraseRead = false"))
+        assertTrue(onPause.contains("passphraseReadGeneration++"))
+        assertTrue(delayedRead.contains("generation != passphraseReadGeneration"))
+    }
+
+    private fun canAwaitWindowFocus(
+        privacyPolicyOk: Boolean = true,
+        activityCount: Int = 1,
+        isFinishing: Boolean = false,
+        isResumed: Boolean = true,
+        isFragmentStateSaved: Boolean = false
+    ) = SourceSharePassphraseImportPolicy.canAwaitWindowFocus(
+        privacyPolicyOk,
+        activityCount,
+        isFinishing,
+        isResumed,
+        isFragmentStateSaved
+    )
+
+    private fun canReadClipboard(
+        privacyPolicyOk: Boolean = true,
+        activityCount: Int = 1,
+        isFinishing: Boolean = false,
+        isResumed: Boolean = true,
+        isFragmentStateSaved: Boolean = false,
+        hasWindowFocus: Boolean = true
+    ) = SourceSharePassphraseImportPolicy.canReadClipboard(
+        privacyPolicyOk,
+        activityCount,
+        isFinishing,
+        isResumed,
+        isFragmentStateSaved,
+        hasWindowFocus
+    )
+
+    private fun String.section(startMarker: String, endMarker: String): String {
+        val start = indexOf(startMarker)
+        val end = indexOf(endMarker, start + startMarker.length)
+        assertTrue("Missing section start: $startMarker", start >= 0)
+        assertTrue("Missing section end: $endMarker", end > start)
+        return substring(start, end)
     }
 }

--- a/app/src/test/java/io/legado/app/help/SourceSharePassphraseImportPolicyTest.kt
+++ b/app/src/test/java/io/legado/app/help/SourceSharePassphraseImportPolicyTest.kt
@@ -8,17 +8,14 @@ import java.io.File
 class SourceSharePassphraseImportPolicyTest {
 
     @Test
-    fun resumeCheckRequiresPrivacyConsentAndOnlyMainActivity() {
-        assertTrue(SourceSharePassphraseImportPolicy.shouldScheduleOnResume(true, 1))
-        assertFalse(SourceSharePassphraseImportPolicy.shouldScheduleOnResume(false, 1))
-        assertFalse(SourceSharePassphraseImportPolicy.shouldScheduleOnResume(true, 2))
-        assertFalse(SourceSharePassphraseImportPolicy.shouldScheduleOnResume(true, 0))
+    fun resumeCheckRequiresPrivacyConsent() {
+        assertTrue(SourceSharePassphraseImportPolicy.shouldScheduleOnResume(true))
+        assertFalse(SourceSharePassphraseImportPolicy.shouldScheduleOnResume(false))
     }
 
     @Test
-    fun focusRetryRequiresOnlyActiveMainActivity() {
+    fun focusRetryRequiresActiveMainActivity() {
         assertTrue(canAwaitWindowFocus())
-        assertFalse(canAwaitWindowFocus(activityCount = 2))
         assertFalse(canAwaitWindowFocus(isResumed = false))
     }
 
@@ -54,13 +51,11 @@ class SourceSharePassphraseImportPolicyTest {
 
     private fun canAwaitWindowFocus(
         privacyPolicyOk: Boolean = true,
-        activityCount: Int = 1,
         isFinishing: Boolean = false,
         isResumed: Boolean = true,
         isFragmentStateSaved: Boolean = false
     ) = SourceSharePassphraseImportPolicy.canAwaitWindowFocus(
         privacyPolicyOk,
-        activityCount,
         isFinishing,
         isResumed,
         isFragmentStateSaved
@@ -68,14 +63,12 @@ class SourceSharePassphraseImportPolicyTest {
 
     private fun canReadClipboard(
         privacyPolicyOk: Boolean = true,
-        activityCount: Int = 1,
         isFinishing: Boolean = false,
         isResumed: Boolean = true,
         isFragmentStateSaved: Boolean = false,
         hasWindowFocus: Boolean = true
     ) = SourceSharePassphraseImportPolicy.canReadClipboard(
         privacyPolicyOk,
-        activityCount,
         isFinishing,
         isResumed,
         isFragmentStateSaved,

--- a/app/src/test/java/io/legado/app/help/SourceSharePassphraseTest.kt
+++ b/app/src/test/java/io/legado/app/help/SourceSharePassphraseTest.kt
@@ -186,8 +186,46 @@ class SourceSharePassphraseTest {
     }
 
     @Test
+    fun decodeAllowsDecorationAfterFullPrefix() {
+        assertEquals(
+            SourceSharePassphrase.DecodeResult.Success(
+                SourceSharePassphrase.Value(
+                    "https://example.com/rules.json",
+                    SourceSharePassphrase.Type.BOOK_SOURCE,
+                    0,
+                    "Legado",
+                )
+            ),
+            SourceSharePassphrase.decode(
+                "复制口令到阅读导入 [书源] #L:example电🛜1杠rules电串！sy©0¥Legado^"
+            ),
+        )
+    }
+
+    @Test
+    fun decodeAcceptsSecondAndMillisecondExpiryTimestamps() {
+        val expected = SourceSharePassphrase.Value(
+            "https://example.com/rules.json",
+            SourceSharePassphrase.Type.BOOK_SOURCE,
+            1_800_000_000_000L,
+            "Legado",
+        )
+
+        listOf("1800000000", "1800000000000").forEach { expiry ->
+            assertEquals(
+                SourceSharePassphrase.DecodeResult.Success(expected),
+                SourceSharePassphrase.decode(
+                    "复制口令到阅读导入#L:example电🛜1杠rules电串！sy©$expiry¥Legado^",
+                    time = fixedTime,
+                ),
+            )
+        }
+    }
+
+    @Test
     fun decodeRejectsInvalidExpiryTokens() {
-        listOf("", "00", "123456", "12345678", "abc", "١٢٣٤٥٦٧").forEach { expiry ->
+        listOf("", "00", "123456", "12345678", "12345678901", "abc", "١٢٣٤٥٦٧")
+            .forEach { expiry ->
             assertEquals(
                 SourceSharePassphrase.DecodeResult.Invalid,
                 SourceSharePassphrase.decode(


### PR DESCRIPTION
## 修改
- 主页面恢复后等待窗口真正获得焦点再读取分享口令，并在暂停时使排队读取失效
- 去除对 Activity 数量的依赖，修复从应用内部页面返回主页时漏识别剪贴板口令
- 兼容 10 位秒级和 13 位毫秒级有效期时间戳，继续校验完整前缀、类型和有效期
- 补充焦点生命周期、隐私授权、排队读取和时间戳边界测试

## 验证
- `.\gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.help.SourceSharePassphraseImportPolicyTest --tests io.legado.app.help.SourceSharePassphraseTest --offline --no-daemon --max-workers=1 --console=plain "-Pkotlin.compiler.execution.strategy=in-process"`
- 17 项测试通过
- `git diff --check`
