### PR TITLE
JavaScript 书源编辑器增加登录入口

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/source/edit/JsSourceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/edit/JsSourceEditActivity.kt
@@ -14,6 +14,7 @@ import io.legado.app.databinding.ActivityJsSourceEditBinding
 import io.legado.app.model.jsSource.JsSourceUpsert
 import io.legado.app.ui.book.source.debug.BookSourceDebugActivity
 import io.legado.app.ui.code.CodeEditActivity
+import io.legado.app.ui.login.SourceLoginActivity
 import io.legado.app.utils.StartActivityContract
 import io.legado.app.utils.toastOnUi
 import io.legado.app.utils.viewbindingdelegate.viewBinding
@@ -53,14 +54,22 @@ class JsSourceEditActivity : BaseActivity<ActivityJsSourceEditBinding>(imageBg =
             return@registerForActivityResult
         }
         pendingText = text
-        val debugRequested = result.data?.getStringExtra(CodeEditActivity.EXTRA_RESULT_ACTION) ==
-            CodeEditActivity.RESULT_ACTION_DEBUG_SOURCE
-        stage = stageForEditorResult(debugRequested)
-        if (debugRequested) {
-            saveForDebug(text)
-        } else {
-            saveSource(text)
+        val action = result.data?.getStringExtra(CodeEditActivity.EXTRA_RESULT_ACTION)
+        val debugRequested = action == CodeEditActivity.RESULT_ACTION_DEBUG_SOURCE
+        val loginRequested = action == CodeEditActivity.RESULT_ACTION_LOGIN_SOURCE
+        stage = stageForEditorResult(debugRequested, loginRequested)
+        when {
+            debugRequested -> saveForDebug(text)
+            loginRequested -> saveForLogin(text)
+            else -> saveSource(text)
         }
+    }
+
+    private val loginResult = registerForActivityResult(
+        StartActivityContract(SourceLoginActivity::class.java)
+    ) {
+        stage = stage.afterLoginResult()
+        pendingText?.let(::openEditor) ?: super.finish()
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -82,7 +91,9 @@ class JsSourceEditActivity : BaseActivity<ActivityJsSourceEditBinding>(imageBg =
                 JsSourceEditRestoreAction.OPEN_EDITOR -> openEditor(text)
                 JsSourceEditRestoreAction.SAVE_AND_FINISH -> saveSource(text)
                 JsSourceEditRestoreAction.SAVE_FOR_DEBUG -> saveForDebug(text)
+                JsSourceEditRestoreAction.SAVE_FOR_LOGIN -> saveForLogin(text)
                 JsSourceEditRestoreAction.LAUNCH_DEBUG -> launchDebugWhenResumed()
+                JsSourceEditRestoreAction.LAUNCH_LOGIN -> launchLoginWhenResumed()
                 JsSourceEditRestoreAction.AWAIT_RESULT -> Unit
             }
         }
@@ -104,6 +115,7 @@ class JsSourceEditActivity : BaseActivity<ActivityJsSourceEditBinding>(imageBg =
             putExtra("languageName", "source.js")
             putExtra("returnUnchangedText", true)
             putExtra(CodeEditActivity.EXTRA_SHOW_DEBUG_SOURCE, true)
+            putExtra(CodeEditActivity.EXTRA_SHOW_LOGIN_SOURCE, true)
         }
     }
 
