### PR TITLE
ci: 新增 PR 测试版发布流程

### DIFF
--- a/.github/scripts/lzy_web.py
+++ b/.github/scripts/lzy_web.py
@@ -55,8 +55,9 @@ def upload_file(file_dir, folder_id):
         "id": "WU_FILE_0",
         "name": file_name,
     }
-    files = {'upload_file': (file_name, open(file_dir, "rb"), 'application/octet-stream')}
-    res = requests.post(url_upload, data=post_data, files=files, headers=headers, cookies=cookie, timeout=120).json()
+    with open(file_dir, "rb") as upload_stream:
+        files = {'upload_file': (file_name, upload_stream, 'application/octet-stream')}
+        res = requests.post(url_upload, data=post_data, files=files, headers=headers, cookies=cookie, timeout=120).json()
     log(f"{file_dir} -> {res['info']}")
     return res['zt'] == 1
 
@@ -64,35 +65,37 @@ def upload_file(file_dir, folder_id):
 # 上传文件夹内的文件
 def upload_folder(folder_dir, folder_id):
     file_list = sorted(os.listdir(folder_dir), reverse=True)
+    success = True
     for file in file_list:
         path = os.path.join(folder_dir, file)
         if os.path.isfile(path):
-            upload_file(path, folder_id)
+            success = upload_file(path, folder_id) and success
         else:
-            upload_folder(path, folder_id)
+            success = upload_folder(path, folder_id) and success
+    return success
 
 
 # 上传
 def upload(dir, folder_id):
     if dir is None:
         log('ERROR: 请指定上传的文件路径')
-        return
+        return False
     if folder_id is None:
         log('ERROR: 请指定蓝奏云的文件夹id')
-        return
+        return False
     if os.path.isfile(dir):
-        upload_file(dir, str(folder_id))
-    else:
-        upload_folder(dir, str(folder_id))
+        return upload_file(dir, str(folder_id))
+    return upload_folder(dir, str(folder_id))
+
+
+def main(argv):
+    if len(argv) != 2:
+        log('ERROR: 参数错误,请以这种格式重新尝试\npython lzy_web.py 需上传的路径 蓝奏云文件夹id')
+        return 2
+    if not login_by_cookie():
+        return 1
+    return 0 if upload(argv[0], argv[1]) else 1
 
 
 if __name__ == '__main__':
