### PR TITLE
补充 CryptoJS 使用说明

### DIFF
--- a/app/src/main/assets/web/help/md/jsHelp.md
+++ b/app/src/main/assets/web/help/md/jsHelp.md
@@ -371,6 +371,8 @@ java.deleteFile(path: String): Boolean
 
 ### [js加解密类](https://github.com/LegadoTeam/legado/blob/master/app/src/main/java/io/legado/app/help/JsEncodeUtils.kt) 部分函数
 
+> 规则和 JavaScript 书源中可直接使用内置的 `CryptoJS`，例如 `CryptoJS.MD5("text").toString()`。
+
 > 提供在JavaScript环境中快捷调用crypto算法的函数，由[hutool-crypto](https://www.hutool.cn/docs/#/crypto/概述)实现  
 > 由于兼容性问题，hutool-crypto当前版本为5.8.22  
 


### PR DESCRIPTION
参考 skybbk1001/legadoT@653c0fd9de4698d5aff84e5fca9936d42e4ca0ad 的文档增量，仅补齐主线仍缺的 CryptoJS 使用说明；网络选项部分主线已有更严格实现。示例显式调用 toString()，并与 Hutool java.* 说明分段。验证：定向 CryptoJsCompatibilityTest 通过；git diff --check 通过。