### PR TITLE
fix: explicitly enable predictive back callbacks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
         android:name=".App"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="${app_name}"

--- a/app/src/test/java/io/legado/app/base/PredictiveBackTest.kt
+++ b/app/src/test/java/io/legado/app/base/PredictiveBackTest.kt
@@ -1,6 +1,7 @@
 package io.legado.app.base
 
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 
@@ -18,6 +19,6 @@ class PredictiveBackTest {
         assertFalse(blanketFinishCallback.containsMatchIn(baseActivity))
 
         val manifest = File("src/main/AndroidManifest.xml").readText()
-        assertFalse(manifest.contains("""android:enableOnBackInvokedCallback="false"""))
+        assertTrue(manifest.contains("""android:enableOnBackInvokedCallback="true"""))
     }
 }


### PR DESCRIPTION
## Summary

- explicitly opt into `OnBackInvokedCallback` dispatch across Android 13-15
- tighten the existing regression test to require the manifest opt-in

## Root cause

On Android 13-15, omitting the application-level `enableOnBackInvokedCallback` attribute defaults to legacy back dispatch. Android 16 enables it by default for apps targeting API 36, but that does not cover older supported OS versions. The existing test only rejected an explicit `false` value.

## Validation

- parsed `AndroidManifest.xml` as XML and verified the namespaced attribute is `true`
- `git diff --check`
