### PR TITLE
补充书源导入链接跳转说明

### DIFF
--- a/app/src/main/assets/web/help/md/jsHelp.md
+++ b/app/src/main/assets/web/help/md/jsHelp.md
@@ -599,6 +599,7 @@ cache.deleteMemory(key: String)
 ```js
 // 跳转外部链接，传入http链接或者scheme跳转到浏览器或其他应用
 // 指定mimeType，可以跳转指定类型应用，例如（video/*）
+// legado:// 或 yuedu:// 导入链接会直接打开应用内导入确认页
 java.openUrl(url: String, mimeType: String = null)
 ```
 ## 视频播放器函数


### PR DESCRIPTION
## 变更内容
- 补充 `java.openUrl` 对 `legado://` 和 `yuedu://` 导入链接的行为说明
- 明确此类链接会直接进入应用内导入确认页

## 验证
- `git diff --check`
- 对照 `JsExtensions.openUrl` 当前实现
