### PR TITLE
修复正式发布工作流无效构建变体

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        product: [ app, google ]
+        product: [ app ]
       fail-fast: false
     runs-on: ubuntu-latest
     env:

--- a/app/src/test/java/io/legado/app/ci/ReleaseWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/ReleaseWorkflowTest.kt
@@ -1,5 +1,6 @@
 package io.legado.app.ci
 
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -28,5 +29,15 @@ class ReleaseWorkflowTest {
 
         assertTrue(checkoutStep.contains("- uses: actions/checkout@"))
         assertTrue(checkoutStep.contains("fetch-depth: 0"))
+    }
+
+    @Test
+    fun `release matrix only builds existing product flavors`() {
+        val matrix = workflowText
+            .substringAfter("    strategy:\n")
+            .substringBefore("      fail-fast:")
+
+        assertTrue(matrix.contains("product: [ app ]"))
+        assertFalse(matrix.contains("google"))
     }
 }


### PR DESCRIPTION
## 变更内容
- 正式发布矩阵只调度当前存在的 `app` product flavor
- 增加工作流契约测试，防止已删除的 `google` flavor 再次进入矩阵

## 原因
`google` flavor 与 `app/src/google` 已在 `543c3548aa` 删除，但正式发布工作流仍执行 `assembleGoogleRelease`。Gradle 任务查询会明确报错 `Task 'assembleGoogleRelease' not found`；分叉修复前的真实 Actions run `32098798115` 也在 `build (google)` 以同一错误失败。参考 `skybbk1001/legadoT@f7bef5eeed`，按当前主线最小适配。

## 验证
- `./gradlew :app:help --task assembleGoogleRelease --no-daemon --max-workers=2 --console=plain`（修复前确认任务不存在）
- `./gradlew :app:testAppReleaseUnitTest --tests io.legado.app.ci.ReleaseWorkflowTest --no-daemon --max-workers=2 --console=plain`（2 项通过）
- `git diff --check`