### PR TITLE
修复 Web 资源发布遗漏组件声明

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -59,7 +59,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7.2.0
         with:
           commit_message: Bump web ${{ env.APP_VER}}
-          file_pattern: app/src/main/assets/web/vue/
+          file_pattern: app/src/main/assets/web/vue/ modules/web/src/components.d.ts
           skip_fetch: true
           skip_push: true
 

--- a/app/src/test/java/io/legado/app/ci/WebWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/WebWorkflowTest.kt
@@ -33,6 +33,7 @@ class WebWorkflowTest {
         assertTrue(workflowText.contains(masterPush))
         assertTrue(workflowText.contains("skip_fetch: true"))
         assertTrue(workflowText.contains("skip_push: true"))
+        assertTrue(workflowText.contains("file_pattern: app/src/main/assets/web/vue/ modules/web/src/components.d.ts"))
         assertTrue(workflowText.contains("bash .github/scripts/push-web-assets.sh"))
     }
 }


### PR DESCRIPTION
## 变更
- Web 构建自动提交静态资源时一并提交自动生成的组件声明
- 增加工作流契约检查，防止生成文件残留导致回推前 rebase 失败

## 验证
- git diff --check
- 静态契约检查通过
- 等待 GitHub Actions