### PR TITLE
修复应用日志 JVM 测试崩溃

### DIFF
--- a/app/src/main/java/io/legado/app/constant/AppLog.kt
+++ b/app/src/main/java/io/legado/app/constant/AppLog.kt
@@ -35,8 +35,10 @@ object AppLog {
         mLogs.add(0, Triple(System.currentTimeMillis(), message, throwable))
         runCatching { postEvent(EventBus.APP_LOG_UPDATED, true) }
         if (BuildConfig.DEBUG) {
-            val stackTrace = Thread.currentThread().stackTrace
-            Log.e(stackTrace[3].className, message, throwable)
+            runCatching {
+                val stackTrace = Thread.currentThread().stackTrace
+                Log.e(stackTrace[3].className, message, throwable)
+            }
         }
     }
 
@@ -52,8 +54,10 @@ object AppLog {
         mLogs.add(0, Triple(System.currentTimeMillis(), message, throwable))
         runCatching { postEvent(EventBus.APP_LOG_UPDATED, true) }
         if (BuildConfig.DEBUG) {
-            val stackTrace = Thread.currentThread().stackTrace
-            Log.e(stackTrace[3].className, message, throwable)
+            runCatching {
+                val stackTrace = Thread.currentThread().stackTrace
+                Log.e(stackTrace[3].className, message, throwable)
+            }
         }
     }
 


### PR DESCRIPTION
## 变更
- 隔离 `AppLog.put` 与 `putNotSave` 中仅用于调试的 `Log.e` 调用
- 避免 JVM 单测环境未实现 Android Log 时中断应用日志与 HTTP 日志存储

## 验证
- 修复前：`HttpLogInterceptorTest.storeReturnsNewestRecordsWithAClampedLimit` 稳定失败，报错 `Method e in android.util.Log not mocked`
- 修复后：`AppLogExportTest`、`AppLogDialogLiveUpdateTest`、`HttpLogInterceptorTest` 共 7 项测试通过
- `git diff --check` 通过