### PR TITLE
清理已删除同步工作流的测试

### DIFF
--- a/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
@@ -17,16 +17,6 @@ class TestReleaseWorkflowTest {
         workflowFile.readText().replace("\r\n", "\n")
     }
 
-    private val syncWorkflowText by lazy {
-        val userDir = requireNotNull(System.getProperty("user.dir"))
-        val workflowFile = generateSequence(File(userDir)) {
-            it.parentFile
-        }.map {
-            File(it, ".github/workflows/SyncUpstream.yml")
-        }.first { it.isFile }
-        workflowFile.readText().replace("\r\n", "\n")
-    }
-
     private val lanzouUploaderText by lazy {
         val userDir = requireNotNull(System.getProperty("user.dir"))
         val scriptFile = generateSequence(File(userDir)) {
@@ -70,16 +60,6 @@ class TestReleaseWorkflowTest {
         assertFalse(workflowText.contains("Deploy apk to server"))
         assertFalse(workflowText.contains("Post to Telegram Channel"))
         assertFalse(workflowText.contains("Push To \"test\" Branch"))
-    }
-
-    @Test
-    fun `upstream sync dispatches test release for its pushed commit`() {
-        assertTrue(syncWorkflowText.contains("actions: write"))
-        assertTrue(syncWorkflowText.contains("contents: write"))
-        assertTrue(syncWorkflowText.contains("git merge-base --is-ancestor upstream/master master"))
-        assertFalse(syncWorkflowText.contains("git merge --no-edit upstream/master || true"))
-        assertTrue(syncWorkflowText.contains("gh workflow run TestRelease.yml --ref master"))
-        assertTrue(syncWorkflowText.contains("-f commit_sha=\"${'$'}(git rev-parse HEAD)\""))
     }
 
     @Test


### PR DESCRIPTION
## 说明

`SyncUpstream.yml` 已从主线删除，但 `TestReleaseWorkflowTest` 仍会查找并断言该文件，导致所有 PR 的 release 单元测试在 `NoSuchElementException` 处失败。

本次仅删除对应的失效加载器和测试，不改变现有发布流程。

## 验证

- `git diff --check`
- 确认测试目录与工作流目录不再引用 `SyncUpstream.yml`
- 未在本机运行 Gradle；使用 GitHub Actions 验证