### PR TITLE
fix: 蓝奏云上传失败时返回错误

### DIFF
--- a/.github/scripts/lzy_web.py
+++ b/.github/scripts/lzy_web.py
@@ -1,9 +1,10 @@
-#import requests, os, datetime, sys, time
-import os
 import datetime
+import os
 import sys
 import time
+
 import requests
+
 # Cookie 中 phpdisk_info 的值
 cookie_phpdisk_info = os.environ.get('phpdisk_info')
 # Cookie 中 ylogin 的值
@@ -25,8 +26,9 @@ cookie = {
 
 # 日志打印
 def log(msg):
-    utc_time = datetime.datetime.utcnow()
-    china_time = utc_time + datetime.timedelta(hours=8)
+    china_time = datetime.datetime.now(
+        datetime.timezone(datetime.timedelta(hours=8))
+    )
     print(f"[{china_time.strftime('%Y.%m.%d %H:%M:%S')}] {msg}")
 
 
@@ -51,7 +53,6 @@ def login_by_cookie():
 # 上传文件
 def upload_file(file_dir, folder_id):
     file_name = os.path.basename(file_dir)
-    #url_upload = "https://up.woozooo.com/fileup.php"
     url_upload = "https://pc.woozooo.com/html5up.php"
     headers['Referer'] = f'https://pc.woozooo.com/mydisk.php?item=files&action=index&u={cookie_ylogin}'
     post_data = {
@@ -59,65 +60,77 @@ def upload_file(file_dir, folder_id):
         'vie': '2',
         've': '2',
         'id': 'WU_FILE_2',
-        "name": '{file_name}',
+        "name": file_name,
         "folder_id_bb_n": folder_id,
     }
-    files = {'upload_file': (file_name, open(file_dir, "rb"), 'application/octet-stream')}
-
-    retry_time = 0
-    retry_time_max = 2  # 最大重试次数
-    while True:
-        if retry_time > retry_time_max:
-            return False
-        log(f'开始第{retry_time+1}次请求')
+    for attempt in range(1, 4):
+        log(f'开始第{attempt}次请求')
         try:
-            response = requests.post(url_upload, data=post_data, files=files, headers=headers, cookies=cookie, timeout=3600)
+            with open(file_dir, "rb") as upload_stream:
+                files = {
+                    'upload_file': (file_name, upload_stream, 'application/octet-stream')
+                }
+                response = requests.post(
+                    url_upload,
+                    data=post_data,
+                    files=files,
+                    headers=headers,
+                    cookies=cookie,
+                    timeout=3600,
+                )
+            response.raise_for_status()
             log(f'response -> {response.text}')
             res = response.json()
-            log(f"{file_dir} -> {res['info']}")
-            if res['zt'] == 1:
+            log(f"{file_dir} -> {res.get('info', '未知响应')}")
+            if res.get('zt') == 1:
                 return True
-            else:
-                retry_time += 1
-                time.sleep(2)
         except Exception as e:
-            log(f'第{retry_tim+1}次请求异常: {e}')
-            retry_time += 1
+            log(f'第{attempt}次请求异常: {e}')
+        if attempt < 3:
             time.sleep(2)
+    return False
 
 
 # 上传文件夹内的文件
 def upload_folder(folder_dir, folder_id):
-    file_list = sorted(os.listdir(folder_dir), reverse=True)
+    file_list = sorted(
+        (
+            os.path.join(root, file)
+            for root, _, files in os.walk(folder_dir)
+            for file in files
+        ),
+        reverse=True,
+    )
+    if not file_list:
+        log('ERROR: 上传目录中没有文件')
+        return False
+    success = True
     for file in file_list:
-        path = os.path.join(folder_dir, file)
-        if os.path.isfile(path):
-            upload_file(path, folder_id)
-        else:
-            upload_folder(path, folder_id)
+        success = upload_file(file, folder_id) and success
+    return success
 
 
 # 上传
 def upload(dir, folder_id):
-    if dir is None:
-        log('ERROR: 请指定上传的文件路径')
-        return
-    if folder_id is None:
+    if not dir or not os.path.exists(dir):
+        log('ERROR: 请指定有效的上传文件路径')
+        return False
+    if not folder_id:
         log('ERROR: 请指定蓝奏云的文件夹id')
-        return
+        return False
     if os.path.isfile(dir):
-        upload_file(dir, str(folder_id))
-    else:
-        upload_folder(dir, str(folder_id))
+        return upload_file(dir, str(folder_id))
+    return upload_folder(dir, str(folder_id))
+
+
+def main(argv):
+    if len(argv) != 2:
+        log('ERROR: 参数错误,请以这种格式重新尝试\npython lzy_web.py 需上传的路径 蓝奏云文件夹id')
+        return 2
+    if not login_by_cookie():
+        return 1
+    return 0 if upload(argv[0], argv[1]) else 1
 
 
 if __name__ == '__main__':
-    argv = sys.argv[1:]
-    if len(argv) != 2:
-        log('ERROR: 参数错误,请以这种格式重新尝试\npython lzy_web.py 需上传的路径 蓝奏云文件夹id')
-    # 需上传的路径
-    upload_path = argv[0]
-    # 蓝奏云文件夹id
-    lzy_folder_id = argv[1]
-    if login_by_cookie():
-        upload(upload_path, lzy_folder_id)
+    sys.exit(main(sys.argv[1:]))

--- a/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
@@ -27,6 +27,16 @@ class TestReleaseWorkflowTest {
         workflowFile.readText().replace("\r\n", "\n")
     }
 
+    private val lanzouUploaderText by lazy {
+        val userDir = requireNotNull(System.getProperty("user.dir"))
+        val scriptFile = generateSequence(File(userDir)) {
+            it.parentFile
+        }.map {
+            File(it, ".github/scripts/lzy_web.py")
+        }.first { it.isFile }
+        scriptFile.readText().replace("\r\n", "\n")
+    }
+
     @Test
     fun `test release runs for every master push`() {
         assertTrue(workflowText.contains("push:"))
@@ -70,5 +80,14 @@ class TestReleaseWorkflowTest {
         assertFalse(syncWorkflowText.contains("git merge --no-edit upstream/master || true"))
         assertTrue(syncWorkflowText.contains("gh workflow run TestRelease.yml --ref master"))
         assertTrue(syncWorkflowText.contains("-f commit_sha=\"${'$'}(git rev-parse HEAD)\""))
+    }
+
+    @Test
+    fun `lanzou uploader propagates login and upload failures`() {
+        assertTrue(lanzouUploaderText.contains("with open(file_dir, \"rb\") as upload_stream:"))
+        assertTrue(lanzouUploaderText.contains("return 0 if upload(argv[0], argv[1]) else 1"))
+        assertTrue(lanzouUploaderText.contains("sys.exit(main(sys.argv[1:]))"))
+        assertFalse(lanzouUploaderText.contains("\"name\": '{file_name}'"))
+        assertFalse(lanzouUploaderText.contains("retry_tim+"))
     }
 }


### PR DESCRIPTION
## 问题
最新蓝奏云接口调整后，登录失败、重试耗尽或目录内部分文件上传失败不会返回非零状态，Actions 可能把未完成上传误报为成功；重试还会复用已读完的文件句柄。

## 修复
- 保留已验证可用的新登录和上传接口
- 每次重试重新打开文件，并修正提交的文件名
- 汇总目录内所有上传结果，空目录和无效路径直接失败
- 恢复 `main()` 返回码与 `sys.exit`，让 TestRelease 正确反映失败

## 验证
- Python 语法编译
- 无网络 mock 验证重试读取完整内容、部分失败传播及主函数退出码
- `git diff --check`