### PR TITLE
ci: 确保 Actions 推送提交触发测试版

### DIFF
--- a/.github/workflows/SyncUpstream.yml
+++ b/.github/workflows/SyncUpstream.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 */12 * * *'
   workflow_dispatch: {}  # 支持手动触发
 
+permissions:
+  actions: write
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -34,9 +38,7 @@ jobs:
         id: check
         run: |
           git fetch upstream master
-          LOCAL=$(git rev-parse master)
-          REMOTE=$(git rev-parse upstream/master)
-          if [ "$LOCAL" = "$REMOTE" ]; then
+          if git merge-base --is-ancestor upstream/master master; then
             echo "up_to_date=true" >> $GITHUB_OUTPUT
             echo "✅ Already up to date."
           else
@@ -48,9 +50,17 @@ jobs:
         if: steps.check.outputs.up_to_date == 'false'
         run: |
           git checkout master
-          git merge --no-edit upstream/master || true
+          git merge --no-edit upstream/master
 
       - name: Push to origin
         if: steps.check.outputs.up_to_date == 'false'
         run: |
           git push "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" master
+
+      - name: Dispatch Test Release
+        if: steps.check.outputs.up_to_date == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run TestRelease.yml --ref master \
+            -f commit_sha="$(git rev-parse HEAD)"

--- a/.github/workflows/TestRelease.yml
+++ b/.github/workflows/TestRelease.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit on master to build
+        required: false
+        type: string
 
 concurrency:
   group: test-release
@@ -21,15 +27,27 @@ jobs:
     outputs:
       version: ${{ steps.set-ver.outputs.version }}
       label: ${{ steps.set-ver.outputs.label }}
+      commit: ${{ steps.set-ver.outputs.commit }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.commit_sha || github.sha }}
 
       - id: set-ver
+        env:
+          COMMIT_SHA: ${{ inputs.commit_sha || github.sha }}
         run: |
+          if [[ ! "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]] || \
+            ! git merge-base --is-ancestor "$COMMIT_SHA" origin/master; then
+            echo "Commit must belong to master: $COMMIT_SHA"
+            exit 1
+          fi
           version="3.$(TZ=Asia/Shanghai date +%y%m%d%H)"
           branch="${GITHUB_REF_NAME//[^[:alnum:]._-]/_}"
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "label=${branch}_${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+          echo "label=${branch}_${COMMIT_SHA:0:7}" >> "$GITHUB_OUTPUT"
+          echo "commit=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Verify Release Credentials
         env:
@@ -66,6 +84,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.commit }}
 
       - name: Setup JDK 17
         uses: actions/setup-java@v5
@@ -188,9 +207,8 @@ jobs:
       VERSION: ${{ needs.prepare.outputs.version }}
       RELEASE_LABEL: ${{ needs.prepare.outputs.label }}
       BRANCH: ${{ github.ref_name }}
-      COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-      COMMIT_URL: ${{ github.event.head_commit.url }}
-      COMMIT_SHA: ${{ github.sha }}
+      COMMIT_URL: ${{ format('{0}/{1}/commit/{2}', github.server_url, github.repository, needs.prepare.outputs.commit) }}
+      COMMIT_SHA: ${{ needs.prepare.outputs.commit }}
       ylogin: ${{ secrets.LANZOU_ID }}
       phpdisk_info: ${{ secrets.LANZOU_PSD }}
       LANZOU_FOLDER_ID: ${{ secrets.LANZOU_FOLDER_ID }}
@@ -199,6 +217,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ needs.prepare.outputs.commit }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -219,10 +238,11 @@ jobs:
 
       - name: Prepare Release Notes
         run: |
+          commit_message="$(git log -1 --format=%B "$COMMIT_SHA")"
           {
             printf '此版本为提交测试版，可能存在不稳定情况，升级前请备份数据。\n\n'
             printf 'Branch: %s\n\nCommit: %s\n\n%s\n\n%s\n' \
-              "$BRANCH" "$COMMIT_SHA" "$COMMIT_URL" "$COMMIT_MESSAGE"
+              "$BRANCH" "$COMMIT_SHA" "$COMMIT_URL" "$commit_message"
           } > "$GITHUB_WORKSPACE/release-notes.md"
 
       - name: Update Beta Tag

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -17,10 +17,14 @@ on:
 
 concurrency:
   group: build-web-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   UPSTREAM_REPOSITORY: LegadoTeam/legado
+
+permissions:
+  actions: write
+  contents: write
 
 jobs:
   build:
@@ -66,4 +70,12 @@ jobs:
       - name: Push web assets
         if: ${{ steps.web-commit.outputs.changes_detected == 'true' }}
         run: bash .github/scripts/push-web-assets.sh
