### PR TITLE
fix: guard lyric layout width in narrow windows

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/audio/AudioPlayActivity.kt
@@ -7,10 +7,12 @@ import android.os.Bundle
 import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.widget.SeekBar
 import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.core.view.doOnLayout
+import androidx.core.view.doOnNextLayout
 import androidx.lifecycle.lifecycleScope
 import io.legado.app.R
 import io.legado.app.base.VMBaseActivity
@@ -446,12 +448,18 @@ class AudioPlayActivity :
         }
         // Keep the lyric view out of the draw pass until ConstraintLayout has assigned its width.
         lyricViewX.invisible()
-        lyricViewX.doOnLayout {
-            if (oldLyric == lyric) {
+        fun loadLyricWhenWide(view: View) {
+            // LyricViewX subtracts 16dp padding on both sides before building StaticLayout.
+            // A narrow landscape window can otherwise produce a negative layout width.
+            if (oldLyric != lyric) return
+            if (view.width <= 32.dpToPx()) {
+                view.doOnNextLayout(::loadLyricWhenWide)
+            } else {
                 lyricViewX.loadLyric(lyric)
                 lyricViewX.visible()
             }
         }
+        lyricViewX.doOnLayout(::loadLyricWhenWide)
         if (firstLyric) {
             lyricViewX.postDelayed({
                 upLyricP(AudioPlay.durChapterPos)

--- a/app/src/test/java/io/legado/app/ui/book/audio/AudioEpisodeUnitTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/audio/AudioEpisodeUnitTest.kt
@@ -89,12 +89,16 @@ class AudioEpisodeUnitTest {
             .substringBefore("override fun upLyricP(position: Int)")
         val invisible = upLyric.indexOf("lyricViewX.invisible()")
         val layout = upLyric.indexOf("lyricViewX.doOnLayout")
+        val widthGuard = upLyric.indexOf("view.width <= 32.dpToPx()")
+        val retry = upLyric.indexOf("view.doOnNextLayout(::loadLyricWhenWide)")
         val load = upLyric.indexOf("lyricViewX.loadLyric(lyric)")
         val visible = upLyric.indexOf("lyricViewX.visible()")
 
         assertTrue(invisible >= 0)
         assertTrue(layout > invisible)
-        assertTrue(load > layout)
+        assertTrue(widthGuard >= 0)
+        assertTrue(retry > widthGuard)
+        assertTrue(load > widthGuard)
         assertTrue(visible > load)
     }
 


### PR DESCRIPTION
Related to #940.

The landscape audio layout reserves 260dp for the cover and LyricViewX uses 16dp lrcPadding on both sides. In a narrow or freeform window, a small positive view width can still become a negative StaticLayout width (the report shows Layout: -128 < 0).

This waits until the laid-out width is greater than 32dp before calling loadLyric, and retries on the next layout when the first pass is too narrow so a resize can recover.

Validation:

- .\\gradlew.bat :app:testDebugUnitTest --tests io.legado.app.ui.book.audio.AudioEpisodeUnitTest --no-daemon
- BUILD SUCCESSFUL
- No instrumentation test was added; the existing source-contract test covers the load ordering and retry guard.

This PR addresses the reported lyric-layout crash only; the issue's separate playback-state behavior remains unverified.
