### PR TITLE
test: lock source editor holder state

### DIFF
--- a/app/src/test/java/io/legado/app/ui/book/source/edit/BookSourceEditLayoutTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/source/edit/BookSourceEditLayoutTest.kt
@@ -103,6 +103,43 @@ class BookSourceEditLayoutTest {
     }
 
     @Test
+    fun `edit adapters replay current safety state after holder reuse`() {
+        listOf(BOOK_SOURCE_ADAPTER_PATH, RSS_SOURCE_ADAPTER_PATH).forEach { path ->
+            val source = File(repositoryRoot, path).readText()
+            val bind = source.section(
+                "fun bind(editEntity: EditEntity)",
+                "private fun applyInteractionState()"
+            )
+            val stateUpdate = Regex(
+                "(?m)^\\s*isUnsafeText\\s*=\\s*!presentation\\.isInlineEditable\\s*$"
+            ).find(bind)?.range?.first ?: -1
+            val stateReplay = Regex(
+                "(?m)^\\s*applyInteractionState\\(\\)\\s*$"
+            ).find(bind)?.range?.first ?: -1
+
+            assertTrue(
+                "$path must keep safety state on the holder",
+                Regex("private\\s+var\\s+isUnsafeText\\s*=\\s*false").containsMatchIn(source)
+            )
+            assertTrue(
+                "$path must replay safety state when attached",
+                Regex(
+                    "onViewAttachedToWindow\\([^)]*\\)\\s*\\{\\s*" +
+                        "applyInteractionState\\(\\)"
+                ).containsMatchIn(source)
+            )
+            assertTrue("$path must update holder safety state while binding", stateUpdate >= 0)
+            assertTrue(
+                "$path must replay safety state after updating it",
+                stateReplay > stateUpdate
+            )
+            assertTrue(Regex("isFocusable\\s*=\\s*!isUnsafeText").containsMatchIn(source))
+            assertTrue(Regex("isFocusableInTouchMode\\s*=\\s*!isUnsafeText")
+                .containsMatchIn(source))
+        }
+    }
+
+    @Test
     fun `source editor keeps the caret visible after selection and layout changes`() {
         val source = File(repositoryRoot, ACTIVITY_PATH).readText()
         val initView = source.section("private fun initView()", "private fun initOptionPanel()")
@@ -233,6 +270,10 @@ class BookSourceEditLayoutTest {
         const val LAYOUT_PATH = "app/src/main/res/layout/activity_book_source_edit.xml"
         const val ACTIVITY_PATH =
             "app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditActivity.kt"
+        const val BOOK_SOURCE_ADAPTER_PATH =
+            "app/src/main/java/io/legado/app/ui/book/source/edit/BookSourceEditAdapter.kt"
+        const val RSS_SOURCE_ADAPTER_PATH =
+            "app/src/main/java/io/legado/app/ui/rss/source/edit/RssSourceEditAdapter.kt"
         const val CARD_VIEW = "androidx.cardview.widget.CardView"
         const val FLEXBOX = "com.google.android.flexbox.FlexboxLayout"
         const val TAB_LAYOUT = "com.google.android.material.tabs.TabLayout"


### PR DESCRIPTION
## 变更说明

补充书源与 RSS 编辑器的 ViewHolder 复用契约测试，锁定安全文本状态保存在 holder 上，并在 bind 更新后和重新 attach 时重放，避免回收后沿用首次绑定的焦点状态。

关联 Issue：无

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 文档
- [ ] 构建或依赖
- [x] 重构或维护

## 涉及平台

- [x] Android
- [ ] Web
- [ ] Android 与 Web

## 涉及模块

- [ ] 阅读文本与翻页
- [ ] 漫画阅读
- [ ] 朗读与音频
- [ ] 书架与书籍管理
- [x] 书源与规则解析
- [ ] Web 服务与前端
- [ ] 备份、同步与数据
- [ ] 构建、安装与更新
- [ ] 其他或不确定

## 影响类型

- [ ] 崩溃或无响应
- [ ] 数据丢失或损坏
- [ ] 性能或耗电
- [ ] 兼容性
- [ ] 界面或交互
- [ ] 功能结果错误
- [x] 无用户可见影响

## 验证

- [x] `BookSourceEditLayoutTest`：7/7 通过
- [x] 反向变异：将 bind 状态改回局部变量后新增测试按预期失败
- [x] `git diff --check` 通过，提交仅修改一个测试文件
- [x] 已完成与改动范围相符的验证
- [x] 未引入无关改动