@@ -125,6 +137,37 @@ class JsSourceEditActivity : BaseActivity<ActivityJsSourceEditBinding>(imageBg =
                 if (stage != JsSourceEditStage.DEBUG_READY) return@withStateAtLeast
                 stage = JsSourceEditStage.DEBUG_OPEN
                 debugResult.launch {
+                    putExtra("key", sourceUrl)
+                }
+            }
+        }
+    }
+
+    private fun saveForLogin(text: String) {
+        saveSource(text, showSuccessToast = false, finishAfterSave = false) { source ->
+            if (source.hasLogin()) {
+                launchLoginWhenResumed()
+            } else {
+                stage = JsSourceEditStage.READY
+                toastOnUi(R.string.source_no_login)
+                pendingText?.let(::openEditor) ?: super.finish()
+            }
+        }
+    }
+
+    private fun launchLoginWhenResumed() {
+        val sourceUrl = openedSourceUrl ?: run {
+            val text = pendingText ?: return super.finish()
+            stage = JsSourceEditStage.SAVING_FOR_LOGIN
+            saveForLogin(text)
+            return
+        }
+        lifecycleScope.launch {
+            lifecycle.withStateAtLeast(Lifecycle.State.RESUMED) {
+                if (stage != JsSourceEditStage.LOGIN_READY) return@withStateAtLeast
+                stage = JsSourceEditStage.LOGIN_OPEN
+                loginResult.launch {
+                    putExtra("type", "bookSource")
                     putExtra("key", sourceUrl)
                 }
             }

--- a/app/src/main/java/io/legado/app/ui/book/source/edit/JsSourceEditFlow.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/edit/JsSourceEditFlow.kt
@@ -5,23 +5,31 @@ internal enum class JsSourceEditStage {
     EDITOR_OPEN,
     SAVING,
     SAVING_FOR_DEBUG,
+    SAVING_FOR_LOGIN,
     DEBUG_READY,
     DEBUG_OPEN,
+    LOGIN_READY,
+    LOGIN_OPEN,
 }
 
 internal enum class JsSourceEditRestoreAction {
     OPEN_EDITOR,
     SAVE_AND_FINISH,
     SAVE_FOR_DEBUG,
+    SAVE_FOR_LOGIN,
     LAUNCH_DEBUG,
+    LAUNCH_LOGIN,
     AWAIT_RESULT,
 }
 
-internal fun stageForEditorResult(debugRequested: Boolean): JsSourceEditStage {
-    return if (debugRequested) {
-        JsSourceEditStage.SAVING_FOR_DEBUG
-    } else {
-        JsSourceEditStage.SAVING
+internal fun stageForEditorResult(
+    debugRequested: Boolean,
+    loginRequested: Boolean = false,
+): JsSourceEditStage {
+    return when {
+        loginRequested -> JsSourceEditStage.SAVING_FOR_LOGIN
+        debugRequested -> JsSourceEditStage.SAVING_FOR_DEBUG
+        else -> JsSourceEditStage.SAVING
     }
 }
 
@@ -30,9 +38,12 @@ internal fun JsSourceEditStage.restoreAction(): JsSourceEditRestoreAction {
         JsSourceEditStage.READY -> JsSourceEditRestoreAction.OPEN_EDITOR
         JsSourceEditStage.SAVING -> JsSourceEditRestoreAction.SAVE_AND_FINISH
         JsSourceEditStage.SAVING_FOR_DEBUG -> JsSourceEditRestoreAction.SAVE_FOR_DEBUG
+        JsSourceEditStage.SAVING_FOR_LOGIN -> JsSourceEditRestoreAction.SAVE_FOR_LOGIN
         JsSourceEditStage.DEBUG_READY -> JsSourceEditRestoreAction.LAUNCH_DEBUG
+        JsSourceEditStage.LOGIN_READY -> JsSourceEditRestoreAction.LAUNCH_LOGIN
         JsSourceEditStage.EDITOR_OPEN,
-        JsSourceEditStage.DEBUG_OPEN -> JsSourceEditRestoreAction.AWAIT_RESULT
+        JsSourceEditStage.DEBUG_OPEN,
+        JsSourceEditStage.LOGIN_OPEN -> JsSourceEditRestoreAction.AWAIT_RESULT
     }
 }
 
@@ -40,6 +51,7 @@ internal fun JsSourceEditStage.afterSuccessfulSave(): JsSourceEditStage {
     return when (this) {
         JsSourceEditStage.SAVING -> JsSourceEditStage.READY
         JsSourceEditStage.SAVING_FOR_DEBUG -> JsSourceEditStage.DEBUG_READY
+        JsSourceEditStage.SAVING_FOR_LOGIN -> JsSourceEditStage.LOGIN_READY
         else -> error("Unexpected successful save from $this")
     }
 }
@@ -47,6 +59,13 @@ internal fun JsSourceEditStage.afterSuccessfulSave(): JsSourceEditStage {
 internal fun JsSourceEditStage.afterDebugResult(): JsSourceEditStage {
     check(this == JsSourceEditStage.DEBUG_OPEN) {
         "Unexpected debug result from $this"
+    }
+    return JsSourceEditStage.READY
+}
+
+internal fun JsSourceEditStage.afterLoginResult(): JsSourceEditStage {
+    check(this == JsSourceEditStage.LOGIN_OPEN) {
+        "Unexpected login result from $this"
     }
     return JsSourceEditStage.READY
 }

--- a/app/src/main/java/io/legado/app/ui/code/CodeEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/code/CodeEditActivity.kt
@@ -58,8 +58,10 @@ class CodeEditActivity :
     CurlAnalyzeUrlDialog.Callback {
     companion object {
         const val EXTRA_SHOW_DEBUG_SOURCE = "showDebugSourceAction"
+        const val EXTRA_SHOW_LOGIN_SOURCE = "showLoginSourceAction"
         const val EXTRA_RESULT_ACTION = "resultAction"
         const val RESULT_ACTION_DEBUG_SOURCE = "debugSource"
+        const val RESULT_ACTION_LOGIN_SOURCE = "loginSource"
 
         private var isInitialized = false
         private var findText = ""
@@ -78,6 +80,7 @@ class CodeEditActivity :
     private var searchOptions: SearchOptions? = null
     private var menuSaveBtn: MenuItem? = null
     private var menuDebugSourceBtn: MenuItem? = null
+    private var menuLoginSourceBtn: MenuItem? = null
     private var useSafeEditor = false
     private var safeEditor: WebView? = null
     private var safeEditorStatus = SafeEditorStatus.IDLE
@@ -253,6 +256,7 @@ class CodeEditActivity :
             !safeEditorReadPending
         menuSaveBtn?.isEnabled = enabled
         menuDebugSourceBtn?.isEnabled = enabled && isDebugSourceActionEnabled()
+        menuLoginSourceBtn?.isEnabled = enabled && isLoginSourceActionEnabled()
     }
 
     private fun buildSafeEditorHtml(text: String): String {
@@ -587,6 +591,10 @@ class CodeEditActivity :
         return intent.getBooleanExtra(EXTRA_SHOW_DEBUG_SOURCE, false)
     }
 
+    private fun isLoginSourceActionEnabled(): Boolean {
+        return intent.getBooleanExtra(EXTRA_SHOW_LOGIN_SOURCE, false)
+    }
+
     override fun upEdit(fontSize: Int?, autoComplete: Boolean?, autoWarp: Boolean?, editNonPrintable: Int?) {
         if (useSafeEditor) return
         if (fontSize != null) {
@@ -632,6 +640,7 @@ class CodeEditActivity :
         menuInflater.inflate(R.menu.code_edit_activity, menu)
         menuSaveBtn = menu.findItem(R.id.menu_save)
         menuDebugSourceBtn = menu.findItem(R.id.menu_debug_source)
+        menuLoginSourceBtn = menu.findItem(R.id.menu_login)
         updateEditorMenu(menu)
         return super.onCompatCreateOptionsMenu(menu)
     }
@@ -643,6 +652,9 @@ class CodeEditActivity :
 
     private fun updateEditorMenu(menu: Menu) {
         val showSoraActions = !useSafeEditor
+        val canReturnText = viewModel.writable &&
+            (!useSafeEditor ||
+                (safeEditorStatus == SafeEditorStatus.READY && !safeEditorReadPending))
         menu.findItem(R.id.menu_search)?.isVisible = showSoraActions
         menu.findItem(R.id.menu_change_theme)?.isVisible = showSoraActions
         menu.findItem(R.id.menu_format_code)?.isVisible = showSoraActions
@@ -653,18 +665,21 @@ class CodeEditActivity :
         }
         menu.findItem(R.id.menu_save)?.apply {
             isVisible = viewModel.writable
-            isEnabled = viewModel.writable &&
-                (!useSafeEditor ||
-                    (safeEditorStatus == SafeEditorStatus.READY && !safeEditorReadPending))
+            isEnabled = canReturnText
         }
         menu.findItem(R.id.menu_debug_source)?.apply {
             isVisible = shouldShowDebugSourceAction(
                 viewModel.writable,
                 isDebugSourceActionEnabled()
             )
-            isEnabled = viewModel.writable &&
-                (!useSafeEditor ||
-                    (safeEditorStatus == SafeEditorStatus.READY && !safeEditorReadPending))
+            isEnabled = canReturnText
+        }
+        menu.findItem(R.id.menu_login)?.apply {
+            isVisible = shouldShowLoginSourceAction(
+                viewModel.writable,
+                isLoginSourceActionEnabled()
+            )
+            isEnabled = canReturnText
         }
     }
 
@@ -793,6 +808,7 @@ class CodeEditActivity :
             R.id.menu_search -> if (!useSafeEditor) search()
             R.id.menu_save -> save(false)
             R.id.menu_debug_source -> returnText(RESULT_ACTION_DEBUG_SOURCE)
+            R.id.menu_login -> returnText(RESULT_ACTION_LOGIN_SOURCE)
             R.id.menu_format_code -> if (!useSafeEditor) viewModel.formatCode(editor)
             R.id.menu_curl_analyze_url -> showCurlAnalyzeUrlConverter()
             R.id.menu_change_theme -> if (!useSafeEditor) showDialogFragment(ChangeThemeDialog())
@@ -912,5 +928,9 @@ class CodeEditActivity :
 }
 
 internal fun shouldShowDebugSourceAction(writable: Boolean, requested: Boolean): Boolean {
+    return writable && requested
+}
+
+internal fun shouldShowLoginSourceAction(writable: Boolean, requested: Boolean): Boolean {
     return writable && requested
 }

--- a/app/src/main/res/menu/code_edit_activity.xml
+++ b/app/src/main/res/menu/code_edit_activity.xml
@@ -24,6 +24,12 @@
         app:showAsAction="always" />
 
     <item
+        android:id="@+id/menu_login"
+        android:title="@string/login"
+        android:visible="false"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_change_theme"
         android:title="@string/change_theme"
         app:showAsAction="never" />

--- a/app/src/test/java/io/legado/app/ui/book/source/edit/JsSourceDirectDebugTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/source/edit/JsSourceDirectDebugTest.kt
@@ -1,6 +1,7 @@
 package io.legado.app.ui.book.source.edit
 
 import io.legado.app.ui.code.shouldShowDebugSourceAction
+import io.legado.app.ui.code.shouldShowLoginSourceAction
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -18,11 +19,23 @@ class JsSourceDirectDebugTest {
     }
 
     @Test
+    fun `optional login action requires writable editor and explicit request`() {
+        assertFalse(shouldShowLoginSourceAction(writable = false, requested = false))
+        assertFalse(shouldShowLoginSourceAction(writable = false, requested = true))
+        assertFalse(shouldShowLoginSourceAction(writable = true, requested = false))
+        assertTrue(shouldShowLoginSourceAction(writable = true, requested = true))
+    }
+
+    @Test
     fun `editor result selects the correct save flow`() {
         assertEquals(JsSourceEditStage.SAVING, stageForEditorResult(debugRequested = false))
         assertEquals(
             JsSourceEditStage.SAVING_FOR_DEBUG,
             stageForEditorResult(debugRequested = true),
+        )
+        assertEquals(
+            JsSourceEditStage.SAVING_FOR_LOGIN,
+            stageForEditorResult(debugRequested = false, loginRequested = true),
         )
     }
 
@@ -36,6 +49,10 @@ class JsSourceDirectDebugTest {
             JsSourceEditRestoreAction.SAVE_FOR_DEBUG,
             JsSourceEditStage.SAVING_FOR_DEBUG.restoreAction(),
         )
+        assertEquals(
+            JsSourceEditRestoreAction.SAVE_FOR_LOGIN,
+            JsSourceEditStage.SAVING_FOR_LOGIN.restoreAction(),
+        )
     }
 
     @Test
@@ -47,6 +64,10 @@ class JsSourceDirectDebugTest {
         assertEquals(
             JsSourceEditRestoreAction.AWAIT_RESULT,
             JsSourceEditStage.DEBUG_OPEN.restoreAction(),
+        )
+        assertEquals(
+            JsSourceEditRestoreAction.AWAIT_RESULT,
+            JsSourceEditStage.LOGIN_OPEN.restoreAction(),
         )
     }
 
@@ -64,6 +85,14 @@ class JsSourceDirectDebugTest {
             JsSourceEditStage.READY,
             JsSourceEditStage.SAVING.afterSuccessfulSave(),
         )
+        assertEquals(
+            JsSourceEditStage.LOGIN_READY,
+            JsSourceEditStage.SAVING_FOR_LOGIN.afterSuccessfulSave(),
+        )
+        assertEquals(
+            JsSourceEditRestoreAction.LAUNCH_LOGIN,
+            JsSourceEditStage.LOGIN_READY.restoreAction(),
+        )
     }
 
     @Test
@@ -71,6 +100,10 @@ class JsSourceDirectDebugTest {
         assertEquals(
             JsSourceEditStage.READY,
             JsSourceEditStage.DEBUG_OPEN.afterDebugResult(),
+        )
+        assertEquals(
+            JsSourceEditStage.READY,
+            JsSourceEditStage.LOGIN_OPEN.afterLoginResult(),
         )
     }
 
@@ -80,10 +113,29 @@ class JsSourceDirectDebugTest {
         val sourceEditor = projectFile(
             "app/src/main/java/io/legado/app/ui/book/source/edit/JsSourceEditActivity.kt"
         ).readText()
+        val debugLauncher = sourceEditor.indexOf("private val debugResult")
+        val editorLauncher = sourceEditor.indexOf("private val editorResult")
+        val loginLauncher = sourceEditor.indexOf("private val loginResult")
+        val debugMenuItem = codeEditorMenu
+            .substringAfter("android:id=\"@+id/menu_debug_source\"")
+            .substringBefore("/>")
+        val loginMenuItem = codeEditorMenu
+            .substringAfter("android:id=\"@+id/menu_login\"")
+            .substringBefore("/>")
 
         assertTrue(codeEditorMenu.contains("android:id=\"@+id/menu_debug_source\""))
-        assertTrue(codeEditorMenu.contains("android:visible=\"false\""))
+        assertTrue(codeEditorMenu.contains("android:id=\"@+id/menu_login\""))
+        assertTrue(debugMenuItem.contains("android:visible=\"false\""))
+        assertTrue(loginMenuItem.contains("android:visible=\"false\""))
+        assertTrue(debugLauncher >= 0 && debugLauncher < editorLauncher)
+        assertTrue(editorLauncher < loginLauncher)
         assertTrue(sourceEditor.contains("putExtra(CodeEditActivity.EXTRA_SHOW_DEBUG_SOURCE, true)"))
+        assertTrue(sourceEditor.contains("putExtra(CodeEditActivity.EXTRA_SHOW_LOGIN_SOURCE, true)"))
+        assertTrue(sourceEditor.contains("StartActivityContract(SourceLoginActivity::class.java)"))
+        assertTrue(sourceEditor.contains("if (source.hasLogin())"))
+        assertTrue(sourceEditor.contains("toastOnUi(R.string.source_no_login)"))
+        assertTrue(sourceEditor.contains("putExtra(\"type\", \"bookSource\")"))
+        assertTrue(sourceEditor.contains("putExtra(\"key\", sourceUrl)"))
         assertTrue(sourceEditor.contains("outState.putString(STATE_STAGE, stage.name)"))
         assertTrue(sourceEditor.contains("catch (error: CancellationException)"))
         assertTrue(sourceEditor.contains("withStateAtLeast(Lifecycle.State.RESUMED)"))


### PR DESCRIPTION
## 修改
- JavaScript 单文件书源编辑器增加直接登录操作
- 登录前先保存当前脚本，确保登录页使用的是编辑器中的最新书源配置
- 登录完成后返回原编辑位置；旋转或 Activity 重建时保留保存、启动登录和等待结果状态
- 未配置登录能力时提示并返回编辑器
- 扩展编辑流程回归测试，覆盖登录状态转换和恢复路径

## 验证
- `JsSourceDirectDebugTest`：8 项通过
- `git diff --check`
