### PR TITLE
统一多列封面书名字号

### DIFF
--- a/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
@@ -44,6 +44,20 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import splitties.init.appCtx
 
+internal fun coverTitleTextSize(
+    viewWidth: Float,
+    viewHeight: Float,
+    characterCount: Int,
+    largeTextHeight: Float
+): Float = if (
+    (characterCount - 2) * largeTextHeight > viewHeight * 0.7f ||
+    (characterCount - 3) * largeTextHeight > viewHeight * 0.6f
+) {
+    viewWidth / 10
+} else {
+    viewWidth / 7
+}
+
 /**
  * 封面
  */
@@ -186,6 +200,12 @@ class CoverImageView @JvmOverloads constructor(
         name?.toStringArray()?.let { name ->
             var line = 0
             namePaint.textSize = viewWidth / 7
+            namePaint.textSize = coverTitleTextSize(
+                viewWidth,
+                viewHeight,
+                name.size,
+                namePaint.textHeight
+            )
             namePaint.strokeWidth = namePaint.textSize / 6
             name.forEachIndexed { index, char ->
                 namePaint.color = backgroundColor
@@ -198,18 +218,15 @@ class CoverImageView @JvmOverloads constructor(
                 if (startY > viewHeight * 0.9) {
                     if ((name.size - index - 1) == 1) { //只剩一个字
                         startY -= namePaint.textHeight / 5
-                        namePaint.textSize = viewWidth / 9
                         return@forEachIndexed
                     }
                     startX += namePaint.textSize
                     line++
-                    namePaint.textSize = viewWidth / 10
                     startY = viewHeight * 0.2f + namePaint.textHeight * line
                 }
                 else if (startY > viewHeight * 0.8 && (name.size - index - 1) > 2) { //剩余字数大于2
                     startX += namePaint.textSize
                     line++
-                    namePaint.textSize = viewWidth / 10
                     startY = viewHeight * 0.2f + namePaint.textHeight * line
                 }
             }

--- a/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
+++ b/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
@@ -3,6 +3,7 @@ package io.legado.app
 import io.legado.app.data.entities.Book
 import io.legado.app.service.buildHttpTtsCacheFileName
 import io.legado.app.ui.book.info.normalizeWebFileName
+import io.legado.app.ui.widget.image.coverTitleTextSize
 import io.legado.app.utils.calculateSvgBitmapSize
 import io.legado.app.utils.isForegroundServiceStartDenied
 import org.junit.Assert.assertEquals
@@ -109,6 +110,35 @@ class RuntimeMediaStabilityTest {
         assertTrue(generation.contains("nameBitmapCache.put(cacheKey, bitmap)"))
         assertTrue(generation.contains("currentNameBitmap = cacheKey to bitmap"))
         assertTrue(generation.contains("postInvalidate()"))
+    }
+
+    @Test
+    fun textCoverKeepsOneTitleSizeAcrossColumns() {
+        val width = 105f
+        val height = 140f
+        val largeTextHeight = 18f
+
+        for (characterCount in 4..7) {
+            assertEquals(
+                width / 7,
+                coverTitleTextSize(width, height, characterCount, largeTextHeight),
+                0.001f
+            )
+        }
+        assertEquals(
+            width / 10,
+            coverTitleTextSize(width, height, 8, largeTextHeight),
+            0.001f
+        )
+
+        val source = listOf(File("src/main/java"), File("app/src/main/java"))
+            .first { it.isDirectory }
+            .resolve("io/legado/app/ui/widget/image/CoverImageView.kt")
+            .readText()
+        val titleLoop = source.substringAfter("name.forEachIndexed { index, char ->")
+            .substringBefore("if (!drawBookAuthor)")
+
+        assertFalse(titleLoop.contains("namePaint.textSize ="))
     }
 
     @Test


### PR DESCRIPTION
## 变更

- 在绘制前一次性选择书名字号：短书名保持原大字号，需要分列时统一使用紧凑字号
- 移除逐字绘制过程中对字号的修改，避免第一列与后续列大小不一致
- 增加回归测试，覆盖短书名、长书名与绘制循环不再改字号

## 验证

- `./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.RuntimeMediaStabilityTest --no-daemon --max-workers=1`
- 9 tests, 0 failures, 0 errors, 0 skipped

Refs #954