### PR TITLE
feat: add update CDN fallback choices

### DIFF
--- a/app/src/main/java/io/legado/app/help/update/AppUpdate.kt
+++ b/app/src/main/java/io/legado/app/help/update/AppUpdate.kt
@@ -18,6 +18,8 @@ object AppUpdate {
         val downloadUrl: String,
         val fileName: String,
         val backupDownloadUrl: String? = null,
+        val mirrorDownloadUrl: String? = null,
+        val alternateMirrorDownloadUrl: String? = null,
         val size: Long = 0L,
         val createdAt: Long = 0L,
         val isBeta: Boolean = false

--- a/app/src/main/java/io/legado/app/help/update/AppUpdateGitHub.kt
+++ b/app/src/main/java/io/legado/app/help/update/AppUpdateGitHub.kt
@@ -109,12 +109,20 @@ object AppUpdateGitHub : AppUpdate.AppUpdateInterface {
 
 internal fun AppReleaseInfo.toUpdateInfo(isBeta: Boolean = false): AppUpdate.UpdateInfo {
     val primaryUrl = if (isBeta) downloadUrl else resolveAppUpdateDownloadUrl(name, downloadUrl)
+    val mirrorUrl = if (isBeta) null else resolveAppUpdateMirrorUrl(name, primaryUrl)
+    val alternateMirrorUrl = if (isBeta) {
+        null
+    } else {
+        resolveAppUpdateAlternateMirrorUrl(name, primaryUrl, mirrorUrl)
+    }
     return AppUpdate.UpdateInfo(
         tagName = versionName,
         updateLog = note,
         downloadUrl = primaryUrl,
         fileName = name,
         backupDownloadUrl = if (isBeta) null else resolveAppUpdateBackupUrl(primaryUrl, downloadUrl),
+        mirrorDownloadUrl = mirrorUrl,
+        alternateMirrorDownloadUrl = alternateMirrorUrl,
         size = size,
         createdAt = createdAt,
         isBeta = isBeta

--- a/app/src/main/java/io/legado/app/help/update/AppUpdateSelector.kt
+++ b/app/src/main/java/io/legado/app/help/update/AppUpdateSelector.kt
@@ -102,6 +102,22 @@ internal fun resolveAppUpdateDownloadUrl(fileName: String, githubUrl: String): S
     }
 }
 
+internal fun resolveAppUpdateMirrorUrl(fileName: String, primaryUrl: String): String? {
+    if (fileName.contains("_._")) return null
+    return "https://cdn.gigu.edu.kg/app/$fileName".takeUnless { it == primaryUrl }
+}
+
+internal fun resolveAppUpdateAlternateMirrorUrl(
+    fileName: String,
+    primaryUrl: String,
+    mirrorUrl: String?
+): String? {
+    if (fileName.contains("_._")) return null
+    return "https://cdn.mgz.edu.kg/app/$fileName".takeUnless {
+        it == primaryUrl || it == mirrorUrl
+    }
+}
+
 internal fun resolveAppUpdateBackupUrl(primaryUrl: String, githubUrl: String): String? =
     githubUrl.takeUnless { it == primaryUrl }
 

--- a/app/src/main/java/io/legado/app/ui/about/UpdateDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/about/UpdateDialog.kt
@@ -34,6 +34,8 @@ class UpdateDialog() : BaseDialogFragment(R.layout.dialog_update) {
             putString("url", updateInfo.downloadUrl)
             putString("name", updateInfo.fileName)
             putString("backupUrl", updateInfo.backupDownloadUrl)
+            putString("mirrorUrl", updateInfo.mirrorDownloadUrl)
+            putString("alternateMirrorUrl", updateInfo.alternateMirrorDownloadUrl)
             putLong("size", updateInfo.size)
             putLong("createdAt", updateInfo.createdAt)
             putBoolean("isBeta", updateInfo.isBeta)
@@ -92,10 +94,17 @@ class UpdateDialog() : BaseDialogFragment(R.layout.dialog_update) {
             binding.toolBar.inflateMenu(R.menu.app_update)
             binding.toolBar.menu.findItem(R.id.menu_download_backup).isVisible =
                 !arguments?.getString("backupUrl").isNullOrBlank()
+            binding.toolBar.menu.findItem(R.id.menu_download_mirror).isVisible =
+                !arguments?.getString("mirrorUrl").isNullOrBlank()
+            binding.toolBar.menu.findItem(R.id.menu_download_alternate_mirror).isVisible =
+                !arguments?.getString("alternateMirrorUrl").isNullOrBlank()
             binding.toolBar.setOnMenuItemClickListener {
                 when (it.itemId) {
                     R.id.menu_download -> startDownload(arguments?.getString("url"))
                     R.id.menu_download_backup -> startDownload(arguments?.getString("backupUrl"))
+                    R.id.menu_download_mirror -> startDownload(arguments?.getString("mirrorUrl"))
+                    R.id.menu_download_alternate_mirror ->
+                        startDownload(arguments?.getString("alternateMirrorUrl"))
                     R.id.menu_open_in_browser -> arguments?.getString("backupUrl").orEmpty()
                         .ifBlank { arguments?.getString("url").orEmpty() }
                         .takeIf(String::isNotBlank)

--- a/app/src/main/res/menu/app_update.xml
+++ b/app/src/main/res/menu/app_update.xml
@@ -18,6 +18,16 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/menu_download_mirror"
+        android:title="@string/download_from_backup_cdn"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/menu_download_alternate_mirror"
+        android:title="@string/download_from_second_cdn"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_ignore_version"
         android:title="@string/ignore_this_version"
         app:showAsAction="never" />

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1134,6 +1134,8 @@
     <string name="double_page_horizontal">平板/横屏双页</string>
     <string name="open_in_browser">浏览器打开</string>
     <string name="download_from_github">GitHub 直链下载</string>
+    <string name="download_from_backup_cdn">从 cdn.gigu.edu.kg 下载</string>
+    <string name="download_from_second_cdn">从 cdn.mgz.edu.kg 下载</string>
     <string name="ignore_this_version">忽略此版本</string>
     <string name="copy_url">拷贝 URL</string>
     <string name="full_screen">全屏</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1137,6 +1137,8 @@
     <string name="double_page_horizontal">Tablet/Landscape Dual Page</string>
     <string name="open_in_browser">open in browser</string>
     <string name="download_from_github">Download from GitHub</string>
+    <string name="download_from_backup_cdn">Download from cdn.gigu.edu.kg</string>
+    <string name="download_from_second_cdn">Download from cdn.mgz.edu.kg</string>
     <string name="ignore_this_version">Ignore this version</string>
     <string name="copy_url">copy url</string>
     <string name="full_screen">full screen</string>

--- a/app/src/test/java/io/legado/app/help/update/AppUpdateSelectorTest.kt
+++ b/app/src/test/java/io/legado/app/help/update/AppUpdateSelectorTest.kt
@@ -348,11 +348,27 @@ class AppUpdateSelectorTest {
 
     @Test
     fun updateDownloadsUseCdnExceptForHistoricalSanitizedNames() {
+        val armFile = "legado_app_3.26071309_release.apk"
         assertEquals(
             "https://cdn.mgz.la/app/legado_app_3.26071309_release.apk",
             resolveAppUpdateDownloadUrl(
-                "legado_app_3.26071309_release.apk",
+                armFile,
                 "https://github.com/example/arm.apk"
+            )
+        )
+        assertEquals(
+            "https://cdn.gigu.edu.kg/app/legado_app_3.26071309_release.apk",
+            resolveAppUpdateMirrorUrl(
+                armFile,
+                "https://cdn.mgz.la/app/$armFile"
+            )
+        )
+        assertEquals(
+            "https://cdn.mgz.edu.kg/app/legado_app_3.26071309_release.apk",
+            resolveAppUpdateAlternateMirrorUrl(
+                armFile,
+                "https://cdn.mgz.la/app/$armFile",
+                "https://cdn.gigu.edu.kg/app/$armFile"
             )
         )
         assertEquals(
@@ -369,6 +385,19 @@ class AppUpdateSelectorTest {
                 "https://github.com/example/legacy-universal.apk"
             )
         )
+        assertNull(
+            resolveAppUpdateMirrorUrl(
+                "legado_app_3.26.0713082212_._release.apk",
+                "https://github.com/example/legacy-universal.apk"
+            )
+        )
+        assertNull(
+            resolveAppUpdateAlternateMirrorUrl(
+                "legado_app_3.26.0713082212_._release.apk",
+                "https://github.com/example/legacy-universal.apk",
+                null
+            )
+        )
     }
 
     @Test
@@ -377,6 +406,30 @@ class AppUpdateSelectorTest {
         val cdnUrl = resolveAppUpdateDownloadUrl("legado_app_release.apk", githubUrl)
 
         assertEquals(githubUrl, resolveAppUpdateBackupUrl(cdnUrl, githubUrl))
+        assertEquals(
+            "https://cdn.gigu.edu.kg/app/legado_app_release.apk",
+            resolveAppUpdateMirrorUrl("legado_app_release.apk", cdnUrl)
+        )
+        assertEquals(
+            "https://cdn.mgz.edu.kg/app/legado_app_release.apk",
+            resolveAppUpdateAlternateMirrorUrl(
+                "legado_app_release.apk",
+                cdnUrl,
+                "https://cdn.gigu.edu.kg/app/legado_app_release.apk"
+            )
+        )
+        val update = release("legado_app_release.apk").copy(downloadUrl = githubUrl)
+            .toUpdateInfo()
+        assertEquals(cdnUrl, update.downloadUrl)
+        assertEquals(
+            "https://cdn.gigu.edu.kg/app/legado_app_release.apk",
+            update.mirrorDownloadUrl
+        )
+        assertEquals(
+            "https://cdn.mgz.edu.kg/app/legado_app_release.apk",
+            update.alternateMirrorDownloadUrl
+        )
+        assertEquals(githubUrl, update.backupDownloadUrl)
         assertNull(resolveAppUpdateBackupUrl(githubUrl, githubUrl))
         assertTrue(isIgnoredAppUpdate("3.26080220", "3.26080220"))
         assertFalse(isIgnoredAppUpdate("3.26080221", "3.26080220"))
@@ -390,6 +443,8 @@ class AppUpdateSelectorTest {
 
         assertEquals(release.downloadUrl, update.downloadUrl)
         assertNull(update.backupDownloadUrl)
+        assertNull(update.mirrorDownloadUrl)
+        assertNull(update.alternateMirrorDownloadUrl)
         assertTrue(update.isBeta)
     }
 

--- a/app/src/test/java/io/legado/app/ui/about/UpdateDialogLifecycleTest.kt
+++ b/app/src/test/java/io/legado/app/ui/about/UpdateDialogLifecycleTest.kt
@@ -57,6 +57,43 @@ class UpdateDialogLifecycleTest {
     }
 
     @Test
+    fun `formal update dialog exposes the backup cdn separately from github`() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/ui/about/UpdateDialog.kt"
+        ).readText()
+
+        assertTrue(source.contains("putString(\"mirrorUrl\", updateInfo.mirrorDownloadUrl)"))
+        assertTrue(
+            source.contains(
+                "putString(\"alternateMirrorUrl\", updateInfo.alternateMirrorDownloadUrl)"
+            )
+        )
+        assertTrue(source.contains("R.id.menu_download_mirror).isVisible"))
+        assertTrue(
+            source.contains(
+                "R.id.menu_download_mirror -> startDownload(arguments?.getString(\"mirrorUrl\"))"
+            )
+        )
+        assertTrue(source.contains("R.id.menu_download_alternate_mirror).isVisible"))
+        assertTrue(
+            source.contains(
+                "R.id.menu_download_alternate_mirror ->"
+            ) && source.contains("startDownload(arguments?.getString(\"alternateMirrorUrl\"))")
+        )
+        assertTrue(source.contains("R.id.menu_download_backup -> startDownload"))
+        assertTrue(
+            projectFile("src/main/res/menu/app_update.xml")
+                .readText()
+                .contains("android:id=\"@+id/menu_download_mirror\"")
+        )
+        assertTrue(
+            projectFile("src/main/res/menu/app_update.xml")
+                .readText()
+                .contains("android:id=\"@+id/menu_download_alternate_mirror\"")
+        )
+    }
+
+    @Test
     fun `manual update errors show their message without a redundant action prefix`() {
         val source = projectFile(
             "src/main/java/io/legado/app/ui/about/AboutFragment.kt"


### PR DESCRIPTION
## Summary

- Keep `cdn.mgz.la` as the formal update primary URL.
- Add manual download choices for `cdn.gigu.edu.kg` and `cdn.mgz.edu.kg`, while retaining GitHub as the final fallback.
- Keep historical `_._` packages and beta updates on their existing GitHub paths.

## Validation

- `AppUpdateSelectorTest`: 20 tests, 0 failures/errors/skips.
- `UpdateDialogLifecycleTest`: 5 tests, 0 failures/errors/skips.
- Command: `./gradlew.bat app:testDebugUnitTest --tests io.legado.app.help.update.AppUpdateSelectorTest --tests io.legado.app.ui.about.UpdateDialogLifecycleTest --no-daemon --max-workers=1 --console=plain`
- Live formal APK probe: `cdn.mgz.la` and `cdn.gigu.edu.kg` both return HTTP 200 with identical 20,849,925-byte content and ETag.

## Operational note

`cdn.mgz.edu.kg` now resolves in DNS, but the current edge still presents a certificate without this hostname and returns HTTP 515 for the tested APK path. The app exposes it only as an explicit manual option; the domain needs valid TLS/vhost configuration before that option can succeed. No insecure HTTP fallback is added.
