### PR TITLE
fix(toc): 隔离失效后的目录标题缓存任务

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/ChapterListAdapter.kt
@@ -38,7 +38,8 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
 
     val cacheFileNames = hashSetOf<String>()
     val audioCacheKeys = hashSetOf<AudioCacheKey>()
-    private val displayTitleMap = ConcurrentHashMap<String, String>()
+    @Volatile
+    private var displayTitleMap = ConcurrentHashMap<String, String>()
     private val handler = Handler(Looper.getMainLooper())
     private val baseStartPadding = 12.dpToPx()
     private val depthIndent = 10.dpToPx()
@@ -110,12 +111,13 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
 
     fun clearDisplayTitle() {
         upDisplayTitleJob?.cancel()
-        displayTitleMap.clear()
+        displayTitleMap = ConcurrentHashMap()
     }
 
     fun upDisplayTitles(startIndex: Int) {
         if (released) return
         upDisplayTitleJob?.cancel()
+        val displayTitleMap = displayTitleMap
         upDisplayTitleJob = Coroutine.async(callback.scope) {
             val book = callback.book ?: return@async
             val items = getItems()
@@ -126,12 +128,16 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
             val useReplace = AppConfig.tocUiUseReplace && book.getUseReplaceRule()
             launch {
                 for (i in safeStartIndex until items.size) {
-                    updateDisplayTitle(items, i, replaceRules, useReplace, replaceBook)
+                    updateDisplayTitle(
+                        items, i, replaceRules, useReplace, replaceBook, displayTitleMap
+                    )
                 }
             }
             launch {
                 for (i in safeStartIndex - 1 downTo 0) {
-                    updateDisplayTitle(items, i, replaceRules, useReplace, replaceBook)
+                    updateDisplayTitle(
+                        items, i, replaceRules, useReplace, replaceBook, displayTitleMap
+                    )
                 }
             }
         }
@@ -143,6 +149,7 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
         replaceRules: List<io.legado.app.data.entities.ReplaceRule>,
         useReplace: Boolean,
         replaceBook: ReplaceBook,
+        displayTitleMap: ConcurrentHashMap<String, String>,
     ) {
         val item = items[index]
         val chapter = item.chapter
@@ -156,7 +163,9 @@ class ChapterListAdapter(context: Context, val callback: Callback) :
         currentCoroutineContext().ensureActive()
         displayTitleMap[item.key] = displayTitle
         handler.post {
-            if (!released && getItem(index)?.key == item.key) {
+            if (displayTitleMap === this.displayTitleMap &&
+                !released && getItem(index)?.key == item.key
+            ) {
                 notifyItemChanged(index, true)
             }
         }

--- a/app/src/test/java/io/legado/app/ui/book/toc/ChapterListAdapterContractTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/toc/ChapterListAdapterContractTest.kt
@@ -1,9 +1,11 @@
 package io.legado.app.ui.book.toc
 
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 class ChapterListAdapterContractTest {
 
@@ -32,5 +34,38 @@ class ChapterListAdapterContractTest {
         val resetItems = initBook.indexOf("adapter.setItems(emptyList())")
 
         assertTrue(clearCache in 0 until resetItems)
+    }
+
+    @Test
+    fun `display title workers keep an isolated cache snapshot`() {
+        val source = sequenceOf(File("src/main/java"), File("app/src/main/java"))
+            .first { it.isDirectory }
+            .resolve("io/legado/app/ui/book/toc/ChapterListAdapter.kt")
+            .readText()
+        val clearCache = source.substringAfter("fun clearDisplayTitle()")
+            .substringBefore("fun upDisplayTitles")
+        val updateTitles = source.substringAfter("fun upDisplayTitles")
+            .substringBefore("private suspend fun updateDisplayTitle")
+
+        assertTrue(source.contains("@Volatile\n    private var displayTitleMap"))
+        assertTrue(clearCache.contains("displayTitleMap = ConcurrentHashMap()"))
+        assertFalse(clearCache.contains("displayTitleMap.clear()"))
+        assertTrue(
+            updateTitles.indexOf("val displayTitleMap = displayTitleMap") in
+                    0 until updateTitles.indexOf("Coroutine.async")
+        )
+        assertTrue(source.contains("displayTitleMap: ConcurrentHashMap<String, String>"))
+        assertTrue(source.contains("displayTitleMap === this.displayTitleMap"))
+    }
+
+    @Test
+    fun `stale worker writes stay in the replaced cache`() {
+        var activeCache = ConcurrentHashMap<String, String>()
+        val staleWorkerCache = activeCache
+
+        activeCache = ConcurrentHashMap()
+        staleWorkerCache["chapter:0"] = "old title"
+
+        assertNull(activeCache["chapter:0"])
     }
 }


### PR DESCRIPTION
## 变更说明

完整重载目录时，旧标题计算协程可能已经通过取消检查，随后越过 `clear()` 把旧标题重新写入当前缓存，导致 #948 修复仍存在窄竞态。

本改动在缓存失效时替换为新的 volatile `ConcurrentHashMap`，并让每个标题 worker 在启动前捕获当前 map 实例。旧 worker 即使晚到也只能写入废弃实例，其已排队的 UI 回调也会通过实例身份检查退出。

关联 Issue：Refs #948

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 构建或依赖
- [ ] 重构或维护

## 涉及平台

- [x] Android
- [ ] Web
- [ ] Android 与 Web

## 涉及模块

- [x] 阅读文本与翻页
- [ ] 漫画阅读
- [ ] 朗读与音频
- [ ] 书架与书籍管理
- [ ] 书源与规则解析
- [ ] Web 服务与前端
- [ ] 备份、同步与数据
- [ ] 构建、安装与更新
- [ ] 其他或不确定

## 影响类型

- [ ] 崩溃或无响应
- [ ] 数据丢失或损坏
- [ ] 性能或耗电
- [ ] 兼容性
- [x] 界面或交互
- [x] 功能结果错误
- [ ] 无用户可见影响

## 验证

- `ANDROID_HOME=C:\Users\miaogongzi\AppData\Local\Android\Sdk .\gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.ui.book.toc.ChapterListAdapterContractTest --no-daemon --no-configuration-cache --console=plain`：4 个测试通过，0 failures/errors/skipped
- `git diff HEAD^ HEAD --check`：通过
- [x] 已完成与改动范围相符的验证
- [x] 未引入无关改动
