### PR TITLE
fix: clean review markup from book exports

### DIFF
--- a/app/src/main/java/io/legado/app/service/ExportBookService.kt
+++ b/app/src/main/java/io/legado/app/service/ExportBookService.kt
@@ -362,7 +362,7 @@ class ExportBookService : BaseService() {
         return resolveExportChapterContent(
             content = BookHelp.getContent(book, chapter),
             isVolume = chapter.isVolume
-        )
+        )?.let(::sanitizeExportContent)
     }
 
     private suspend fun exportTxt(path: String, book: Book) {
@@ -578,15 +578,17 @@ class ExportBookService : BaseService() {
                             imagePdfContentBlocks(rawContent, exportChapter.isVolume)
                         } else {
                             val textContent = rawContent ?: return@forEachIndexed
-                            val displayContent = contentProcessor.getContent(
-                                book,
-                                exportChapter,
-                                textContent,
-                                includeTitle = false,
-                                useReplace = useReplace,
-                                chineseConvert = false,
-                                reSegment = false
-                            ).toString()
+                            val displayContent = sanitizeExportContent(
+                                contentProcessor.getContent(
+                                    book,
+                                    exportChapter,
+                                    textContent,
+                                    includeTitle = false,
+                                    useReplace = useReplace,
+                                    chineseConvert = false,
+                                    reSegment = false
+                                ).toString()
+                            )
                             splitPdfContentBlocks(displayContent)
                         }
                         if (!AppConfig.exportNoChapterName) {
@@ -741,7 +743,7 @@ class ExportBookService : BaseService() {
                 "\n" + HtmlFormatter.format(book.getDisplayIntro())
             )
         }"
-        append(qy, null)
+        append(sanitizeExportContent(qy), null)
         val threads = if (AppConfig.parallelExportBook) {
             AppConst.MAX_THREAD
         } else {
@@ -769,17 +771,18 @@ class ExportBookService : BaseService() {
     ): Pair<String, ArrayList<SrcData>?> {
         val content = getChapterContentForExport(book, chapter)
             ?: return Pair("", null)
-        val content1 = contentProcessor
-            .getContent(
+        val content1 = HtmlFormatter.format(
+            contentProcessor.getContent(
                 book,
                 // 不导出vip标识
                 chapter.apply { isVip = false },
-                content,
+                removeExportImages(content),
                 includeTitle = !AppConfig.exportNoChapterName,
                 useReplace = useReplace,
                 chineseConvert = false,
                 reSegment = false
             ).toString()
+        )
         if (AppConfig.exportPictureFile) {
             //txt导出图片文件
             val srcList = arrayListOf<SrcData>()
@@ -1010,8 +1013,8 @@ class ExportBookService : BaseService() {
             )
             // 不导出vip标识
             chapter.isVip = false
-            val content1 = contentProcessor
-                .getContent(
+            val content1 = sanitizeExportContent(
+                contentProcessor.getContent(
                     book,
                     chapter,
                     contentFix,
@@ -1020,6 +1023,7 @@ class ExportBookService : BaseService() {
                     chineseConvert = false,
                     reSegment = false
                 ).toString()
+            )
             val title = chapter.run {
                 // 不导出vip标识
                 isVip = false
@@ -1206,8 +1210,8 @@ class ExportBookService : BaseService() {
                     ?: return@forEachIndexed
                 val (contentFix, resources) = fixPic(book, content, chapter)
                 epubBook.resources.addAll(resources)
-                val content1 = contentProcessor
-                    .getContent(
+                val content1 = sanitizeExportContent(
+                    contentProcessor.getContent(
                         book,
                         chapter,
                         contentFix,
@@ -1216,6 +1220,7 @@ class ExportBookService : BaseService() {
                         chineseConvert = false,
                         reSegment = false
                     ).toString()
+                )
                 val title = chapter.run {
                     // 不导出vip标识
                     isVip = false

--- a/app/src/main/java/io/legado/app/service/ExportContentSanitizer.kt
+++ b/app/src/main/java/io/legado/app/service/ExportContentSanitizer.kt
@@ -1,0 +1,81 @@
+package io.legado.app.service
+
+import io.legado.app.constant.AppPattern
+import io.legado.app.model.analyzeRule.AnalyzeUrl.Companion.paramPattern
+import io.legado.app.utils.GSON
+import io.legado.app.utils.fromJsonObject
+
+private val legacyReviewClickPattern = Regex(
+    """^(?:getDP\(\s*\d+\s*,\s*\d+\s*\)|getZP\(\s*\d+\s*\))$"""
+)
+
+private val legacyReviewShowPattern = Regex(
+    """^(?:dp|zp)show\(\s*\d+\s*\)$""",
+    RegexOption.IGNORE_CASE
+)
+
+private val legacyReviewUrlPattern = Regex(
+    """^(?:dp|zp)url\([\s\S]*\)$""",
+    RegexOption.IGNORE_CASE
+)
+
+private val exportInvisibleCharsRegex = Regex("[\\u200B\\uFEFF]")
+
+internal fun sanitizeExportContent(content: String): String {
+    val matcher = AppPattern.imgPattern.matcher(content)
+    if (!matcher.find()) {
+        return content.replace(exportInvisibleCharsRegex, "")
+    }
+
+    val sanitized = StringBuilder(content.length)
+    var start = 0
+    do {
+        if (matcher.start() > start) {
+            sanitized.append(content, start, matcher.start())
+        }
+        if (!isExportReviewImage(matcher.group(1))) {
+            sanitized.append(content, matcher.start(), matcher.end())
+        }
+        start = matcher.end()
+    } while (matcher.find())
+    if (start < content.length) {
+        sanitized.append(content, start, content.length)
+    }
+    return sanitized.toString().replace(exportInvisibleCharsRegex, "")
+}
+
+internal fun removeExportImages(content: String): String {
+    val matcher = AppPattern.imgPattern.matcher(content)
+    if (!matcher.find()) return content
+    val text = StringBuilder(content.length)
+    var start = 0
+    do {
+        text.append(content, start, matcher.start())
+        start = matcher.end()
+    } while (matcher.find())
+    if (start < content.length) {
+        text.append(content, start, content.length)
+    }
+    return text.toString()
+}
+
+internal fun isExportReviewImage(src: String?): Boolean {
+    if (src.isNullOrEmpty()) return false
+    val urlMatcher = paramPattern.matcher(src)
+    if (!urlMatcher.find()) return false
+    val options = GSON.fromJsonObject<Map<String, String>>(src.substring(urlMatcher.end()))
+        .getOrNull() ?: return false
+    val click = options["click"]
+    if (click != null && legacyReviewClickPattern.matches(click.trim())) {
+        return true
+    }
+    if (click != null && legacyReviewShowPattern.matches(click.trim())) {
+        val js = options["js"]?.trim()
+        if (js != null && legacyReviewUrlPattern.matches(js)) return true
+    }
+    val style = options["style"]
+    val reviewCount = options["reviewCount"]?.toIntOrNull() ?: return false
+    return (style == "text" || style == "TEXT") &&
+        reviewCount > 0 &&
+        !click.isNullOrBlank()
+}

--- a/app/src/test/java/io/legado/app/service/ExportContentSanitizerTest.kt
+++ b/app/src/test/java/io/legado/app/service/ExportContentSanitizerTest.kt
@@ -1,0 +1,59 @@
+package io.legado.app.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExportContentSanitizerTest {
+
+    @Test
+    fun `removes review images but keeps ordinary images and text`() {
+        val body = """
+            正文​一
+            <img src="https://example.com/body.jpg">
+            <img src="data:image/svg+xml;base64,QQ,{'style':'TEXT','reviewCount':'37','click':'getDP(1,37)'}">
+            <img src="data:image/svg+xml;base64,QQ,{'style':'full','click':'getZP(3)'}">
+            <img src="http://localhost/54,{'style':'TEXT','js':'dpurl(65,\'000000\')','click':'dpshow(1)'}">
+            <img src="data:image/svg+xml;base64,QQ,{'style':'text','reviewCount':'37','click':'openImage()'}">
+            <img src="data:image/svg+xml;base64,QQ,{'style':'text','reviewCount':'0','click':'getDP(1,37)'}">
+        """.trimIndent()
+
+        val sanitized = sanitizeExportContent(body)
+
+        assertTrue(sanitized.contains("正文一"))
+        assertTrue(sanitized.contains("body.jpg"))
+        assertFalse(sanitized.contains("getDP(1,37)"))
+        assertFalse(sanitized.contains("getZP(3)"))
+        assertFalse(sanitized.contains("dpshow(1)"))
+        assertFalse(sanitized.contains("reviewCount"))
+        assertFalse(sanitized.contains("\u200B"))
+    }
+
+    @Test
+    fun `keeps non-review svg and ordinary click image`() {
+        val body = """
+            <img src="data:image/svg+xml;base64,QQ">
+            <img src="https://example.com/map.svg,{'style':'full','click':'openMap()'}">
+            <img src="https://example.com/icon.svg,{'style':'text','click':'getDP(1)'}">
+        """.trimIndent()
+
+        val sanitized = sanitizeExportContent(body)
+
+        assertEquals(body, sanitized)
+    }
+
+    @Test
+    fun `accepts invisible controls that leak from cached html`() {
+        val input = "a\u200B\u200C\u200D\u200E\u200F\uFEFFb"
+        assertEquals("a\u200C\u200D\u200E\u200Fb", sanitizeExportContent(input))
+    }
+
+    @Test
+    fun `removes remaining body images before txt formatting`() {
+        assertEquals(
+            "前文后文",
+            removeExportImages("前文<img src=\"https://example.com/body.jpg\">后文")
+        )
+    }
+}


### PR DESCRIPTION
Fixes #956

Summary:
- Remove cached legacy and inline review image markup from TXT, PDF, and EPUB exports while keeping ordinary body images.
- Strip zero-width space and BOM characters from export text; TXT output formats only text and keeps genuine image sidecars.
- Re-sanitize after export replacement rules so injected review markup cannot reach PDF/EPUB output.

Recognized review contracts are the existing getDP/getZP and style=text + positive reviewCount + click formats, plus the legacy dpshow/dpurl form shown in the report evidence. Native reader review columns are layout-only and are not touched.

Tests:
.\\gradlew.bat :app:testDebugUnitTest --tests io.legado.app.service.ExportContentSanitizerTest --tests io.legado.app.service.ExportChapterContentTest --tests io.legado.app.service.PdfExportTest