### PR TITLE
test: 覆盖共享 JS 函数默认 this

### DIFF
--- a/app/src/test/java/io/legado/app/JsEngineCapabilitiesTest.kt
+++ b/app/src/test/java/io/legado/app/JsEngineCapabilitiesTest.kt
@@ -54,6 +54,16 @@ class JsEngineCapabilitiesTest {
     }
 
     @Test
+    fun sharedLibraryFunctionUsesCallerBindingsAsDefaultThis() {
+        val shared = RhinoScriptEngine.getRuntimeScope(ScriptBindings())
+        RhinoScriptEngine.eval("function readCache() { return this.cache }", shared)
+        val bindings = ScriptBindings().apply { this["cache"] = "runtime" }
+        bindings.chainTo(shared)
+
+        Assert.assertEquals("runtime", RhinoScriptEngine.eval("readCache()", bindings))
+    }
+
+    @Test
     fun constForInAndBlockScopesRemainIndependent() {
         val script = """
             const params = { first: 1, second: 2 };


### PR DESCRIPTION
## 变更

- 增加共享 JavaScript 库函数默认 `this` 的回归测试
- 验证函数在调用方作用域执行时可读取当前绑定

## 验证

- `git diff --check`
- 未在本地运行 Gradle，交由 GitHub Actions 执行单元测试与构建
