### PR TITLE
fix: 稳定 Web 资产构建与推送

### DIFF
--- a/.github/scripts/push-web-assets.sh
+++ b/.github/scripts/push-web-assets.sh
@@ -11,6 +11,11 @@ if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
   exit 1
 fi
 
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Stashing uncommitted build byproducts before web asset push"
+  git stash push --include-untracked --message "web asset build byproducts" >/dev/null
+fi
+
 for ((attempt = 1; attempt <= max_attempts; attempt++)); do
   echo "Syncing $branch before web asset push (attempt $attempt/$max_attempts)"
   git fetch "$remote" "$branch"

--- a/.github/scripts/test-push-web-assets.sh
+++ b/.github/scripts/test-push-web-assets.sh
@@ -35,6 +35,8 @@ git -C "$worker" config user.email test@example.com
 printf 'generated\n' > "$worker/generated.txt"
 git -C "$worker" add generated.txt
 git -C "$worker" commit -m "Generate web assets" >/dev/null
+printf 'build byproduct\n' >> "$worker/base.txt"
+printf 'untracked byproduct\n' > "$worker/byproduct.txt"
 
 git clone --branch master "$remote" "$upstream" >/dev/null 2>&1
 git -C "$upstream" config user.name test
@@ -60,6 +62,8 @@ chmod +x "$remote/hooks/pre-receive"
 git clone --branch master "$remote" "$verify" >/dev/null 2>&1
 test -f "$verify/generated.txt"
 test -f "$verify/upstream.txt"
+test ! -e "$verify/byproduct.txt"
+test "$(cat "$verify/base.txt")" = "base"
 test -f "$reject_marker"
 git -C "$verify" log --format=%s | grep -Fxq "Generate web assets"
 git -C "$verify" log --format=%s | grep -Fxq "Advance master"

--- a/modules/web/package.json
+++ b/modules/web/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "pnpm test && run-p type-check \"build-only {@}\" -- && node ./scripts/sync.js",
+    "build": "pnpm test && pnpm build-only && pnpm type-check && node ./scripts/sync.js",
     "preview": "vite preview",
     "build-only": "vite build",
     "test": "node --test",


### PR DESCRIPTION
修复主线 Web 资产构建成功后，因额外构建副产物导致 `git rebase` 拒绝执行的问题。

- 在临时 Runner 上将未提交的构建副产物放入 stash，再执行现有 rebase/推送重试
- 扩展现有 shell 自测，覆盖 tracked 与 untracked 副产物不会进入主线

验证：
- `test-push-web-assets.sh` 通过
- 两个脚本 `bash -n` 通过
- `git diff --check` 通过

失败现场：https://github.com/LegadoTeam/legado/actions/runs/31527357913