### PR TITLE
test: lock bookshelf reading count query

### DIFF
--- a/app/src/test/java/io/legado/app/ui/main/bookshelf/BookshelfReadProgressTest.kt
+++ b/app/src/test/java/io/legado/app/ui/main/bookshelf/BookshelfReadProgressTest.kt
@@ -213,6 +213,19 @@ class BookshelfReadProgressTest {
         assertTrue(query.contains("durChapterTime DESC limit 1"))
     }
 
+    @Test
+    fun `reading count query only includes started shelf books`() {
+        val source = projectFile("src/main/java/io/legado/app/data/dao/BookDao.kt").readText()
+        val propertyIndex = source.indexOf("val readingCount")
+        val queryStart = source.lastIndexOf("@get:Query(", propertyIndex)
+        val query = source.substring(queryStart, propertyIndex)
+
+        assertTrue(query.contains("(durChapterIndex > 0 OR durChapterPos > 0)"))
+        assertTrue(query.contains("and type & \${BookType.notShelf} = 0"))
+        assertFalse(query.replace("BookType.notShelf", "").contains("BookType."))
+        assertFalse(query.contains("durChapterTime"))
+    }
+
     private fun parseProjectXml(pathInApp: String): Document {
         return DocumentBuilderFactory.newInstance().apply {
             isNamespaceAware = true


### PR DESCRIPTION
## Summary
- Lock the existing BookDao.readingCount query to books with actual reading progress.
- Preserve the non-shelf type filter and reject the stale durChapterTime predicate, whose default value would count unopened books.

This is the minimal test residual identified while re-auditing fork-only commit 1c2ae751ad. Production behavior is already stronger in upstream commit 347edb95bd (#316); this PR adds the missing regression contract.

## Validation
- :app:testAppReleaseUnitTest --tests io.legado.app.ui.main.bookshelf.BookshelfReadProgressTest --no-daemon --max-workers=1 --console=plain
- 10 tests, 0 failures/errors/skips
- git diff --check
