### PR TITLE
修复书架阅读进度条轨道配色

### DIFF
--- a/app/src/main/java/io/legado/app/ui/main/bookshelf/BookshelfReadProgress.kt
+++ b/app/src/main/java/io/legado/app/ui/main/bookshelf/BookshelfReadProgress.kt
@@ -1,11 +1,13 @@
 package io.legado.app.ui.main.bookshelf
 
+import android.graphics.Color
 import android.widget.TextView
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import io.legado.app.data.entities.Book
 import io.legado.app.help.book.readProgress
 import io.legado.app.help.config.AppConfig
 import io.legado.app.lib.theme.accentColor
+import io.legado.app.utils.ColorUtils
 import io.legado.app.utils.gone
 import io.legado.app.utils.visible
 import kotlin.math.roundToInt
@@ -23,7 +25,9 @@ fun LinearProgressIndicator.updateBookshelfReadProgress(
     }
 
     val progressPercent = (progressFraction * 100).roundToInt()
-    setIndicatorColor(context.accentColor)
+    val accent = context.accentColor
+    setIndicatorColor(accent)
+    trackColor = ColorUtils.withAlpha(accent, Color.alpha(trackColor) / 255f)
     progress = progressPercent
     visible()
     percentView?.apply {


### PR DESCRIPTION
## 修改
- 书架阅读进度条的进度色继续使用当前主题强调色
- 轨道色改为同一强调色并保留原有透明度，避免主题切换后轨道仍显示旧色系
- 不新增固定颜色资源，所有书架样式继续复用同一更新函数

## 验证
- `git diff --check`
- GitHub Actions `release`、`releaseA`
