### PR TITLE
修复源编辑器光标跟随输入法布局

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt
@@ -332,11 +332,11 @@ class BookSourceEditActivity :
         binding.recyclerView.adapter = adapter
         binding.fieldNav.bindFieldNavigation(binding.recyclerView)
         binding.recyclerView.viewTreeObserver.addOnGlobalFocusChangeListener { oldFocus, newFocus ->
-            (oldFocus as? CodeView)?.setOnClickListener(null)
-            if (newFocus is CodeView) {
-                newFocus.setOnClickListener { sendText("") }
-                newFocus.postDelayed({ sendText("") }, 120)
-            }
+            (oldFocus as? CodeView)?.keepSelectionVisible = false
+            (newFocus as? CodeView)?.keepSelectionVisible = true
+        }
+        binding.recyclerView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+            (binding.recyclerView.findFocus() as? CodeView)?.requestSelectionVisible()
         }
         val transparentBar = transparentNavBar && !AppConfig.isEInkMode
         listOf(binding.tabLayout, binding.fieldNav).forEach { tabs ->
@@ -901,31 +901,6 @@ class BookSourceEditActivity :
                     edit.append(text)
                 } else {
                     edit.replace(start, end, text)//光标所在位置插入文字
-                }
-            }
-            if (adapter.editEntityMaxLine >= 999) {
-                view.post {
-                    val editTextLocation = IntArray(2)
-                    view.getLocationOnScreen(editTextLocation)
-                    val recyclerViewLocation = IntArray(2)
-                    binding.recyclerView.getLocationOnScreen(recyclerViewLocation)
-                    val layout = view.layout
-                    if (layout != null) {
-                        val line = layout.getLineForOffset(end)
-                        val cursorYInEditText = layout.getLineTop(line)
-                        // 光标相对于屏幕的位置
-                        val cursorYOnScreen = editTextLocation[1] + cursorYInEditText
-                        // 光标相对于RecyclerView的位置
-                        val cursorYInRecyclerView = cursorYOnScreen - recyclerViewLocation[1]
-                        val recyclerViewBottom = binding.recyclerView.height - 120 //考虑键盘的经验值
-                        // 如果光标不在可见范围内，则滚动到光标位置
-                        if (cursorYInRecyclerView !in 0..recyclerViewBottom) {
-                            val scrollDistance = cursorYInRecyclerView - recyclerViewBottom / 3
-                            if (scrollDistance > 0 && binding.recyclerView.canScrollVertically(1) || scrollDistance < 0 && binding.recyclerView.canScrollVertically(-1)) {
-                                binding.recyclerView.smoothScrollBy(0, scrollDistance)
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/app/src/main/java/io/legado/app/ui/rss/source/edit/RssSourceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/rss/source/edit/RssSourceEditActivity.kt
@@ -309,11 +309,11 @@ class RssSourceEditActivity :
         binding.recyclerView.adapter = adapter
         binding.fieldNav.bindFieldNavigation(binding.recyclerView)
         binding.recyclerView.viewTreeObserver.addOnGlobalFocusChangeListener { oldFocus, newFocus ->
-            (oldFocus as? CodeView)?.setOnClickListener(null)
-            if (newFocus is CodeView) {
-                newFocus.setOnClickListener { sendText("") }
-                newFocus.postDelayed({ sendText("") }, 120)
-            }
+            (oldFocus as? CodeView)?.keepSelectionVisible = false
+            (newFocus as? CodeView)?.keepSelectionVisible = true
+        }
+        binding.recyclerView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+            (binding.recyclerView.findFocus() as? CodeView)?.requestSelectionVisible()
         }
         val transparentBar = transparentNavBar && !AppConfig.isEInkMode
         listOf(binding.tabLayout, binding.fieldNav).forEach { tabs ->
@@ -655,31 +655,6 @@ class RssSourceEditActivity :
                     edit.append(text)
                 } else {
                     edit.replace(start, end, text)//光标所在位置插入文字
-                }
-            }
-            if (adapter.editEntityMaxLine >= 999) {
-                view.post {
-                    val editTextLocation = IntArray(2)
-                    view.getLocationOnScreen(editTextLocation)
-                    val recyclerViewLocation = IntArray(2)
-                    binding.recyclerView.getLocationOnScreen(recyclerViewLocation)
-                    val layout = view.layout
-                    if (layout != null) {
-                        val line = layout.getLineForOffset(end)
-                        val cursorYInEditText = layout.getLineTop(line)
-                        // 光标相对于屏幕的位置
-                        val cursorYOnScreen = editTextLocation[1] + cursorYInEditText
-                        // 光标相对于RecyclerView的位置
-                        val cursorYInRecyclerView = cursorYOnScreen - recyclerViewLocation[1]
-                        val recyclerViewBottom = binding.recyclerView.height - 120 //考虑键盘的经验值
-                        // 如果光标不在可见范围内，则滚动到光标位置
-                        if (cursorYInRecyclerView !in 0..recyclerViewBottom) {
-                            val scrollDistance = cursorYInRecyclerView - recyclerViewBottom / 3
-                            if (scrollDistance > 0 && binding.recyclerView.canScrollVertically(1) || scrollDistance < 0 && binding.recyclerView.canScrollVertically(-1)) {
-                                binding.recyclerView.smoothScrollBy(0, scrollDistance)
-                            }
-                        }
-                    }
                 }
             }
         }

--- a/app/src/main/java/io/legado/app/ui/widget/code/CodeView.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/code/CodeView.kt
@@ -39,6 +39,19 @@ class CodeView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
     private var largeTextMode = false
     private val mUpdateHandler = Handler(Looper.getMainLooper())
     private var mAutoCompleteTokenizer: Tokenizer? = null
+    private val selectionVisibilityRunnable = Runnable {
+        if (keepSelectionVisible && isFocused &&
+            selectionStart == selectionEnd && selectionEnd >= 0
+        ) {
+            bringPointIntoView(selectionEnd)
+        }
+    }
+    internal var keepSelectionVisible = false
+        set(value) {
+            field = value
+            if (value) requestSelectionVisible() else removeCallbacks(selectionVisibilityRunnable)
+        }
+
     private val displayDensity = resources.displayMetrics.density
     private val mErrorHashSet: SortedMap<Int, Int> = TreeMap()
     private val mSyntaxPatternMap: MutableMap<Pattern, Int> = HashMap()
@@ -120,6 +133,22 @@ class CodeView @JvmOverloads constructor(context: Context, attrs: AttributeSet? 
                 event.keyCode == KeyEvent.KEYCODE_PAGE_DOWN ||
                 event.keyCode == KeyEvent.KEYCODE_MOVE_HOME ||
                 event.keyCode == KeyEvent.KEYCODE_MOVE_END
+    }
+
+    override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+        super.onSelectionChanged(selStart, selEnd)
+        if (keepSelectionVisible) requestSelectionVisible()
+    }
+
+    override fun performClick(): Boolean {
+        val handled = super.performClick()
+        if (keepSelectionVisible) requestSelectionVisible()
+        return handled
+    }
+
+    internal fun requestSelectionVisible() {
+        removeCallbacks(selectionVisibilityRunnable)
+        post(selectionVisibilityRunnable)
     }
 
     override fun showDropDown() {

--- a/app/src/test/java/io/legado/app/ui/book/source/edit/BookSourceEditLayoutTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/source/edit/BookSourceEditLayoutTest.kt
@@ -103,21 +103,35 @@ class BookSourceEditLayoutTest {
     }
 
     @Test
-    fun `source editor suppresses focus scrolling and follows repeated caret taps`() {
+    fun `source editor keeps the caret visible after selection and layout changes`() {
         val source = File(repositoryRoot, ACTIVITY_PATH).readText()
         val initView = source.section("private fun initView()", "private fun initOptionPanel()")
         val sendText = source.section("override fun sendText(text: String)", "private fun setSourceVariable()")
         val layoutManager = File(repositoryRoot, LAYOUT_MANAGER_PATH).readText()
+        val codeView = File(repositoryRoot, CODE_VIEW_PATH).readText()
 
         assertTrue(initView.contains("binding.recyclerView.layoutManager = NoChildScrollLinearLayoutManager(this)"))
         assertFalse(initView.contains("adapter.editEntityMaxLine < 999"))
         assertTrue(layoutManager.contains("override fun onRequestChildFocus("))
         assertTrue(layoutManager.contains("return true"))
         assertFalse(layoutManager.contains("requestChildRectangleOnScreen"))
-        assertTrue(initView.contains("newFocus.postDelayed({ sendText(\"\") }, 120)"))
-        assertTrue(initView.contains("(oldFocus as? CodeView)?.setOnClickListener(null)"))
-        assertTrue(initView.contains("newFocus.setOnClickListener { sendText(\"\") }"))
-        assertTrue(sendText.contains("binding.recyclerView.smoothScrollBy(0, scrollDistance)"))
+        assertTrue(initView.contains("(oldFocus as? CodeView)?.keepSelectionVisible = false"))
+        assertTrue(initView.contains("(newFocus as? CodeView)?.keepSelectionVisible = true"))
+        assertTrue(initView.contains("binding.recyclerView.addOnLayoutChangeListener"))
+        assertTrue(initView.contains("(binding.recyclerView.findFocus() as? CodeView)?.requestSelectionVisible()"))
+        assertTrue(codeView.contains("override fun onSelectionChanged("))
+        assertTrue(codeView.contains("super.onSelectionChanged(selStart, selEnd)"))
+        assertTrue(codeView.contains("override fun performClick(): Boolean"))
+        assertTrue(codeView.contains("val handled = super.performClick()"))
+        assertTrue(codeView.contains("removeCallbacks(selectionVisibilityRunnable)"))
+        assertTrue(codeView.contains("post(selectionVisibilityRunnable)"))
+        assertTrue(codeView.contains("keepSelectionVisible && isFocused"))
+        assertTrue(codeView.contains("selectionStart == selectionEnd && selectionEnd >= 0"))
+        assertTrue(codeView.contains("bringPointIntoView(selectionEnd)"))
+        assertFalse(codeView.contains("MotionEvent.ACTION_UP"))
+        assertFalse(initView.contains("setOnClickListener { sendText(\"\") }"))
+        assertFalse(sendText.contains("smoothScrollBy"))
+        assertFalse(sendText.contains("editEntityMaxLine"))
     }
 
     @Test
@@ -228,6 +242,8 @@ class BookSourceEditLayoutTest {
             "app/src/main/java/io/legado/app/ui/widget/FieldNavigationExtensions.kt"
         const val LAYOUT_MANAGER_PATH =
             "app/src/main/java/io/legado/app/ui/widget/recycler/NoChildScrollLinearLayoutManager.kt"
+        const val CODE_VIEW_PATH =
+            "app/src/main/java/io/legado/app/ui/widget/code/CodeView.kt"
         const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
         const val APP_NAMESPACE = "http://schemas.android.com/apk/res-auto"
         val CHECK_BOX_IDS = listOf(

--- a/app/src/test/java/io/legado/app/ui/rss/source/edit/RssSourceEditLayoutTest.kt
+++ b/app/src/test/java/io/legado/app/ui/rss/source/edit/RssSourceEditLayoutTest.kt
@@ -100,7 +100,7 @@ class RssSourceEditLayoutTest {
     }
 
     @Test
-    fun `editor suppresses code focus scrolling and follows repeated caret taps`() {
+    fun `editor keeps the caret visible after selection and layout changes`() {
         val source = File(repositoryRoot, ACTIVITY_PATH).readText()
         val initView = source.section("private fun initView()", "private fun initOptionPanel()")
         val sendText = source.section("override fun sendText(text: String)", "@RequiresApi")
@@ -108,10 +108,13 @@ class RssSourceEditLayoutTest {
         assertTrue(initView.contains("override fun onRequestChildFocus("))
         assertTrue(initView.contains(") = focused is CodeView"))
         assertFalse(initView.contains("requestChildRectangleOnScreen"))
-        assertTrue(initView.contains("(oldFocus as? CodeView)?.setOnClickListener(null)"))
-        assertTrue(initView.contains("newFocus.setOnClickListener { sendText(\"\") }"))
-        assertTrue(initView.contains("newFocus.postDelayed({ sendText(\"\") }, 120)"))
-        assertTrue(sendText.contains("binding.recyclerView.smoothScrollBy(0, scrollDistance)"))
+        assertTrue(initView.contains("(oldFocus as? CodeView)?.keepSelectionVisible = false"))
+        assertTrue(initView.contains("(newFocus as? CodeView)?.keepSelectionVisible = true"))
+        assertTrue(initView.contains("binding.recyclerView.addOnLayoutChangeListener"))
+        assertTrue(initView.contains("(binding.recyclerView.findFocus() as? CodeView)?.requestSelectionVisible()"))
+        assertFalse(initView.contains("setOnClickListener { sendText(\"\") }"))
+        assertFalse(sendText.contains("smoothScrollBy"))
+        assertFalse(sendText.contains("editEntityMaxLine"))
     }
 
     private fun parse(path: String): Document =


### PR DESCRIPTION
## 变更说明

#854 只在点击时调用旧的 `sendText("")` 手工滚动；选择变化、同位置重复点按以及输入法/辅助键盘完成布局后的路径仍可能漏掉，且固定 120px 与 `editEntityMaxLine >= 999` 无法反映真实可见区域。

本次让书源和 RSS 编辑页在 CodeView 获得焦点时启用光标跟随：选择变化、普通点击及 RecyclerView 布局完成后，统一合并到下一次消息循环调用 Android 原生 `bringPointIntoView(selectionEnd)`。原生实现会同时处理文本内部滚动、padding 和父容器矩形请求；范围选区仍交给系统处理。删除两页旧的固定像素/最大行数分支，并不再覆盖 Adapter 的点击监听。

关联 Issue：Fixes #851

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 构建或依赖
- [ ] 重构或维护

## 涉及平台

- [x] Android
- [ ] Web
- [ ] Android 与 Web

## 涉及模块

- [ ] 阅读文本与翻页
- [ ] 漫画阅读
- [ ] 朗读与音频
- [ ] 书架与书籍管理
- [x] 书源与规则解析
- [ ] Web 服务与前端
- [ ] 备份、同步与数据
- [ ] 构建、安装与更新
- [ ] 其他或不确定

## 影响类型

- [ ] 崩溃或无响应
- [ ] 数据丢失或损坏
- [ ] 性能或耗电
- [x] 兼容性
- [x] 界面或交互
- [ ] 功能结果错误
- [ ] 无用户可见影响

## 验证

- [x] `git diff --check`
- [x] 两页源码契约覆盖焦点启停、RecyclerView 布局重试、无旧手工滚动
- [x] CodeView 契约覆盖 selection/click、任务合并、折叠光标与原生可见性调用
- [x] 独立代码审查无阻断
- [x] 已完成与改动范围相符的验证
- [x] 未引入无关改动