### PR TITLE
test: lock autotask next schedule order

### DIFF
--- a/app/src/test/java/io/legado/app/config/AutoTaskPersistenceContractTest.kt
+++ b/app/src/test/java/io/legado/app/config/AutoTaskPersistenceContractTest.kt
@@ -185,6 +185,12 @@ class AutoTaskPersistenceContractTest {
         assertTrue(service.contains("return AutoTaskScheduler.shouldRetry(this)"))
         assertTrue(service.contains("start = CoroutineStart.LAZY"))
         assertTrue(service.contains("jobs.remove(jobId, currentJob)"))
+        val scheduleNext = service.indexOf(
+            "val nextScheduled = AutoTaskScheduler.refresh(this, afterBatch = true)"
+        )
+        val runDueTasks = service.indexOf("AutoTaskRunner.runDueTasks(this@AutoTaskJobService)")
+        assertTrue(scheduleNext >= 0)
+        assertTrue(runDueTasks > scheduleNext)
         val saveJob = service.indexOf("jobs[jobId] = currentJob")
         val startJob = service.indexOf("currentJob.start()")
         assertTrue(saveJob >= 0)


### PR DESCRIPTION
## Summary
- Lock AutoTaskJobService to schedule the next persisted job before executing due tasks.
- Preserve the existing post-batch time policy and fallback refresh while guarding the timeout-resilient call order.

This is the minimal test residual identified while re-auditing fork-only commit 4c3426d5b8. Production behavior is already integrated by upstream #322; this PR adds the missing regression contract only.

## Validation
- :app:testAppReleaseUnitTest --tests io.legado.app.config.AutoTaskPersistenceContractTest --no-daemon --max-workers=1 --console=plain
- 10 tests, 0 failures/errors/skips
- git diff --check