### PR TITLE
test: lock reader clip bottom overflow

### DIFF
--- a/app/src/test/java/io/legado/app/ui/book/read/page/provider/NativeReviewProviderSourceTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/page/provider/NativeReviewProviderSourceTest.kt
@@ -68,7 +68,7 @@ class NativeReviewProviderSourceTest {
     }
 
     @Test
-    fun `review overflow remains inside the screen clip`() {
+    fun `drawing overflow remains inside the screen clip`() {
         val provider = projectFile(
             "src/main/java/io/legado/app/ui/book/read/page/provider/ChapterProvider.kt"
         ).readText().normalizeLines()
@@ -77,6 +77,7 @@ class NativeReviewProviderSourceTest {
         val visibleRectBlock = layoutBlock.substringAfter("visibleRect.set(")
 
         assertTrue(visibleRectBlock.contains("viewWidth.toFloat(),"))
+        assertTrue(visibleRectBlock.contains("visibleBottom.toFloat() + 10f.dpToPx()"))
     }
 
     private fun String.normalizeLines(): String = replace("\r\n", "\n")


### PR DESCRIPTION
## Summary
- Lock the existing reader visibleRect bottom overflow contract at the density-aware 10dp allowance.
- Clarify the source-contract test name so it covers the full drawing clip.

This is the minimal test residual identified while re-auditing fork-only commit 4ca7045cac. Production behavior already comes from upstream 0f1846bc05; this PR adds the missing regression assertion.

## Validation
- :app:testAppReleaseUnitTest --tests io.legado.app.ui.book.read.page.provider.NativeReviewProviderSourceTest --no-daemon --max-workers=1 --console=plain
- 3 tests, 0 failures/errors/skips
- git diff --check