+
+      - name: Dispatch Test Release
+        if: ${{ steps.web-commit.outputs.changes_detected == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run TestRelease.yml --ref master \
+            -f commit_sha="$(git rev-parse HEAD)"
 

--- a/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
@@ -17,16 +17,31 @@ class TestReleaseWorkflowTest {
         workflowFile.readText().replace("\r\n", "\n")
     }
 
+    private val syncWorkflowText by lazy {
+        val userDir = requireNotNull(System.getProperty("user.dir"))
+        val workflowFile = generateSequence(File(userDir)) {
+            it.parentFile
+        }.map {
+            File(it, ".github/workflows/SyncUpstream.yml")
+        }.first { it.isFile }
+        workflowFile.readText().replace("\r\n", "\n")
+    }
+
     @Test
     fun `test release runs for every master push`() {
         assertTrue(workflowText.contains("push:"))
         assertTrue(workflowText.contains("- master"))
+        assertTrue(workflowText.contains("workflow_dispatch:"))
+        assertTrue(workflowText.contains("commit_sha:"))
+        assertTrue(workflowText.contains("ref: ${'$'}{{ inputs.commit_sha || github.sha }}"))
+        assertTrue(workflowText.contains("ref: ${'$'}{{ needs.prepare.outputs.commit }}"))
         assertTrue(workflowText.contains("if: ${'$'}{{ !github.event.deleted }}"))
         assertTrue(workflowText.contains("group: test-release"))
         assertTrue(workflowText.contains("cancel-in-progress: false"))
         assertTrue(workflowText.contains("queue: max"))
         assertFalse(workflowText.contains("pull_request:"))
         assertFalse(workflowText.contains("github.event.pull_request"))
+        assertFalse(workflowText.contains("github.event.head_commit"))
     }
 
     @Test
@@ -40,5 +55,15 @@ class TestReleaseWorkflowTest {
         assertFalse(workflowText.contains("Deploy apk to server"))
         assertFalse(workflowText.contains("Post to Telegram Channel"))
         assertFalse(workflowText.contains("Push To \"test\" Branch"))
+    }
+
+    @Test
+    fun `upstream sync dispatches test release for its pushed commit`() {
+        assertTrue(syncWorkflowText.contains("actions: write"))
+        assertTrue(syncWorkflowText.contains("contents: write"))
+        assertTrue(syncWorkflowText.contains("git merge-base --is-ancestor upstream/master master"))
+        assertFalse(syncWorkflowText.contains("git merge --no-edit upstream/master || true"))
+        assertTrue(syncWorkflowText.contains("gh workflow run TestRelease.yml --ref master"))
+        assertTrue(syncWorkflowText.contains("-f commit_sha=\"${'$'}(git rev-parse HEAD)\""))
     }
 }

--- a/app/src/test/java/io/legado/app/ci/WebWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/WebWorkflowTest.kt
@@ -21,7 +21,7 @@ class WebWorkflowTest {
         assertTrue(workflowText.contains("- '.github/workflows/web.yml'"))
         assertTrue(workflowText.contains("- '.github/scripts/push-web-assets.sh'"))
         assertTrue(workflowText.contains("group: build-web-" + "$" + "{{ github.ref }}"))
-        assertTrue(workflowText.contains("cancel-in-progress: true"))
+        assertTrue(workflowText.contains("cancel-in-progress: ${'$'}{{ github.event_name == 'pull_request' }}"))
         assertTrue(workflowText.contains("fetch-depth: 0"))
     }
 
@@ -35,5 +35,8 @@ class WebWorkflowTest {
         assertTrue(workflowText.contains("skip_push: true"))
         assertTrue(workflowText.contains("file_pattern: app/src/main/assets/web/vue/ modules/web/src/components.d.ts"))
         assertTrue(workflowText.contains("bash .github/scripts/push-web-assets.sh"))
+        assertTrue(workflowText.contains("actions: write"))
+        assertTrue(workflowText.contains("gh workflow run TestRelease.yml --ref master"))
+        assertTrue(workflowText.contains("-f commit_sha=\"${'$'}(git rev-parse HEAD)\""))
     }
 }


### PR DESCRIPTION
## 说明
- 为 TestRelease 增加可指定主线提交的 `workflow_dispatch` 入口
- Web 资源与上游同步推送成功后显式派发对应提交的 TestRelease
- 发布标签、检出和说明统一使用校验后的精确提交 SHA
- 主线 Web 构建不中途取消，保留 push 到 dispatch 的原子窗口

## 原因
Actions 使用仓库 `GITHUB_TOKEN` 推送的提交不会再次触发普通 `push` 工作流。Web 资源提交 `c3beb635` 已因此漏发测试版；停用中的上游同步工作流恢复后也有同样风险。

## 验证
- 三份 workflow YAML 解析通过
- TestRelease/Web/SyncUpstream 契约检查通过
- `git diff --check` 通过
- 完整 Web 与 APK 构建交由 PR CI