### PR TITLE
fix: keep cache toolbar accessibility state in sync

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/cache/CacheActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/cache/CacheActivity.kt
@@ -131,6 +131,7 @@ class CacheActivity : VMBaseActivity<ActivityCacheBookBinding, CacheViewModel>()
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
         this.menu = menu
+        updateDownloadMenuState()
         upMenu()
         return super.onPrepareOptionsMenu(menu)
     }
@@ -299,6 +300,20 @@ class CacheActivity : VMBaseActivity<ActivityCacheBookBinding, CacheViewModel>()
         }
     }
 
+    private fun updateDownloadMenuState() {
+        menu?.findItem(R.id.menu_download)?.let { item ->
+            if (CacheBook.isRun) {
+                item.setTitle(R.string.stop)
+                item.setIconCompat(R.drawable.ic_stop_black_24dp)
+            } else {
+                item.setTitle(R.string.download_start)
+                item.setIconCompat(R.drawable.ic_play_24dp)
+            }
+            item.actionView?.contentDescription = item.title
+        }
+        menu?.applyTint(this)
+    }
+
     override fun observeLiveBus() {
         viewModel.upAdapterLiveData.observe(this) {
             notifyItemChanged(it)
@@ -310,19 +325,7 @@ class CacheActivity : VMBaseActivity<ActivityCacheBookBinding, CacheViewModel>()
             notifyItemChanged(it)
         }
         observeEvent<String>(EventBus.UP_DOWNLOAD_STATE) {
-            if (!CacheBook.isRun) {
-                menu?.findItem(R.id.menu_download)?.let { item ->
-                    item.setIconCompat(R.drawable.ic_play_24dp)
-                    item.setTitle(R.string.download_start)
-                }
-                menu?.applyTint(this)
-            } else {
-                menu?.findItem(R.id.menu_download)?.let { item ->
-                    item.setIconCompat(R.drawable.ic_stop_black_24dp)
-                    item.setTitle(R.string.stop)
-                }
-                menu?.applyTint(this)
-            }
+            updateDownloadMenuState()
         }
         observeEvent<Pair<Book, BookChapter>>(EventBus.SAVE_CONTENT) { (book, chapter) ->
             viewModel.cacheChapters[book.bookUrl]?.add(chapter.url)

--- a/app/src/test/java/io/legado/app/ui/menu/CachePopupActionMigrationTest.kt
+++ b/app/src/test/java/io/legado/app/ui/menu/CachePopupActionMigrationTest.kt
@@ -59,6 +59,41 @@ class CachePopupActionMigrationTest {
         assertContains(all, "CacheBook.stop(this@CacheActivity)")
     }
 
+    @Test
+    fun `cache toolbar download state updates the action view accessibility label`() {
+        val source = readProjectFile(CACHE_ACTIVITY)
+        val prepare = section(
+            source,
+            "override fun onPrepareOptionsMenu",
+            "private fun showDownloadMenu"
+        )
+        val state = section(
+            source,
+            "private fun updateDownloadMenuState()",
+            "override fun observeLiveBus"
+        )
+        val observer = section(
+            source,
+            "observeEvent<String>(EventBus.UP_DOWNLOAD_STATE)",
+            "observeEvent<Pair<Book, BookChapter>>(EventBus.SAVE_CONTENT)"
+        )
+
+        assertContains(prepare, "updateDownloadMenuState()")
+        assertContains(observer, "updateDownloadMenuState()")
+        assertOrdered(
+            state,
+            "item.setTitle(R.string.stop)",
+            "item.setIconCompat(R.drawable.ic_stop_black_24dp)",
+            "item.actionView?.contentDescription = item.title"
+        )
+        assertOrdered(
+            state,
+            "item.setTitle(R.string.download_start)",
+            "item.setIconCompat(R.drawable.ic_play_24dp)",
+            "item.actionView?.contentDescription = item.title"
+        )
+    }
+
     private fun section(source: String, start: String, end: String): String {
         val startIndex = source.indexOf(start)
         val endIndex = source.indexOf(end, startIndex + start.length)


### PR DESCRIPTION
Fixes the cache page toolbar download action reported in #860. The custom action view previously copied the initial title into contentDescription once, while download state events only changed the MenuItem title and icon. This keeps the action view label synchronized in both the menu preparation path and UP_DOWNLOAD_STATE updates, covering start/stop states and menu creation after an event. Validation: .\gradlew.bat :app:testDebugUnitTest --tests io.legado.app.ui.menu.CachePopupActionMigrationTest