### PR TITLE
修复刷新位置锚点的排版完成竞态

### DIFF
--- a/app/src/main/java/io/legado/app/model/ReadBook.kt
+++ b/app/src/main/java/io/legado/app/model/ReadBook.kt
@@ -1460,7 +1460,6 @@ object ReadBook : CoroutineScope by MainScope() {
             pendingHighlightAnchor = null
             return
         }
-        if (!textChapter.isCompleted) return
         val currentTitleLength = textChapter.layoutTitleLength.takeIf { it >= 0 } ?: return
         val expectedPosition = resolveHighlightChapterPosition(
             pending.rawPosition,

--- a/app/src/test/java/io/legado/app/model/ReadBookRefreshPositionTest.kt
+++ b/app/src/test/java/io/legado/app/model/ReadBookRefreshPositionTest.kt
@@ -1,5 +1,6 @@
 package io.legado.app.model
 
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -46,6 +47,24 @@ class ReadBookRefreshPositionTest {
             "pendingHighlightAnchor = positionAnchor?.takeIf"
         )
         assertTrue(readBook.contains("return pendingHighlightAnchor?.waitForLayout != true"))
+    }
+
+    @Test
+    fun `completed layout resolves refresh anchor without waiting for callback flag`() {
+        val readBook = source("app/src/main/java/io/legado/app/model/ReadBook.kt")
+        val loadCurrentChapter = readBook.substringAfter("suspend fun contentLoadFinishAwait(")
+            .substringBefore("fun pageAnim()")
+            .substringAfter("0 -> {")
+            .substringBefore("-1 -> {")
+        val anchorResolver = readBook.substringAfter("private fun resolvePendingHighlightAnchor(")
+            .substringBefore("private fun currentPositionAnchor()")
+
+        assertOrder(
+            loadCurrentChapter,
+            "for (page in textChapter.layoutChannel)",
+            "resolvePendingHighlightAnchor(book, textChapter)"
+        )
+        assertFalse(anchorResolver.contains("textChapter.isCompleted"))
     }
 
     private fun assertOrder(source: String, vararg expected: String) {


### PR DESCRIPTION
## Summary

- 排版通道正常结束后直接解析正文刷新位置锚点，避免完成回调的跨线程时序导致偶发跳过
- 补充排版通道耗尽后解析锚点的契约测试

## Testing

- `git diff --check`
- GitHub Actions Test Build（待运行）

Follow-up to #839.
