### PR TITLE
为旧版登录密码字段添加可见性切换

### DIFF
--- a/app/src/main/java/io/legado/app/ui/login/SourceLoginDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/login/SourceLoginDialog.kt
@@ -397,6 +397,8 @@ class SourceLoginDialog : BaseDialogFragment(R.layout.dialog_login, true),
                     }
                     editText.inputType =
                         InputType.TYPE_TEXT_VARIATION_PASSWORD or InputType.TYPE_CLASS_TEXT
+                    it.textInputLayout.endIconMode =
+                        com.google.android.material.textfield.TextInputLayout.END_ICON_PASSWORD_TOGGLE
                     editText.setText(loginInfo[name] ?: default)
                     action?.let { jsStr ->
                         val watcher = object : TextWatcher {

--- a/app/src/test/java/io/legado/app/ui/login/SourceEditInputTouchTargetTest.kt
+++ b/app/src/test/java/io/legado/app/ui/login/SourceEditInputTouchTargetTest.kt
@@ -27,6 +27,23 @@ class SourceEditInputTouchTargetTest {
         assertTrue(source.contains("ItemSourceEditBinding.inflate("))
     }
 
+    @Test
+    fun `legacy and v2 password fields expose visibility toggles`() {
+        val legacy = readProjectFile(
+            "src/main/java/io/legado/app/ui/login/SourceLoginDialog.kt"
+        )
+        val legacyPassword = legacy.substringAfter(
+            "Type.password -> ItemSourceEditBinding.inflate(",
+            missingDelimiterValue = ""
+        ).substringBefore("\n                Type.")
+        val v2 = readProjectFile(
+            "src/main/java/io/legado/app/ui/login/SourceLoginV2Delegate.kt"
+        )
+
+        assertTrue(legacyPassword.contains("TextInputLayout.END_ICON_PASSWORD_TOGGLE"))
+        assertTrue(v2.contains("TextInputLayout.END_ICON_PASSWORD_TOGGLE"))
+    }
+
     private fun readProjectFile(pathInApp: String): String {
         val file = sequenceOf(File(pathInApp), File("app/$pathInApp"))
             .firstOrNull(File::isFile)


### PR DESCRIPTION
## 变更
- 为旧版登录表单的密码字段启用 Material 密码可见性切换
- 沿用现有 `ItemSourceEditBinding`，与 Login UI v2 行为保持一致
- 增加聚焦契约测试，锁定旧版和 v2 两条密码路径

## 背景
审计 `skybbk1001/legadoT@ebc57ed617` 时发现该独立残差。原提交同时引入了 fork 专用登录布局；这里仅按当前主线组件做最小适配，不搬运布局或 UI 架构。

## 验证
- `git diff --check`
- 静态执行校验确认旧版 `Type.password` 分支与 v2 分支都设置 `END_ICON_PASSWORD_TOGGLE`
- 为避免本机 Android 构建的高资源占用，未运行本地 Gradle；以 PR 的单元测试和双发布变体构建为最终验收