-    argv = sys.argv[1:]
-    if len(argv) != 2:
-        log('ERROR: 参数错误,请以这种格式重新尝试\npython lzy_web.py 需上传的路径 蓝奏云文件夹id')
-    # 需上传的路径
-    upload_path = argv[0]
-    # 蓝奏云文件夹id
-    lzy_folder_id = argv[1]
-    if login_by_cookie():
-        upload(upload_path, lzy_folder_id)
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/test_lzy_web.py
+++ b/.github/scripts/test_lzy_web.py
@@ -1,0 +1,32 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("lzy_web.py")
+SPEC = importlib.util.spec_from_file_location("lzy_web", SCRIPT)
+lzy_web = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(lzy_web)
+
+
+class LanzouUploadTest(unittest.TestCase):
+
+    def test_main_reports_login_and_upload_failures(self):
+        with mock.patch.object(lzy_web, "login_by_cookie", return_value=False):
+            self.assertEqual(1, lzy_web.main(["apk", "1"]))
+        with mock.patch.object(lzy_web, "login_by_cookie", return_value=True), \
+                mock.patch.object(lzy_web, "upload", return_value=False):
+            self.assertEqual(1, lzy_web.main(["apk", "1"]))
+
+    def test_folder_upload_reports_any_failed_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            Path(directory, "a.apk").touch()
+            Path(directory, "b.apk").touch()
+            with mock.patch.object(lzy_web, "upload_file", side_effect=[True, False]):
+                self.assertFalse(lzy_web.upload_folder(directory, "1"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/TestRelease.yml
+++ b/.github/workflows/TestRelease.yml
@@ -17,6 +17,7 @@ jobs:
     if: >-
       ${{ !github.event.pull_request.draft &&
           github.event.pull_request.user.login == 'mgz0227' &&
+          github.actor == 'mgz0227' &&
           github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     outputs:
@@ -84,12 +85,16 @@ jobs:
         run: echo "" > "$GITHUB_WORKSPACE/app/src/main/assets/18PlusList.txt"
 
       - name: Release APK Sign
+        env:
+          RELEASE_KEY_STORE: ${{ secrets.RELEASE_KEY_STORE }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
         run: |
-          echo "${{ secrets.RELEASE_KEY_STORE }}" | base64 --decode \
+          printf '%s' "$RELEASE_KEY_STORE" | base64 --decode \
             > "$GITHUB_WORKSPACE/app/legado.jks"
           {
-            echo "RELEASE_KEY_PASSWORD=${{ secrets.RELEASE_KEY_PASSWORD }}"
-            echo "RELEASE_STORE_PASSWORD=${{ secrets.RELEASE_STORE_PASSWORD }}"
+            printf '%s\n' "RELEASE_KEY_PASSWORD=$RELEASE_KEY_PASSWORD"
+            printf '%s\n' "RELEASE_STORE_PASSWORD=$RELEASE_STORE_PASSWORD"
             echo "RELEASE_STORE_FILE=./legado.jks"
             echo "RELEASE_KEY_ALIAS=legado"
           } >> "$GITHUB_WORKSPACE/gradle.properties"

--- a/.github/workflows/TestRelease.yml
+++ b/.github/workflows/TestRelease.yml
@@ -1,0 +1,262 @@
+name: Test Release
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: test-release-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+
+  prepare:
+    if: >-
+      ${{ !github.event.pull_request.draft &&
+          github.event.pull_request.user.login == 'mgz0227' &&
+          github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-ver.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Test Lanzou Upload Helper
+        run: python3 .github/scripts/test_lzy_web.py
+
+      - id: set-ver
+        run: |
+          version="3.$(TZ=Asia/Shanghai date +%y%m%d%H)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Release Credentials
+        env:
+          RELEASE_KEY_STORE: ${{ secrets.RELEASE_KEY_STORE }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          LANZOU_ID: ${{ secrets.LANZOU_ID }}
+          LANZOU_PSD: ${{ secrets.LANZOU_PSD }}
+          LANZOU_FOLDER_ID: ${{ secrets.LANZOU_FOLDER_ID }}
+        run: |
+          for name in \
+            RELEASE_KEY_STORE RELEASE_KEY_PASSWORD RELEASE_STORE_PASSWORD \
+            LANZOU_ID LANZOU_PSD LANZOU_FOLDER_ID; do
+            if [ -z "${!name}" ]; then
+              echo "Missing required secret: $name"
+              exit 1
+            fi
+          done
+
+  build:
+    needs: prepare
+    strategy:
+      matrix:
+        product: [app]
+        type: [release, releaseA]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    env:
+      product: ${{ matrix.product }}
+      type: ${{ matrix.type }}
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.3.0
+
+      - name: Prepare Assets
+        run: echo "" > "$GITHUB_WORKSPACE/app/src/main/assets/18PlusList.txt"
+
+      - name: Release APK Sign
+        run: |
+          echo "${{ secrets.RELEASE_KEY_STORE }}" | base64 --decode \
+            > "$GITHUB_WORKSPACE/app/legado.jks"
+          {
+            echo "RELEASE_KEY_PASSWORD=${{ secrets.RELEASE_KEY_PASSWORD }}"
+            echo "RELEASE_STORE_PASSWORD=${{ secrets.RELEASE_STORE_PASSWORD }}"
+            echo "RELEASE_STORE_FILE=./legado.jks"
+            echo "RELEASE_KEY_ALIAS=legado"
+          } >> "$GITHUB_WORKSPACE/gradle.properties"
+
+      - name: Build With Gradle
+        run: |
+          sed -i "s/^def version = .*/def version = \"$VERSION\"/" \
+            "$GITHUB_WORKSPACE/app/build.gradle"
+
+          if [ "$type" = "release" ]; then
+            typeName="新包名"
+          else
+            typeName="新共存"
+            sed -i "s/'.release'/'.releaseA'/" \
+              "$GITHUB_WORKSPACE/app/build.gradle"
+            if [ -f "$GITHUB_WORKSPACE/app/google-services.json" ]; then
+              sed -i 's/.release/.releaseA/' \
+                "$GITHUB_WORKSPACE/app/google-services.json"
+            fi
+          fi
+
+          chmod +x gradlew
+          ./gradlew :$product:assembleRelease -ParmOnly=true \
+            --build-cache --parallel --daemon --warning-mode all
+          mkdir -p "$GITHUB_WORKSPACE/apk"
+          bash "$GITHUB_WORKSPACE/.github/scripts/collect-apks.sh" \
+            "$GITHUB_WORKSPACE/app/build/outputs/apk" \
+            "$GITHUB_WORKSPACE/apk" \
+            "$product" "$VERSION" "$typeName" arm
+
+          ./gradlew :$product:assembleRelease \
+            --build-cache --parallel --daemon --warning-mode all
+          bash "$GITHUB_WORKSPACE/.github/scripts/collect-apks.sh" \
+            "$GITHUB_WORKSPACE/app/build/outputs/apk" \
+            "$GITHUB_WORKSPACE/apk" \
+            "$product" "$VERSION" "$typeName" universal
+
+      - name: Check Build Result
+        run: |
+          expected_packages=(arm universal)
+          mapfile -d '' apks < <(find "$GITHUB_WORKSPACE/apk" -maxdepth 1 \
+            -type f -name 'legado_*.apk' -print0)
+          if [[ ${#apks[@]} -ne ${#expected_packages[@]} ]]; then
+            echo "Expected ${#expected_packages[@]} APKs, found ${#apks[@]}"
+            exit 1
+          fi
+
+          declare -A verified=()
+          for apk in "${apks[@]}"; do
+            file_name=$(basename "$apk")
+            case "$file_name" in
+              *_universal_*) package_kind=universal ;;
+              *) package_kind=arm ;;
+            esac
+            if [[ -n "${verified[$package_kind]:-}" ]]; then
+              echo "Multiple APKs detected for $package_kind"
+              exit 1
+            fi
+
+            packaged_abis=$(unzip -Z1 "$apk" \
+              | sed -n 's#^lib/\([^/]*\)/.*#\1#p' \
+              | sort -u \
+              | paste -sd ' ' -)
+            if [[ "$package_kind" = "universal" ]]; then
+              expected_native_abis="arm64-v8a armeabi-v7a x86 x86_64"
+            else
+              expected_native_abis="arm64-v8a armeabi-v7a"
+            fi
+            if [[ "$packaged_abis" != "$expected_native_abis" ]]; then
+              echo "$package_kind APK contains unexpected native ABIs: $packaged_abis"
+              exit 1
+            fi
+            verified[$package_kind]=$apk
+          done
+
+          for package_kind in "${expected_packages[@]}"; do
+            if [[ -z "${verified[$package_kind]:-}" ]]; then
+              echo "Missing APK for $package_kind"
+              exit 1
+            fi
+          done
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: legado.test.${{ env.type }}
+          if-no-files-found: error
+          path: ${{ github.workspace }}/apk/*.apk
+
+  publish:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: test-release-publish
+      cancel-in-progress: false
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      PR_SHA: ${{ github.sha }}
+      ylogin: ${{ secrets.LANZOU_ID }}
+      phpdisk_info: ${{ secrets.LANZOU_PSD }}
+      LANZOU_FOLDER_ID: ${{ secrets.LANZOU_FOLDER_ID }}
+      LANZOU_URL: ${{ secrets.LANZOU_URL }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: apk/
+
+      - name: Prepare APKs
+        working-directory: apk/
+        run: |
+          mv */*.apk .
+          rm -rf -- */
+          for file in *.apk; do
+            if [[ "$file" = *新包名* ]]; then
+              mv -- "$file" "${file/新包名/release}"
+            else
+              mv -- "$file" "${file/新共存/releaseA}"
+            fi
+          done
+
+      - name: Prepare Release Notes
+        run: |
+          printf '此版本为 PR 测试版，可能存在不稳定情况，升级前请备份数据。\n\nPR #%s: %s\n\n%s\n\nCommit: %s\n' \
+            "$PR_NUMBER" "$PR_TITLE" "$PR_URL" "$PR_SHA" \
+            > "$GITHUB_WORKSPACE/release-notes.md"
+
+      - name: Update Beta Tag
+        run: |
+          git tag --force beta "$(git rev-parse HEAD)"
+          git push origin refs/tags/beta --force
+
+      - name: Publish Beta Release
+        uses: ncipollo/release-action@v1
+        with:
+          name: legado_test_PR${{ github.event.pull_request.number }}_${{ env.VERSION }}
+          tag: beta
+          bodyFile: ${{ github.workspace }}/release-notes.md
+          prerelease: true
+          makeLatest: false
+          allowUpdates: true
+          removeArtifacts: true
+          artifactErrorsFailBuild: true
+          artifacts: ${{ github.workspace }}/apk/*.apk
+
+      - name: Prepare Lanzou APKs
+        working-directory: apk/
+        run: |
+          bash "$GITHUB_WORKSPACE/.github/scripts/remove-universal-apks.sh" \
+            "$GITHUB_WORKSPACE/apk"
+          for file in *.apk; do
+            renamed="${file/新包名/release}"
+            renamed="${renamed/新共存/releaseA}"
+            mv -- "$file" "${renamed%.apk}_测试版_PR${PR_NUMBER}.apk"
+          done
+
+      - name: Upload To Lanzou
+        run: |
+          python3 "$GITHUB_WORKSPACE/.github/scripts/lzy_web.py" \
+            "$GITHUB_WORKSPACE/apk" "$LANZOU_FOLDER_ID"
+          echo "[$(TZ=Asia/Shanghai date '+%Y.%m.%d %H:%M:%S')] 分享链接: $LANZOU_URL"

--- a/.github/workflows/TestRelease.yml
+++ b/.github/workflows/TestRelease.yml
@@ -187,6 +187,7 @@ jobs:
     concurrency:
       group: test-release-publish
       cancel-in-progress: false
+      queue: max
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
       PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
@@ -21,6 +21,7 @@ class TestReleaseWorkflowTest {
     fun `test release only accepts trusted repository pull requests`() {
         assertTrue(workflowText.contains("pull_request:"))
         assertTrue(workflowText.contains("github.event.pull_request.user.login == 'mgz0227'"))
+        assertTrue(workflowText.contains("github.actor == 'mgz0227'"))
         assertTrue(
             workflowText.contains(
                 "github.event.pull_request.head.repo.full_name == github.repository"

--- a/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
@@ -1,0 +1,43 @@
+package io.legado.app.ci
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class TestReleaseWorkflowTest {
+
+    private val workflowText by lazy {
+        val userDir = requireNotNull(System.getProperty("user.dir"))
+        val workflowFile = generateSequence(File(userDir)) {
+            it.parentFile
+        }.map {
+            File(it, ".github/workflows/TestRelease.yml")
+        }.first { it.isFile }
+        workflowFile.readText().replace("\r\n", "\n")
+    }
+
+    @Test
+    fun `test release only accepts trusted repository pull requests`() {
+        assertTrue(workflowText.contains("pull_request:"))
+        assertTrue(workflowText.contains("github.event.pull_request.user.login == 'mgz0227'"))
+        assertTrue(
+            workflowText.contains(
+                "github.event.pull_request.head.repo.full_name == github.repository"
+            )
+        )
+        assertFalse(workflowText.contains("pull_request_target:"))
+    }
+
+    @Test
+    fun `test release only publishes beta and lanzou artifacts`() {
+        assertTrue(workflowText.contains("tag: beta"))
+        assertTrue(workflowText.contains("prerelease: true"))
+        assertTrue(workflowText.contains("removeArtifacts: true"))
+        assertTrue(workflowText.contains("_测试版_PR"))
+        assertTrue(workflowText.contains("lzy_web.py"))
+        assertFalse(workflowText.contains("Deploy apk to server"))
+        assertFalse(workflowText.contains("Post to Telegram Channel"))
+        assertFalse(workflowText.contains("Push To \"test\" Branch"))
+    }
+}

--- a/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
@@ -34,6 +34,7 @@ class TestReleaseWorkflowTest {
         assertTrue(workflowText.contains("tag: beta"))
         assertTrue(workflowText.contains("prerelease: true"))
         assertTrue(workflowText.contains("removeArtifacts: true"))
+        assertTrue(workflowText.contains("queue: max"))
         assertTrue(workflowText.contains("_测试版_PR"))
         assertTrue(workflowText.contains("lzy_web.py"))
         assertFalse(workflowText.contains("Deploy apk to server"))


### PR DESCRIPTION
## 变更

- 新增 Test Release，仅对同仓库、非草稿、作者及触发者均为 mgz0227 的 PR 运行。
- 复用 Beta Release 的签名配置，分别构建 release / releaseA 的 ARM 与通用 APK。
- 串行更新固定 beta tag/release，并使用 queue: max 保留并发 PR 的发布任务。
- 蓝奏云仅上传 ARM APK，文件名追加 测试版_PR编号。
- 蓝奏云登录或任一文件上传失败会正确中止任务，不再静默成功。
- 不上传 CDN、Telegram、test 分支或正式版本 tag。

## 验证

- python .github/scripts/test_lzy_web.py（2/2）
- TestRelease.yml YAML 解析与静态分发契约检查
- git diff --cached --check
- Android 构建与发布由 GitHub Actions 验证，未在本机运行 Gradle