### PR TITLE
feat: add configurable horizontal text covers

### DIFF
--- a/app/src/main/java/io/legado/app/constant/PreferKey.kt
+++ b/app/src/main/java/io/legado/app/constant/PreferKey.kt
@@ -24,6 +24,8 @@ object PreferKey {
     const val coverShowAuthor = "coverShowAuthor"
     const val coverShowNameN = "coverShowNameN"
     const val coverShowAuthorN = "coverShowAuthorN"
+    const val coverHorizontal = "coverHorizontal"
+    const val coverKeepPunctuation = "coverKeepPunctuation"
     const val remoteServerId = "remoteServerId"
     const val hideStatusBar = "hideStatusBar"
     const val clickActionTL = "clickActionTopLeft"

--- a/app/src/main/java/io/legado/app/help/storage/BackupConfig.kt
+++ b/app/src/main/java/io/legado/app/help/storage/BackupConfig.kt
@@ -149,7 +149,9 @@ object BackupConfig {
         PreferKey.coverShowName,
         PreferKey.coverShowAuthor,
         PreferKey.coverShowNameN,
-        PreferKey.coverShowAuthorN
+        PreferKey.coverShowAuthorN,
+        PreferKey.coverHorizontal,
+        PreferKey.coverKeepPunctuation
     )
 
     fun keyIsNotIgnore(key: String): Boolean {

--- a/app/src/main/java/io/legado/app/model/BookCover.kt
+++ b/app/src/main/java/io/legado/app/model/BookCover.kt
@@ -50,6 +50,10 @@ object BookCover {
         private set
     var drawBookAuthor = true
         private set
+    var drawBookNameHorizontal = false
+        private set
+    var keepPunctuation = false
+        private set
     lateinit var defaultDrawable: Drawable
         private set
 
@@ -71,6 +75,8 @@ object BookCover {
             drawBookAuthor = appCtx.getPrefBoolean(PreferKey.coverShowAuthor, true)
             path = appCtx.getPrefString(PreferKey.defaultCover)
         }
+        drawBookNameHorizontal = appCtx.getPrefBoolean(PreferKey.coverHorizontal, false)
+        keepPunctuation = appCtx.getPrefBoolean(PreferKey.coverKeepPunctuation, false)
         defaultDrawable = runCatching {
             BitmapUtils.decodeBitmap(path!!, 600, 900)!!.toDrawable(appCtx.resources)
         }.getOrDefault(appCtx.resources.getDrawable(R.drawable.image_cover_default, null))

--- a/app/src/main/java/io/legado/app/ui/config/CoverConfigFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/config/CoverConfigFragment.kt
@@ -90,7 +90,9 @@ class CoverConfigFragment : PreferenceFragment(),
             }
 
             PreferKey.coverShowAuthor,
-            PreferKey.coverShowAuthorN -> {
+            PreferKey.coverShowAuthorN,
+            PreferKey.coverHorizontal,
+            PreferKey.coverKeepPunctuation -> {
                 BookCover.upDefaultCover()
             }
         }

--- a/app/src/main/java/io/legado/app/ui/config/CoverConfigFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/config/CoverConfigFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.preference.Preference
 import io.legado.app.R
+import io.legado.app.constant.EventBus
 import io.legado.app.constant.PreferKey
 import io.legado.app.lib.dialogs.selector
 import io.legado.app.lib.prefs.SwitchPreference
@@ -21,6 +22,7 @@ import io.legado.app.utils.getPrefBoolean
 import io.legado.app.utils.getPrefString
 import io.legado.app.utils.inputStream
 import io.legado.app.utils.putPrefString
+import io.legado.app.utils.postEvent
 import io.legado.app.utils.readUri
 import io.legado.app.utils.removePref
 import io.legado.app.utils.setEdgeEffectColor
@@ -81,12 +83,14 @@ class CoverConfigFragment : PreferenceFragment(),
                 findPreference<SwitchPreference>(PreferKey.coverShowAuthor)
                     ?.isEnabled = getPrefBoolean(key)
                 BookCover.upDefaultCover()
+                postEvent(EventBus.BOOKSHELF_REFRESH, "")
             }
 
             PreferKey.coverShowNameN -> {
                 findPreference<SwitchPreference>(PreferKey.coverShowAuthorN)
                     ?.isEnabled = getPrefBoolean(key)
                 BookCover.upDefaultCover()
+                postEvent(EventBus.BOOKSHELF_REFRESH, "")
             }
 
             PreferKey.coverShowAuthor,
@@ -94,6 +98,7 @@ class CoverConfigFragment : PreferenceFragment(),
             PreferKey.coverHorizontal,
             PreferKey.coverKeepPunctuation -> {
                 BookCover.upDefaultCover()
+                postEvent(EventBus.BOOKSHELF_REFRESH, "")
             }
         }
     }

