### PR TITLE
补充 JS 书源 variable 字符串兼容测试

### DIFF
--- a/app/src/test/java/io/legado/app/model/jsSource/JsSourceMarshallerTest.kt
+++ b/app/src/test/java/io/legado/app/model/jsSource/JsSourceMarshallerTest.kt
@@ -86,7 +86,7 @@ class JsSourceMarshallerTest {
     }
 
     @Test
-    fun `accepts object variable in book info`() {
+    fun `accepts object and JSON string variable in book info`() {
         val book = Book(bookUrl = "https://source.example/book")
         book.variable = """{"old":"value"}"""
         assertEquals("value", book.variableMap["old"])
@@ -100,6 +100,16 @@ class JsSourceMarshallerTest {
 
         assertEquals("abc", book.variableMap["token"])
         assertNull(book.variableMap["old"])
+
+        JsSourceMarshaller.mergeBookInfo(
+            book,
+            """{"variable":"{\"session\":\"xyz\"}"}""",
+            textSource,
+            canReName = true,
+        )
+
+        assertEquals("xyz", book.variableMap["session"])
+        assertNull(book.variableMap["token"])
     }
 
     @Test


### PR DESCRIPTION
## 说明

- 延续 #831 的 JavaScript 书源封送兼容性覆盖
- 在现有 variable 测试中同时验证对象和 JSON 字符串两种文档化输入
- 验证第二次整体替换会写入新键并清除旧键
- 不修改生产行为

参考 fork 提交 skybbk1001/legadoT@97d80e3d3c4483832d29e0e8dd54cb4e68fab5c4 中的字符串输入回归用例，按当前主线测试结构做最小适配。

## 验证

- git diff --check
- PowerShell ConvertFrom-Json 双层解析测试 fixture，得到 session=xyz
- 静态确认生产实现的 JsonObject / JSON string 两个分支均由该测试覆盖
- 按低资源约束未在本地重新启动 Android Gradle 编译，交由 PR CI 执行单元测试与双变体构建