### PR TITLE
docs: correct webView source helper signature

### DIFF
--- a/app/src/main/assets/web/help/md/jsHelp.md
+++ b/app/src/main/assets/web/help/md/jsHelp.md
@@ -231,7 +231,7 @@ java.webView(html: String?, url: String?, js: String?, cacheFirst: Boolean = fal
 java.webViewGetOverrideUrl(html: String?, url: String?, js: String?, overrideUrlRegex: String, cacheFirst: Boolean = false, delayTime: Long = 0): String?
 
 * 使用webView获取资源url
-java.webViewGetOverrideUrl(html: String?, url: String?, js: String?, overrideUrlRegex: String, cacheFirst: Boolean = false, delayTime: Long = 0): String?
+java.webViewGetSource(html: String?, url: String?, js: String?, sourceRegex: String, cacheFirst: Boolean = false, delayTime: Long = 0): String?
 
 * 使用内置浏览器打开链接，可用于获取验证码 手动验证网站防爬
 * @param url 要打开的链接


### PR DESCRIPTION
## Summary
- Correct the jsHelp entry under the resource URL section to document java.webViewGetSource with its sourceRegex parameter.
- Keep the documented contract aligned with the existing runtime overloads and editor completion.

## Validation
- git diff --check
- UTF-8 resource contract check passed for the corrected signature and section.
