### PR TITLE
补充阅读菜单自定义按钮无障碍标签

### DIFF
--- a/app/src/main/res/layout/view_read_menu.xml
+++ b/app/src/main/res/layout/view_read_menu.xml
@@ -64,12 +64,12 @@
                 android:paddingStart="8dp"
                 android:paddingEnd="4dp"
                 android:src="@drawable/ic_custom"
+                android:contentDescription="@string/custom_button"
                 android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="@+id/tv_chapter_url"
                 app:layout_constraintRight_toLeftOf="@+id/tv_source_action"
                 app:layout_constraintTop_toTopOf="parent"
-                tools:visibility="visible"
-                tools:ignore="ContentDescription" />
+                tools:visibility="visible" />
 
             <io.legado.app.ui.widget.text.AccentBgTextView
                 android:id="@+id/tv_source_action"


### PR DESCRIPTION
## 变更内容

- 为阅读菜单中的书源自定义按钮补充 `@string/custom_button` 内容描述
- 删除该控件对应的 `ContentDescription` lint 忽略

## 根因

该按钮在书源启用 `customButton` 时显示，并支持单击和长按操作，但布局没有无障碍名称，TalkBack 无法说明按钮用途。

## 验证

- 使用命名空间 XML 解析确认 `tv_custom_btn` 的 `contentDescription` 为 `@string/custom_button`
- 确认该控件不再忽略 `ContentDescription`
- `git diff --check`