### PR TITLE
修复透明标题栏标签文字对比度

### DIFF
--- a/app/src/main/java/io/legado/app/ui/widget/TitleBar.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/TitleBar.kt
@@ -20,14 +20,18 @@ import androidx.core.view.forEach
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.children
 import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.tabs.TabLayout
 import io.legado.app.R
 import io.legado.app.help.config.AppConfig
+import io.legado.app.lib.theme.backgroundColor
 import io.legado.app.lib.theme.elevation
 import io.legado.app.lib.theme.getToolbarTextColor
 import io.legado.app.lib.theme.primaryColor
 import io.legado.app.lib.theme.transparentNavBar
+import io.legado.app.utils.ColorUtils
 import io.legado.app.utils.activity
 import io.legado.app.utils.applyTint
+import io.legado.app.utils.getCompatColor
 import io.legado.app.utils.setOnApplyWindowInsetsListenerCompat
 import splitties.views.bottomPadding
 import splitties.views.topPadding
@@ -233,6 +237,15 @@ class TitleBar @JvmOverloads constructor(
         toolbar.navigationIcon?.colorFilter = colorFilter
         toolbar.overflowIcon?.colorFilter = colorFilter
         toolbar.findViewById<SearchView>(R.id.search_view)?.applyTint(color)
+        val tabUnselectedColor = context.getCompatColor(
+            if (ColorUtils.isColorLight(context.backgroundColor)) {
+                R.color.md_light_secondary
+            } else {
+                R.color.md_dark_secondary
+            }
+        )
+        toolbar.findViewById<TabLayout>(R.id.tab_layout)
+            ?.setTabTextColors(tabUnselectedColor, color)
         toolbar.menu.forEach { item ->
             (item.actionView as? SearchView)?.applyTint(color)
         }

--- a/app/src/test/java/io/legado/app/ui/source/SourceImmersiveBackgroundTest.kt
+++ b/app/src/test/java/io/legado/app/ui/source/SourceImmersiveBackgroundTest.kt
@@ -58,6 +58,10 @@ class SourceImmersiveBackgroundTest {
         assertTrue(titleBar.contains("toolbar.navigationIcon?.colorFilter = colorFilter"))
         assertTrue(titleBar.contains("toolbar.overflowIcon?.colorFilter = colorFilter"))
         assertTrue(titleBar.contains("findViewById<SearchView>(R.id.search_view)?.applyTint(color)"))
+        assertTrue(titleBar.contains("findViewById<TabLayout>(R.id.tab_layout)"))
+        assertTrue(titleBar.contains("setTabTextColors(tabUnselectedColor, color)"))
+        assertTrue(titleBar.contains("R.color.md_light_secondary"))
+        assertTrue(titleBar.contains("R.color.md_dark_secondary"))
         assertTrue(titleBar.contains("toolbar.menu.forEach { item ->"))
 
         val menu = projectFile("src/main/java/io/legado/app/utils/MenuExtensions.kt").readText()


### PR DESCRIPTION
## 变更

- 透明 `TitleBar` 也按实际可见页面背景更新内嵌 `TabLayout` 文字色
- 复用现有主/次文字色资源，保留选中与未选中标签层级
- 共享修复书架分组与目录标签，不改变不透明栏、E-Ink 或显式主题

参考 `skybbk1001/legadoT@1c2ae751ad` 与 `skybbk1001/legadoT@529442a836` 暴露的标签对比度问题，按当前 AppCompat `TitleBar` 架构做最小根因修复。

## 验证

- `git diff --check`
- 现有透明栏契约测试补充 Tab 接线断言
- 核对 Material 1.13 默认 Tab selector：selected 使用 primary，unselected 使用 secondary
- 本地首次 Android 编译在 5 分钟低资源限时内未完成，已终止；交由 CI 完成编译与双变体构建