### PR TITLE
fix: 防止旧正文覆盖失败的换源写入

### DIFF
--- a/app/src/main/java/io/legado/app/help/book/BookHelp.kt
+++ b/app/src/main/java/io/legado/app/help/book/BookHelp.kt
@@ -87,10 +87,18 @@ internal class ContentSaveFence {
     }
 
     fun replace(key: ContentSaveKey, fileName: String, write: () -> Unit) {
+        var failure: Throwable? = null
         states.compute(key) { _, current ->
-            write()
-            ContentSaveState((current?.version ?: 0L) + 1L, fileName)
+            val nextVersion = (current?.version ?: 0L) + 1L
+            try {
+                write()
+                ContentSaveState(nextVersion, fileName)
+            } catch (error: Throwable) {
+                failure = error
+                ContentSaveState(nextVersion, current?.fileName)
+            }
         }
+        failure?.let { throw it }
     }
 }
 

--- a/app/src/test/java/io/legado/app/help/book/ContentSaveFenceTest.kt
+++ b/app/src/test/java/io/legado/app/help/book/ContentSaveFenceTest.kt
@@ -3,6 +3,7 @@ package io.legado.app.help.book
 import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -24,6 +25,30 @@ class ContentSaveFenceTest {
         )
         assertEquals("replacement", content)
         assertEquals("replacement.nb", fence.state(key).fileName)
+    }
+
+    @Test
+    fun `failed authoritative replacement still rejects an older network write`() {
+        val fence = ContentSaveFence()
+        val key = ContentSaveKey("book", 3)
+        val requestVersion = fence.state(key).version
+        var content = ""
+
+        assertThrows(IllegalStateException::class.java) {
+            fence.replace(key, "replacement.nb") {
+                content = "replacement"
+                error("metadata update failed")
+            }
+        }
+
+        assertFalse(
+            fence.writeIfCurrent(key, requestVersion, "stale.nb") {
+                content = "stale network content"
+            }
+        )
+        assertEquals("replacement", content)
+        assertEquals(requestVersion + 1L, fence.state(key).version)
+        assertEquals(null, fence.state(key).fileName)
     }
 
     @Test


### PR DESCRIPTION
## 问题
权威换源写入在文件已落盘、元数据更新抛错时，会让 `ConcurrentHashMap.compute` 放弃新的版本状态。此前已经发出的网络请求仍持有旧版本令牌，随后可能覆盖刚写入的正文。

## 修复
- 权威写入无论成功或抛错都推进内容版本，使旧网络令牌失效
- 失败时保留上一个已确认文件名，并在状态提交后原样重抛异常
- 新增“写入后抛错仍拒绝旧网络结果”的回归测试

## 验证
- 栅栏失败路径契约检查通过
- `git diff --check` 通过
- 目标单测与完整构建交由 GitHub Actions