### PR TITLE
test: 覆盖 HttpTTS 辅助字段往返

### DIFF
--- a/app/src/test/java/io/legado/app/data/entities/HttpTtsCookieJarTest.kt
+++ b/app/src/test/java/io/legado/app/data/entities/HttpTtsCookieJarTest.kt
@@ -2,6 +2,7 @@ package io.legado.app.data.entities
 
 import io.legado.app.utils.GSON
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -9,24 +10,31 @@ import java.io.File
 class HttpTtsCookieJarTest {
 
     @Test
-    fun `cookie jar survives import export and editing`() {
+    fun `auxiliary fields survive import export and editing`() {
+        val jsLib = "function sign(text) { return java.md5Encode(text) }"
         val imported = HttpTTS.fromJson(
-            """{"name":"test","url":"https://example.com","enabledCookieJar":true}"""
+            """{"name":"test","url":"https://example.com","jsLib":"$jsLib","enabledCookieJar":true}"""
         ).getOrThrow()
         val legacy = HttpTTS.fromJson(
             """{"name":"test","url":"https://example.com"}"""
         ).getOrThrow()
         val roundTrip = HttpTTS.fromJson(GSON.toJson(imported)).getOrThrow()
 
+        assertEquals(jsLib, imported.jsLib)
         assertTrue(imported.enabledCookieJar == true)
+        assertNull(legacy.jsLib)
         assertEquals(false, legacy.enabledCookieJar)
+        assertEquals(jsLib, roundTrip.jsLib)
         assertTrue(roundTrip.enabledCookieJar == true)
 
         val source = appFile("src/main/java/io/legado/app/ui/book/read/config/HttpTtsEditDialog.kt")
             .readText()
         val layout = appFile("src/main/res/layout/dialog_http_tts_edit.xml").readText()
+        assertTrue(source.contains("tvJsLib.setText(httpTTS.jsLib)"))
+        assertTrue(source.contains("jsLib = binding.tvJsLib.text?.toString()"))
         assertTrue(source.contains("cbIsEnableCookie.isChecked = httpTTS.enabledCookieJar == true"))
         assertTrue(source.contains("enabledCookieJar = binding.cbIsEnableCookie.isChecked"))
+        assertTrue(layout.contains("android:id=\"@+id/tv_jsLib\""))
         assertTrue(layout.contains("android:id=\"@+id/cb_is_enable_cookie\""))
     }
 


### PR DESCRIPTION
## 变更
- 扩展 HttpTtsCookieJarTest，同时覆盖 jsLib 与 enabledCookieJar 的 JSON 导入、旧格式缺省值和导出后再导入
- 锁定 HttpTTS 编辑页对 jsLib 的读取、写回和布局绑定

## 背景
legadoT 提交 3b5247b2eb 暴露了这个测试缺口。当前主线运行时已经正确支持两个辅助字段，因此这里只补回归契约，不重复修改实现，也不带入 fork 专属帮助文档。

## 验证
- .\gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.data.entities.HttpTtsCookieJarTest --no-daemon --max-workers=1
- BUILD SUCCESSFUL（58 tasks）
- git diff --check