--- a/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
@@ -7,7 +7,10 @@ import android.graphics.Outline
 import android.graphics.Paint
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.text.Layout
+import android.text.StaticLayout
 import android.text.TextPaint
+import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
@@ -44,6 +47,20 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import splitties.init.appCtx
 
+private const val HORIZONTAL_TITLE_MAX_LINES = 4
+
+internal fun normalizeCoverText(value: String?, keepPunctuation: Boolean): String? =
+    value?.let { text ->
+        if (keepPunctuation) text.trim() else text.replace(AppPattern.bdRegex, "").trim()
+    }
+
+internal fun coverBitmapCacheKey(
+    pathName: String,
+    width: Int,
+    horizontal: Boolean,
+    drawAuthor: Boolean
+): String = "$pathName|$width|${if (horizontal) 'h' else 'v'}|${if (drawAuthor) 'a' else 'n'}"
+
 internal fun coverTitleTextSize(
     viewWidth: Float,
     viewHeight: Float,
@@ -53,7 +70,7 @@ internal fun coverTitleTextSize(
     (characterCount - 2) * largeTextHeight > viewHeight * 0.7f ||
     (characterCount - 3) * largeTextHeight > viewHeight * 0.6f
 ) {
-    viewWidth / 10
+    viewWidth / 9
 } else {
     viewWidth / 7
 }
@@ -82,9 +99,6 @@ class CoverImageView @JvmOverloads constructor(
     private var author: String? = null
     private var nameHeight = 0f
     private var authorHeight = 0f
-    private val drawBookName = BookCover.drawBookName
-    private val drawBookAuthor by lazy { BookCover.drawBookAuthor }
-
     override fun setLayoutParams(params: ViewGroup.LayoutParams?) {
         if (params != null) {
             val width = params.width
@@ -118,6 +132,8 @@ class CoverImageView @JvmOverloads constructor(
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
+        val drawBookName = BookCover.drawBookName
+        val drawBookAuthor = BookCover.drawBookAuthor
         if (!drawBookName) return
         val currentName = this.name ?: return
         if (AppConfig.useDefaultCover || needNameBitmap[bitmapPath.toString()] == true) {
@@ -127,7 +143,13 @@ class CoverImageView @JvmOverloads constructor(
             } else {
                 currentName
             }
-            val cacheBitmap = getNameBitmap(pathName + width)
+            val cacheKey = coverBitmapCacheKey(
+                pathName,
+                width,
+                BookCover.drawBookNameHorizontal,
+                drawBookAuthor
+            )
+            val cacheBitmap = getNameBitmap(cacheKey)
             if (cacheBitmap != null) {
                 canvas.drawBitmap(cacheBitmap, 0f, 0f, null)
                 return
@@ -145,9 +167,23 @@ class CoverImageView @JvmOverloads constructor(
     }
 
     private fun drawNameAuthor(pathName: String, name: String, author: String?, asyncAwait: Boolean = true) {
-        generateCoverAsync(pathName, name, author, asyncAwait)
+        generateCoverAsync(
+            pathName,
+            name,
+            author,
+            BookCover.drawBookNameHorizontal,
+            BookCover.drawBookAuthor,
+            asyncAwait
+        )
     }
-    private fun generateCoverAsync(pathName: String, name: String, author: String?, asyncAwait: Boolean) {
+    private fun generateCoverAsync(
+        pathName: String,
+        name: String,
+        author: String?,
+        horizontal: Boolean,
+        drawAuthor: Boolean,
+        asyncAwait: Boolean
+    ) {
         currentJob?.cancel()
         currentJob = CoroutineScope(Dispatchers.Default).launch {
             try {
@@ -165,12 +201,12 @@ class CoverImageView @JvmOverloads constructor(
                     } while (width == 0 && attempts < 2000)
                 }
                 ensureActive()
-                val cacheKey = pathName + width
+                val cacheKey = coverBitmapCacheKey(pathName, width, horizontal, drawAuthor)
                 if (getNameBitmap(cacheKey) != null) {
                     postInvalidate()
                     return@launch
                 }
-                val bitmap = generateCoverBitmap(name, author)
+                val bitmap = generateCoverBitmap(name, author, horizontal, drawAuthor)
                 ensureActive()
                 needNameBitmap.put(bitmapPath.toString(), true)
                 nameBitmapCache.put(cacheKey, bitmap)
@@ -183,7 +219,12 @@ class CoverImageView @JvmOverloads constructor(
         }
     }
 
-    private fun generateCoverBitmap(name: String?, author: String?): Bitmap {
+    private fun generateCoverBitmap(
+        name: String?,
+        author: String?,
+        horizontal: Boolean,
+        drawAuthor: Boolean
+    ): Bitmap {
         viewWidth = width.toFloat()
         viewHeight = height.toFloat()
         val bitmap = createBitmap(width, height)
@@ -192,6 +233,17 @@ class CoverImageView @JvmOverloads constructor(
         var startY = viewHeight * 0.2f
         val backgroundColor = appCtx.backgroundColor
         val accentColor = appCtx.accentColor
+        if (horizontal) {
+            drawHorizontalTextCover(
+                bitmapCanvas,
+                name,
+                author,
+                backgroundColor,
+                accentColor,
+                drawAuthor
+            )
+            return bitmap
+        }
         val namePaint = TextPaint().apply {
             typeface = Typeface.DEFAULT_BOLD
             isAntiAlias = true
@@ -231,7 +283,7 @@ class CoverImageView @JvmOverloads constructor(
                 }
             }
         }
-        if (!drawBookAuthor){
+        if (!drawAuthor){
             return bitmap
         }
         val authorPaint = TextPaint(namePaint).apply {
@@ -258,6 +310,88 @@ class CoverImageView @JvmOverloads constructor(
         }
         return bitmap
     }
+
+    private fun drawHorizontalTextCover(
+        canvas: Canvas,
+        name: String?,
+        author: String?,
+        backgroundColor: Int,
+        accentColor: Int,
+        drawAuthor: Boolean
+    ) {
+        val basePaint = TextPaint().apply {
+            isAntiAlias = true
+            typeface = Typeface.DEFAULT_BOLD
+        }
+        name?.takeIf { it.isNotEmpty() }?.let { title ->
+            val titleWidth = (viewWidth * 0.78f).toInt().coerceAtLeast(1)
+            val titlePaint = TextPaint(basePaint).apply {
+                textAlign = Paint.Align.LEFT
+                textSize = viewWidth / 7
+                strokeWidth = textSize / 6
+            }
+            var titleLayout = horizontalTitleLayout(title, titlePaint, titleWidth)
+            if (titleLayout.lineCount > 1) {
+                titlePaint.textSize = viewWidth / 9
+                titlePaint.strokeWidth = titlePaint.textSize / 6
+                titleLayout = horizontalTitleLayout(title, titlePaint, titleWidth)
+            }
+            val titleX = (viewWidth - titleWidth) / 2f
+            val titleY = viewHeight * 0.1f
+            canvas.save()
+            canvas.translate(titleX, titleY)
+            titlePaint.color = backgroundColor
+            titlePaint.style = Paint.Style.STROKE
+            titleLayout.draw(canvas)
+            titlePaint.color = accentColor
+            titlePaint.style = Paint.Style.FILL
+            titleLayout.draw(canvas)
+            canvas.restore()
+        }
+
+        if (!drawAuthor) return
+        author?.takeIf { it.isNotEmpty() }?.let { authorText ->
+            val authorWidth = viewWidth * 0.65f
+            val authorPaint = TextPaint(basePaint).apply {
+                typeface = Typeface.DEFAULT
+                textAlign = Paint.Align.RIGHT
+                textSize = viewWidth / 10
+                strokeWidth = textSize / 5
+            }
+            while (authorPaint.textSize > viewWidth / 16 &&
+                authorPaint.measureText(authorText) > authorWidth
+            ) {
+                authorPaint.textSize -= 0.5f
+                authorPaint.strokeWidth = authorPaint.textSize / 5
+            }
+            val displayAuthor = TextUtils.ellipsize(
+                authorText,
+                authorPaint,
+                authorWidth,
+                TextUtils.TruncateAt.END
+            ).toString()
+            val authorX = viewWidth * 0.9f
+            val authorY = viewHeight * 0.92f
+            authorPaint.color = backgroundColor
+            authorPaint.style = Paint.Style.STROKE
+            canvas.drawText(displayAuthor, authorX, authorY, authorPaint)
+            authorPaint.color = accentColor
+            authorPaint.style = Paint.Style.FILL
+            canvas.drawText(displayAuthor, authorX, authorY, authorPaint)
+        }
+    }
+
+    private fun horizontalTitleLayout(
+        title: String,
+        paint: TextPaint,
+        width: Int
+    ): StaticLayout = StaticLayout.Builder
+        .obtain(title, 0, title.length, paint, width)
+        .setAlignment(Layout.Alignment.ALIGN_CENTER)
+        .setIncludePad(false)
+        .setMaxLines(HORIZONTAL_TITLE_MAX_LINES)
+        .setEllipsize(TextUtils.TruncateAt.END)
+        .build()
 
     fun setHeight(height: Int) {
         val width = height * 3 / 4
@@ -336,8 +470,8 @@ class CoverImageView @JvmOverloads constructor(
         currentJob?.cancel()
         currentJob = null
         triggerChannel.tryReceive()
-        val currentAuthor = author?.replace(AppPattern.bdRegex, "")?.trim()
-        val currentName = name?.replace(AppPattern.bdRegex, "")?.trim()
+        val currentAuthor = normalizeCoverText(author, BookCover.keepPunctuation)
+        val currentName = normalizeCoverText(name, BookCover.keepPunctuation)
         val currentPath = path?.takeIf { it.isNotBlank() }
         if (this.name != currentName || this.author != currentAuthor) {
             currentNameBitmap = null
@@ -359,8 +493,8 @@ class CoverImageView @JvmOverloads constructor(
                 onLoadFinish?.invoke()
                 return
             }
-            if (drawBookName && currentName != null) {
-                val pathName = if (drawBookAuthor){
+            if (BookCover.drawBookName && currentName != null) {
+                val pathName = if (BookCover.drawBookAuthor) {
                     currentName + currentAuthor
                 } else {
                     currentName

--- a/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
@@ -55,11 +55,27 @@ internal fun normalizeCoverText(value: String?, keepPunctuation: Boolean): Strin
     }
 
 internal fun coverBitmapCacheKey(
-    pathName: String,
+    name: String,
+    author: String?,
     width: Int,
+    height: Int,
     horizontal: Boolean,
-    drawAuthor: Boolean
-): String = "$pathName|$width|${if (horizontal) 'h' else 'v'}|${if (drawAuthor) 'a' else 'n'}"
+    drawAuthor: Boolean,
+    backgroundColor: Int,
+    accentColor: Int
+): String = buildString {
+    append(name.length).append(':').append(name)
+    append('|')
+    if (author == null) {
+        append("-1:")
+    } else {
+        append(author.length).append(':').append(author)
+    }
+    append('|').append(width).append('x').append(height)
+    append('|').append(if (horizontal) 'h' else 'v')
+    append('|').append(if (drawAuthor) 'a' else 'n')
+    append('|').append(backgroundColor).append(',').append(accentColor)
+}
 
 internal fun coverTitleTextSize(
     viewWidth: Float,
@@ -97,6 +113,9 @@ class CoverImageView @JvmOverloads constructor(
         private set
     private var name: String? = null
     private var author: String? = null
+    private var sourceName: String? = null
+    private var sourceAuthor: String? = null
+    private var normalizedKeepPunctuation = BookCover.keepPunctuation
     private var nameHeight = 0f
     private var authorHeight = 0f
     override fun setLayoutParams(params: ViewGroup.LayoutParams?) {
@@ -132,29 +151,31 @@ class CoverImageView @JvmOverloads constructor(
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
+        updateNormalizedText()
         val drawBookName = BookCover.drawBookName
         val drawBookAuthor = BookCover.drawBookAuthor
         if (!drawBookName) return
         val currentName = this.name ?: return
         if (AppConfig.useDefaultCover || needNameBitmap[bitmapPath.toString()] == true) {
             val currentAuthor = this.author
-            val pathName = if (drawBookAuthor){
-                currentName + currentAuthor
-            } else {
-                currentName
-            }
+            val backgroundColor = appCtx.backgroundColor
+            val accentColor = appCtx.accentColor
             val cacheKey = coverBitmapCacheKey(
-                pathName,
+                currentName,
+                currentAuthor,
                 width,
+                height,
                 BookCover.drawBookNameHorizontal,
-                drawBookAuthor
+                drawBookAuthor,
+                backgroundColor,
+                accentColor
             )
             val cacheBitmap = getNameBitmap(cacheKey)
             if (cacheBitmap != null) {
                 canvas.drawBitmap(cacheBitmap, 0f, 0f, null)
                 return
             }
-            drawNameAuthor(pathName, currentName, currentAuthor, false)
+            drawNameAuthor(currentName, currentAuthor, backgroundColor, accentColor, false)
         }
     }
 
@@ -166,20 +187,41 @@ class CoverImageView @JvmOverloads constructor(
         }
     }
 
-    private fun drawNameAuthor(pathName: String, name: String, author: String?, asyncAwait: Boolean = true) {
+    private fun updateNormalizedText() {
+        val keepPunctuation = BookCover.keepPunctuation
+        if (keepPunctuation == normalizedKeepPunctuation) return
+        val currentName = normalizeCoverText(sourceName, keepPunctuation)
+        val currentAuthor = normalizeCoverText(sourceAuthor, keepPunctuation)
+        if (name != currentName || author != currentAuthor) {
+            currentNameBitmap = null
+        }
+        name = currentName
+        author = currentAuthor
+        normalizedKeepPunctuation = keepPunctuation
+    }
+
+    private fun drawNameAuthor(
+        name: String,
+        author: String?,
+        backgroundColor: Int = appCtx.backgroundColor,
+        accentColor: Int = appCtx.accentColor,
+        asyncAwait: Boolean = true
+    ) {
         generateCoverAsync(
-            pathName,
             name,
             author,
+            backgroundColor,
+            accentColor,
             BookCover.drawBookNameHorizontal,
             BookCover.drawBookAuthor,
             asyncAwait
         )
     }
     private fun generateCoverAsync(
-        pathName: String,
         name: String,
         author: String?,
+        backgroundColor: Int,
+        accentColor: Int,
         horizontal: Boolean,
         drawAuthor: Boolean,
         asyncAwait: Boolean
@@ -201,12 +243,28 @@ class CoverImageView @JvmOverloads constructor(
                     } while (width == 0 && attempts < 2000)
                 }
                 ensureActive()
-                val cacheKey = coverBitmapCacheKey(pathName, width, horizontal, drawAuthor)
+                val cacheKey = coverBitmapCacheKey(
+                    name,
+                    author,
+                    width,
+                    height,
+                    horizontal,
+                    drawAuthor,
+                    backgroundColor,
+                    accentColor
+                )
                 if (getNameBitmap(cacheKey) != null) {
                     postInvalidate()
                     return@launch
                 }
-                val bitmap = generateCoverBitmap(name, author, horizontal, drawAuthor)
+                val bitmap = generateCoverBitmap(
+                    name,
+                    author,
+                    horizontal,
+                    drawAuthor,
+                    backgroundColor,
+                    accentColor
+                )
                 ensureActive()
                 needNameBitmap.put(bitmapPath.toString(), true)
                 nameBitmapCache.put(cacheKey, bitmap)
@@ -223,7 +281,9 @@ class CoverImageView @JvmOverloads constructor(
         name: String?,
         author: String?,
         horizontal: Boolean,
-        drawAuthor: Boolean
+        drawAuthor: Boolean,
+        backgroundColor: Int,
+        accentColor: Int
     ): Bitmap {
         viewWidth = width.toFloat()
         viewHeight = height.toFloat()
@@ -231,8 +291,6 @@ class CoverImageView @JvmOverloads constructor(
         val bitmapCanvas = Canvas(bitmap)
         var startX = width * 0.2f
         var startY = viewHeight * 0.2f
-        val backgroundColor = appCtx.backgroundColor
-        val accentColor = appCtx.accentColor
         if (horizontal) {
             drawHorizontalTextCover(
                 bitmapCanvas,
@@ -470,6 +528,9 @@ class CoverImageView @JvmOverloads constructor(
         currentJob?.cancel()
         currentJob = null
         triggerChannel.tryReceive()
+        sourceName = name
+        sourceAuthor = author
+        normalizedKeepPunctuation = BookCover.keepPunctuation
         val currentAuthor = normalizeCoverText(author, BookCover.keepPunctuation)
         val currentName = normalizeCoverText(name, BookCover.keepPunctuation)
         val currentPath = path?.takeIf { it.isNotBlank() }
@@ -494,12 +555,7 @@ class CoverImageView @JvmOverloads constructor(
                 return
             }
             if (BookCover.drawBookName && currentName != null) {
-                val pathName = if (BookCover.drawBookAuthor) {
-                    currentName + currentAuthor
-                } else {
-                    currentName
-                }
-                drawNameAuthor(pathName, currentName, currentAuthor, true)
+                drawNameAuthor(currentName, currentAuthor, asyncAwait = true)
             }
             var options = RequestOptions().set(OkHttpModelLoader.loadOnlyWifiOption, loadOnlyWifi)
             if (sourceOrigin != null) {

--- a/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
@@ -103,8 +103,6 @@ class CoverImageView @JvmOverloads constructor(
         private val nameBitmapCache by lazy { LruCache<String, Bitmap>(33) }
         private val needNameBitmap by lazy { LruCache<String, Boolean>(99) }
     }
-    private var viewWidth: Float = 0f
-    private var viewHeight: Float = 0f
     private var currentJob: Job? = null
     @Volatile
     private var currentNameBitmap: Pair<String, Bitmap>? = null
@@ -141,6 +139,10 @@ class CoverImageView @JvmOverloads constructor(
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
+        if (w != oldw || h != oldh) {
+            currentJob?.cancel()
+            currentNameBitmap = null
+        }
         outlineProvider = object : ViewOutlineProvider() {
             override fun getOutline(view: View, outline: Outline) {
                 outline.setRoundRect(0, 0, w, h, 12f)
@@ -227,6 +229,7 @@ class CoverImageView @JvmOverloads constructor(
         asyncAwait: Boolean
     ) {
         currentJob?.cancel()
+        val requestedBitmapPath = bitmapPath
         currentJob = CoroutineScope(Dispatchers.Default).launch {
             try {
                 if (asyncAwait) {
@@ -243,11 +246,14 @@ class CoverImageView @JvmOverloads constructor(
                     } while (width == 0 && attempts < 2000)
                 }
                 ensureActive()
+                val renderWidth = width
+                val renderHeight = height
+                if (renderWidth <= 0 || renderHeight <= 0) return@launch
                 val cacheKey = coverBitmapCacheKey(
                     name,
                     author,
-                    width,
-                    height,
+                    renderWidth,
+                    renderHeight,
                     horizontal,
                     drawAuthor,
                     backgroundColor,
@@ -260,13 +266,15 @@ class CoverImageView @JvmOverloads constructor(
                 val bitmap = generateCoverBitmap(
                     name,
                     author,
+                    renderWidth,
+                    renderHeight,
                     horizontal,
                     drawAuthor,
                     backgroundColor,
                     accentColor
                 )
                 ensureActive()
-                needNameBitmap.put(bitmapPath.toString(), true)
+                needNameBitmap.put(requestedBitmapPath.toString(), true)
                 nameBitmapCache.put(cacheKey, bitmap)
                 currentNameBitmap = cacheKey to bitmap
                 postInvalidate()
@@ -280,16 +288,18 @@ class CoverImageView @JvmOverloads constructor(
     private fun generateCoverBitmap(
         name: String?,
         author: String?,
+        renderWidth: Int,
+        renderHeight: Int,
         horizontal: Boolean,
         drawAuthor: Boolean,
         backgroundColor: Int,
         accentColor: Int
     ): Bitmap {
-        viewWidth = width.toFloat()
-        viewHeight = height.toFloat()
-        val bitmap = createBitmap(width, height)
+        val viewWidth = renderWidth.toFloat()
+        val viewHeight = renderHeight.toFloat()
+        val bitmap = createBitmap(renderWidth, renderHeight)
         val bitmapCanvas = Canvas(bitmap)
-        var startX = width * 0.2f
+        var startX = renderWidth * 0.2f
         var startY = viewHeight * 0.2f
         if (horizontal) {
             drawHorizontalTextCover(
@@ -298,7 +308,9 @@ class CoverImageView @JvmOverloads constructor(
                 author,
                 backgroundColor,
                 accentColor,
-                drawAuthor
+                drawAuthor,
+                viewWidth,
+                viewHeight
             )
             return bitmap
         }
@@ -350,7 +362,7 @@ class CoverImageView @JvmOverloads constructor(
         author?.toStringArray()?.let { author ->
             authorPaint.textSize = viewWidth / 10
             authorPaint.strokeWidth = authorPaint.textSize / 5
-            startX = width * 0.8f
+            startX = renderWidth * 0.8f
             startY = viewHeight * 0.95f - author.size * authorPaint.textHeight
             startY = maxOf(startY, viewHeight * 0.3f)
             author.forEach {
@@ -375,7 +387,9 @@ class CoverImageView @JvmOverloads constructor(
         author: String?,
         backgroundColor: Int,
         accentColor: Int,
-        drawAuthor: Boolean
+        drawAuthor: Boolean,
+        viewWidth: Float,
+        viewHeight: Float
     ) {
         val basePaint = TextPaint().apply {
             isAntiAlias = true
@@ -389,7 +403,7 @@ class CoverImageView @JvmOverloads constructor(
                 strokeWidth = textSize / 6
             }
             var titleLayout = horizontalTitleLayout(title, titlePaint, titleWidth)
-            if (titleLayout.lineCount > 1) {
+            if (titleLayout.lineCount > 1 || titlePaint.measureText(title) > titleWidth) {
                 titlePaint.textSize = viewWidth / 9
                 titlePaint.strokeWidth = titlePaint.textSize / 6
                 titleLayout = horizontalTitleLayout(title, titlePaint, titleWidth)

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1117,6 +1117,10 @@
     <string name="cover_show_name_summary">封面上显示书名</string>
     <string name="cover_show_author">显示作者</string>
     <string name="cover_show_author_summary">封面上显示作者</string>
+    <string name="cover_horizontal">横向显示封面文字</string>
+    <string name="cover_horizontal_summary">书名显示在顶部，作者显示在右下角</string>
+    <string name="cover_keep_punctuation">保留书名和作者标点</string>
+    <string name="cover_keep_punctuation_summary">生成文字封面时不移除标点符号</string>
     <string name="read_aloud_prev_paragraph">朗读上一段</string>
     <string name="read_aloud_next_paragraph">朗读下一段</string>
     <string name="wait_download">待下载</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1120,6 +1120,10 @@
     <string name="cover_show_name_summary">Book title shown on cover</string>
     <string name="cover_show_author">show author</string>
     <string name="cover_show_author_summary">Author shown on cover</string>
+    <string name="cover_horizontal">Horizontal cover text</string>
+    <string name="cover_horizontal_summary">Draw the title at the top and the author at the lower right</string>
+    <string name="cover_keep_punctuation">Keep title and author punctuation</string>
+    <string name="cover_keep_punctuation_summary">Do not remove punctuation from generated cover text</string>
     <string name="read_aloud_prev_paragraph">Read aloud the previous paragraph</string>
     <string name="read_aloud_next_paragraph">Read aloud the next paragraph</string>
     <string name="wait_download">wait download</string>

--- a/app/src/main/res/xml/pref_config_cover.xml
+++ b/app/src/main/res/xml/pref_config_cover.xml
@@ -25,6 +25,24 @@
         app:allowDividerBelow="false"
         app:iconSpaceReserved="false" />
 
+    <io.legado.app.lib.prefs.SwitchPreference
+        android:defaultValue="false"
+        android:key="coverHorizontal"
+        android:title="@string/cover_horizontal"
+        android:summary="@string/cover_horizontal_summary"
+        app:allowDividerAbove="false"
+        app:allowDividerBelow="false"
+        app:iconSpaceReserved="false" />
+
+    <io.legado.app.lib.prefs.SwitchPreference
+        android:defaultValue="false"
+        android:key="coverKeepPunctuation"
+        android:title="@string/cover_keep_punctuation"
+        android:summary="@string/cover_keep_punctuation_summary"
+        app:allowDividerAbove="false"
+        app:allowDividerBelow="false"
+        app:iconSpaceReserved="false" />
+
     <io.legado.app.lib.prefs.PreferenceCategory
         android:key="dayThemeCategory"
         android:title="@string/day"

--- a/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
+++ b/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
@@ -3,7 +3,9 @@ package io.legado.app
 import io.legado.app.data.entities.Book
 import io.legado.app.service.buildHttpTtsCacheFileName
 import io.legado.app.ui.book.info.normalizeWebFileName
+import io.legado.app.ui.widget.image.coverBitmapCacheKey
 import io.legado.app.ui.widget.image.coverTitleTextSize
+import io.legado.app.ui.widget.image.normalizeCoverText
 import io.legado.app.utils.calculateSvgBitmapSize
 import io.legado.app.utils.isForegroundServiceStartDenied
 import org.junit.Assert.assertEquals
@@ -74,7 +76,7 @@ class RuntimeMediaStabilityTest {
         val load = source.substringAfter("path: String? = null,")
             .substringBefore("override fun onDetachedFromWindow")
         val emptyPath = load.substringAfter("if (currentPath == null) {")
-            .substringBefore("if (drawBookName")
+            .substringBefore("if (BookCover.drawBookName")
 
         assertTrue(load.contains("currentJob?.cancel()"))
         assertTrue(load.contains("triggerChannel.tryReceive()"))
@@ -126,7 +128,7 @@ class RuntimeMediaStabilityTest {
             )
         }
         assertEquals(
-            width / 10,
+            width / 9,
             coverTitleTextSize(width, height, 8, largeTextHeight),
             0.001f
         )
@@ -139,6 +141,38 @@ class RuntimeMediaStabilityTest {
             .substringBefore("if (!drawBookAuthor)")
 
         assertFalse(titleLoop.contains("namePaint.textSize ="))
+    }
+
+    @Test
+    fun coverTextOptionsPreservePunctuationAndSeparateRenderCaches() {
+        assertEquals("Title Author", normalizeCoverText("Title, Author", false))
+        assertEquals("Title, Author", normalizeCoverText("Title, Author", true))
+        assertEquals("Title", normalizeCoverText("  Title  ", true))
+        assertNotEquals(
+            coverBitmapCacheKey("TitleAuthor", 105, false, true),
+            coverBitmapCacheKey("TitleAuthor", 105, true, true)
+        )
+        assertNotEquals(
+            coverBitmapCacheKey("TitleAuthor", 105, true, true),
+            coverBitmapCacheKey("TitleAuthor", 105, true, false)
+        )
+    }
+
+    @Test
+    fun horizontalTextCoverHonorsReportedLayoutContract() {
+        val source = listOf(File("src/main/java"), File("app/src/main/java"))
+            .first { it.isDirectory }
+            .resolve("io/legado/app/ui/widget/image/CoverImageView.kt")
+            .readText()
+        val horizontal = source.substringAfter("private fun drawHorizontalTextCover")
+            .substringBefore("fun setHeight")
+
+        assertTrue(horizontal.contains("HORIZONTAL_TITLE_MAX_LINES"))
+        assertTrue(horizontal.contains("setMaxLines(HORIZONTAL_TITLE_MAX_LINES)"))
+        assertTrue(horizontal.contains("TextUtils.TruncateAt.END"))
+        assertTrue(horizontal.contains("textAlign = Paint.Align.RIGHT"))
+        assertTrue(horizontal.contains("textSize = viewWidth / 10"))
+        assertTrue(horizontal.contains("viewHeight * 0.92f"))
     }
 
     @Test

--- a/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
+++ b/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
@@ -174,12 +174,16 @@ class RuntimeMediaStabilityTest {
         assertTrue(horizontal.contains("HORIZONTAL_TITLE_MAX_LINES"))
         assertTrue(horizontal.contains("setMaxLines(HORIZONTAL_TITLE_MAX_LINES)"))
         assertTrue(horizontal.contains("TextUtils.TruncateAt.END"))
+        assertTrue(horizontal.contains("titlePaint.measureText(title) > titleWidth"))
         assertTrue(horizontal.contains("textAlign = Paint.Align.RIGHT"))
         assertTrue(horizontal.contains("textSize = viewWidth / 10"))
         assertTrue(horizontal.contains("viewHeight * 0.92f"))
 
         assertTrue(source.contains("sourceName = name"))
         assertTrue(source.contains("updateNormalizedText()"))
+        assertTrue(source.contains("val renderWidth = width"))
+        assertTrue(source.contains("val renderHeight = height"))
+        assertTrue(source.contains("currentJob?.cancel()"))
         val configSource = File("src/main/java/io/legado/app/ui/config/CoverConfigFragment.kt")
             .takeIf { it.isFile }
             ?: File("app/src/main/java/io/legado/app/ui/config/CoverConfigFragment.kt")

--- a/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
+++ b/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
@@ -149,12 +149,16 @@ class RuntimeMediaStabilityTest {
         assertEquals("Title, Author", normalizeCoverText("Title, Author", true))
         assertEquals("Title", normalizeCoverText("  Title  ", true))
         assertNotEquals(
-            coverBitmapCacheKey("TitleAuthor", 105, false, true),
-            coverBitmapCacheKey("TitleAuthor", 105, true, true)
+            coverBitmapCacheKey("ab", "c", 105, 140, false, true, 1, 2),
+            coverBitmapCacheKey("a", "bc", 105, 140, false, true, 1, 2)
         )
         assertNotEquals(
-            coverBitmapCacheKey("TitleAuthor", 105, true, true),
-            coverBitmapCacheKey("TitleAuthor", 105, true, false)
+            coverBitmapCacheKey("Title", "Author", 105, 140, false, true, 1, 2),
+            coverBitmapCacheKey("Title", "Author", 105, 140, true, true, 1, 2)
+        )
+        assertNotEquals(
+            coverBitmapCacheKey("Title", "Author", 105, 140, true, true, 1, 2),
+            coverBitmapCacheKey("Title", "Author", 105, 140, true, true, 3, 4)
         )
     }
 
@@ -173,6 +177,13 @@ class RuntimeMediaStabilityTest {
         assertTrue(horizontal.contains("textAlign = Paint.Align.RIGHT"))
         assertTrue(horizontal.contains("textSize = viewWidth / 10"))
         assertTrue(horizontal.contains("viewHeight * 0.92f"))
+
+        assertTrue(source.contains("sourceName = name"))
+        assertTrue(source.contains("updateNormalizedText()"))
+        val configSource = File("src/main/java/io/legado/app/ui/config/CoverConfigFragment.kt")
+            .takeIf { it.isFile }
+            ?: File("app/src/main/java/io/legado/app/ui/config/CoverConfigFragment.kt")
+        assertTrue(configSource.readText().contains("postEvent(EventBus.BOOKSHELF_REFRESH, \"\")"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add shared cover switches for horizontal title/author layout and punctuation preservation
- wrap titles to at most four lines with end ellipsis, shrink long authors to one right-aligned line
- keep the existing vertical layout as the default and enlarge its compact size to width / 9
- include the new settings in preference change handling and backup configuration

Closes #954.

## Validation

- `git diff --check`
- `./gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.RuntimeMediaStabilityTest --no-daemon --max-workers=1`

The focused suite passed 11 tests.