### PR TITLE
fix: restore auto-task import dialog contrast

### DIFF
--- a/app/src/main/java/io/legado/app/ui/autoTask/ImportAutoTaskDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/autoTask/ImportAutoTaskDialog.kt
@@ -15,6 +15,7 @@ import io.legado.app.base.adapter.RecyclerAdapter
 import io.legado.app.data.entities.AutoTaskRule
 import io.legado.app.databinding.DialogRecyclerViewBinding
 import io.legado.app.databinding.ItemSourceImportBinding
+import io.legado.app.lib.theme.primaryColor
 import io.legado.app.ui.widget.dialog.CodeDialog
 import io.legado.app.ui.widget.dialog.WaitDialog
 import io.legado.app.utils.GSON
@@ -59,6 +60,7 @@ class ImportAutoTaskDialog() : BaseDialogFragment(R.layout.dialog_recycler_view)
 
     @SuppressLint("NotifyDataSetChanged")
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
+        binding.toolBar.setBackgroundColor(primaryColor)
         binding.toolBar.setTitle(R.string.import_auto_task)
         binding.rotateLoading.visible()
         binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/test/java/io/legado/app/ui/autoTask/AutoTaskImportContractTest.kt
+++ b/app/src/test/java/io/legado/app/ui/autoTask/AutoTaskImportContractTest.kt
@@ -82,6 +82,18 @@ class AutoTaskImportContractTest {
         assertTrue(editBlock.contains("validateImportedTask(task)"))
     }
 
+    @Test
+    fun `automatic task import keeps the dialog title readable`() {
+        val dialog = projectFile(
+            "src/main/java/io/legado/app/ui/autoTask/ImportAutoTaskDialog.kt"
+        )
+        val setup = dialog.substringAfter("override fun onFragmentCreated")
+            .substringBefore("binding.rotateLoading.visible()")
+
+        assertTrue(setup.contains("binding.toolBar.setBackgroundColor(primaryColor)"))
+        assertTrue(setup.indexOf("setBackgroundColor") < setup.indexOf("setTitle"))
+    }
+
     private fun projectFile(pathInApp: String): String {
         return listOf(File(pathInApp), File("app/$pathInApp"))
             .firstOrNull { it.isFile }


### PR DESCRIPTION
Related to #940. Restores the primary-color toolbar background in ImportAutoTaskDialog and adds source-contract coverage. Validation: .\gradlew.bat :app:testDebugUnitTest --tests io.legado.app.ui.autoTask.AutoTaskImportContractTest --no-daemon (BUILD SUCCESSFUL). Scope is limited to the timer-task import dialog contrast item; the separate post-background audio playback state and crash behavior remains unverified and unchanged.