### PR TITLE
fix: preserve reader position after late TOC refresh

### DIFF
--- a/app/src/main/java/io/legado/app/model/CacheBook.kt
+++ b/app/src/main/java/io/legado/app/model/CacheBook.kt
@@ -419,7 +419,8 @@ object CacheBook {
             scope: CoroutineScope,
             chapter: BookChapter,
             semaphore: Semaphore?,
-            resetPageOffset: Boolean = false
+            resetPageOffset: Boolean = false,
+            readPositionVersion: Long? = null,
         ) {
             if (onDownloadSet.contains(chapter.index)) {
                 return
@@ -439,15 +440,31 @@ object CacheBook {
                 onSuccess(chapter)
                 ReadBook.downloadedChapters.add(chapter.index)
                 ReadBook.downloadFailChapters.remove(chapter.index)
-                downloadFinish(chapter, currentContent, resetPageOffset)
+                downloadFinish(
+                    chapter,
+                    currentContent,
+                    resetPageOffset,
+                    readPositionVersion = readPositionVersion,
+                )
             }.onError {
                 onReadError(chapter, it)
                 ReadBook.downloadFailChapters[chapter.index] =
                     (ReadBook.downloadFailChapters[chapter.index] ?: 0) + 1
-                downloadFinish(chapter, "获取正文失败\n${it.localizedMessage}", resetPageOffset)
+                downloadFinish(
+                    chapter,
+                    "获取正文失败\n${it.localizedMessage}",
+                    resetPageOffset,
+                    readPositionVersion = readPositionVersion,
+                )
             }.onCancel {
                 onReadCancel(chapter.index)
-                downloadFinish(chapter, "download canceled", resetPageOffset, true)
+                downloadFinish(
+                    chapter,
+                    "download canceled",
+                    resetPageOffset,
+                    true,
+                    readPositionVersion = readPositionVersion,
+                )
             }.onFinally {
                 postEvent(EventBus.UP_DOWNLOAD, book.bookUrl)
             }.start()
@@ -457,13 +474,15 @@ object CacheBook {
             chapter: BookChapter,
             content: String,
             resetPageOffset: Boolean = false,
-            canceled: Boolean = false
+            canceled: Boolean = false,
+            readPositionVersion: Long? = null,
         ) {
             if (ReadBook.book?.bookUrl == book.bookUrl) {
                 ReadBook.contentLoadFinish(
                     book, chapter, content,
                     resetPageOffset = resetPageOffset,
-                    canceled = canceled
+                    canceled = canceled,
+                    readPositionVersion = readPositionVersion,
                 )
             }
         }

--- a/app/src/main/java/io/legado/app/model/ReadBook.kt
+++ b/app/src/main/java/io/legado/app/model/ReadBook.kt
@@ -960,13 +960,25 @@ object ReadBook : CoroutineScope by MainScope() {
      */
     fun loadContent(
         resetPageOffset: Boolean,
-        success: (() -> Unit)? = null
+        readPositionVersion: Long? = null,
+        success: (() -> Unit)? = null,
     ) {
-        loadContent(durChapterIndex, resetPageOffset = resetPageOffset) {
-            success?.invoke()
-        }
-        loadContent(durChapterIndex + 1, resetPageOffset = resetPageOffset)
-        loadContent(durChapterIndex - 1, resetPageOffset = resetPageOffset)
+        loadContent(
+            durChapterIndex,
+            resetPageOffset = resetPageOffset,
+            readPositionVersion = readPositionVersion,
+            success = { success?.invoke() },
+        )
+        loadContent(
+            durChapterIndex + 1,
+            resetPageOffset = resetPageOffset,
+            readPositionVersion = readPositionVersion,
+        )
+        loadContent(
+            durChapterIndex - 1,
+            resetPageOffset = resetPageOffset,
+            readPositionVersion = readPositionVersion,
+        )
     }
 
     fun loadOrUpContent(success: (() -> Unit)? = null) {
@@ -1066,7 +1078,8 @@ object ReadBook : CoroutineScope by MainScope() {
         index: Int,
         upContent: Boolean = true,
         resetPageOffset: Boolean = false,
-        success: (() -> Unit)? = null
+        readPositionVersion: Long? = null,
+        success: (() -> Unit)? = null,
     ) {
         Coroutine.async {
             val book = book!!
@@ -1079,12 +1092,14 @@ object ReadBook : CoroutineScope by MainScope() {
                         it,
                         upContent,
                         resetPageOffset,
+                        readPositionVersion = readPositionVersion,
                         success = success
                     )
                 } ?: download(
                     downloadScope,
                     chapter,
-                    resetPageOffset
+                    resetPageOffset,
+                    readPositionVersion = readPositionVersion,
                 )
             }
         }.onError {
@@ -1096,14 +1111,22 @@ object ReadBook : CoroutineScope by MainScope() {
         index: Int,
         upContent: Boolean = true,
         resetPageOffset: Boolean = false,
-        success: (() -> Unit)? = null
+        readPositionVersion: Long? = null,
+        success: (() -> Unit)? = null,
     ) = withContext(IO) {
         if (addLoading(index)) {
             try {
                 val book = book!!
                 val chapter = appDb.bookChapterDao.getChapter(book.bookUrl, index)!!
                 val content = BookHelp.getContent(book, chapter) ?: downloadAwait(chapter)
-                contentLoadFinishAwait(book, chapter, content, upContent, resetPageOffset)
+                contentLoadFinishAwait(
+                    book,
+                    chapter,
+                    content,
+                    upContent,
+                    resetPageOffset,
+                    readPositionVersion,
+                )
                 success?.invoke()
             } catch (e: Exception) {
                 AppLog.put("加载正文出错\n${e.localizedMessage}")
@@ -1142,12 +1165,19 @@ object ReadBook : CoroutineScope by MainScope() {
         chapter: BookChapter,
         resetPageOffset: Boolean,
         semaphore: Semaphore? = null,
-        success: (() -> Unit)? = null
+        readPositionVersion: Long? = null,
+        success: (() -> Unit)? = null,
     ) {
         val book = book ?: return removeLoading(chapter.index)
         val bookSource = bookSource
         if (bookSource != null) {
-            CacheBook.getOrCreate(bookSource, book).download(scope, chapter, semaphore)
+            CacheBook.getOrCreate(bookSource, book).download(
+                scope,
+                chapter,
+                semaphore,
+                resetPageOffset = resetPageOffset,
+                readPositionVersion = readPositionVersion,
+            )
         } else {
             val msg = if (book.isLocal) "无内容" else "没有书源"
             contentLoadFinish(
@@ -1155,6 +1185,7 @@ object ReadBook : CoroutineScope by MainScope() {
                 chapter,
                 "加载正文失败\n$msg",
                 resetPageOffset = resetPageOffset,
+                readPositionVersion = readPositionVersion,
                 success = success
             )
         }
@@ -1194,12 +1225,15 @@ object ReadBook : CoroutineScope by MainScope() {
         upContent: Boolean = true,
         resetPageOffset: Boolean,
         canceled: Boolean = false,
-        success: (() -> Unit)? = null
+        readPositionVersion: Long? = null,
+        success: (() -> Unit)? = null,
     ) {
         removeLoading(chapter.index)
         if (canceled || chapter.index !in durChapterIndex - 1..durChapterIndex + 1) {
             return
         }
+        val shouldResetPageOffset = resetPageOffset &&
+            shouldApplyReadPositionReset(readPositionVersion)
         chapterLoadingJobs[chapter.index]?.cancel()
         val job = Coroutine.async(this, start = CoroutineStart.LAZY) {
             val contentProcessor = ContentProcessor.get(book.name, book.origin)
@@ -1229,7 +1263,11 @@ object ReadBook : CoroutineScope by MainScope() {
                         val positionReady = resolvePendingHighlightJump(book, textChapter)
                         if (positionReady && !available && page.containPos(durChapterPos)) {
                             if (upContent) {
-                                callBack?.upContent(offset, resetPageOffset)
+                                callBack?.upContent(
+                                    offset,
+                                    shouldResetPageOffset,
+                                    readPositionVersion = readPositionVersion,
+                                )
                             }
                             available = true
                         }
@@ -1241,7 +1279,13 @@ object ReadBook : CoroutineScope by MainScope() {
                         callBack?.onLayoutPageCompleted(index, page)
                     }
                     resolvePendingHighlightAnchor(book, textChapter)
-                    if (upContent) callBack?.upContent(offset, !available && resetPageOffset)
+                    if (upContent) {
+                        callBack?.upContent(
+                            offset,
+                            !available && shouldResetPageOffset,
+                            readPositionVersion = readPositionVersion,
+                        )
+                    }
                     curPageChanged(
                         syncReadAloudFollow = BaseReadAloudService.shouldSyncSpeechNavigation()
                     )
@@ -1256,7 +1300,13 @@ object ReadBook : CoroutineScope by MainScope() {
                         observeHighlightRuleLayout(textChapter)
                     }
                     textChapter.layoutChannel.receiveAsFlow().collect()
-                    if (upContent) callBack?.upContent(offset, resetPageOffset)
+                    if (upContent) {
+                        callBack?.upContent(
+                            offset,
+                            shouldResetPageOffset,
+                            readPositionVersion = readPositionVersion,
+                        )
+                    }
                 }
 
                 1 -> nextChapterLoadingLock.withLock {
@@ -1270,7 +1320,13 @@ object ReadBook : CoroutineScope by MainScope() {
                         if (page.index > 1) {
                             continue
                         }
-                        if (upContent) callBack?.upContent(offset, resetPageOffset)
+                        if (upContent) {
+                            callBack?.upContent(
+                                offset,
+                                shouldResetPageOffset,
+                                readPositionVersion = readPositionVersion,
+                            )
+                        }
                     }
                 }
             }
@@ -1294,12 +1350,15 @@ object ReadBook : CoroutineScope by MainScope() {
         chapter: BookChapter,
         content: String,
         upContent: Boolean = true,
-        resetPageOffset: Boolean
+        resetPageOffset: Boolean,
+        readPositionVersion: Long? = null,
     ) {
         removeLoading(chapter.index)
         if (chapter.index !in durChapterIndex - 1..durChapterIndex + 1) {
             return
         }
+        val shouldResetPageOffset = resetPageOffset &&
+            shouldApplyReadPositionReset(readPositionVersion)
         kotlin.runCatching {
             val contentProcessor = ContentProcessor.get(book.name, book.origin)
             val displayTitle = chapter.getDisplayTitle(
@@ -1326,7 +1385,11 @@ object ReadBook : CoroutineScope by MainScope() {
                         val positionReady = resolvePendingHighlightJump(book, textChapter)
                         if (positionReady && !available && page.containPos(durChapterPos)) {
                             if (upContent) {
-                                callBack?.upContent(offset, resetPageOffset)
+                                callBack?.upContent(
+                                    offset,
+                                    shouldResetPageOffset,
+                                    readPositionVersion = readPositionVersion,
+                                )
                             }
                             available = true
                         }
@@ -1338,7 +1401,13 @@ object ReadBook : CoroutineScope by MainScope() {
                         callBack?.onLayoutPageCompleted(index, page)
                     }
                     resolvePendingHighlightAnchor(book, textChapter)
-                    if (upContent) callBack?.upContent(offset, !available && resetPageOffset)
+                    if (upContent) {
+                        callBack?.upContent(
+                            offset,
+                            !available && shouldResetPageOffset,
+                            readPositionVersion = readPositionVersion,
+                        )
+                    }
                     curPageChanged(
                         syncReadAloudFollow = BaseReadAloudService.shouldSyncSpeechNavigation()
                     )
@@ -1352,7 +1421,13 @@ object ReadBook : CoroutineScope by MainScope() {
                         observeHighlightRuleLayout(textChapter)
                     }
                     textChapter.layoutChannel.receiveAsFlow().collect()
-                    if (upContent) callBack?.upContent(offset, resetPageOffset)
+                    if (upContent) {
+                        callBack?.upContent(
+                            offset,
+                            shouldResetPageOffset,
+                            readPositionVersion = readPositionVersion,
+                        )
+                    }
                 }
 
                 1 -> {
@@ -1365,7 +1440,13 @@ object ReadBook : CoroutineScope by MainScope() {
                         if (page.index > 1) {
                             continue
                         }
-                        if (upContent) callBack?.upContent(offset, resetPageOffset)
+                        if (upContent) {
+                            callBack?.upContent(
+                                offset,
+                                shouldResetPageOffset,
+                                readPositionVersion = readPositionVersion,
+                            )
+                        }
                     }
                 }
             }
@@ -1504,9 +1585,17 @@ object ReadBook : CoroutineScope by MainScope() {
                     it.bookUrl == newBook.bookUrl && it.chapterIndex == durChapterIndex
                 }
             } else if (loadContent) {
-                loadContent(true)
+                loadContent(
+                    resetPageOffset = true,
+                    readPositionVersion = callBack?.readPositionVersion(),
+                )
             }
         }
+    }
+
+    private fun shouldApplyReadPositionReset(readPositionVersion: Long?): Boolean {
+        return readPositionVersion == null ||
+            callBack?.isReadPositionVersionCurrent(readPositionVersion) != false
     }
 
     private fun clearExpiredChapterLoadingJob(clearAll: Boolean = false) {
@@ -1664,12 +1753,18 @@ object ReadBook : CoroutineScope by MainScope() {
         fun upContent(
             relativePosition: Int = 0,
             resetPageOffset: Boolean = true,
+            readPositionVersion: Long? = null,
             success: (() -> Unit)? = null
         )
+
+        fun readPositionVersion(): Long? = null
+
+        fun isReadPositionVersionCurrent(version: Long): Boolean = true
 
         suspend fun upContentAwait(
             relativePosition: Int = 0,
             resetPageOffset: Boolean = true,
+            readPositionVersion: Long? = null,
             success: (() -> Unit)? = null
         )
 

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
@@ -1302,11 +1302,14 @@ class ReadBookActivity : BaseReadBookActivity(),
     override fun upContent(
         relativePosition: Int,
         resetPageOffset: Boolean,
+        readPositionVersion: Long?,
         success: (() -> Unit)?
     ) {
         lifecycleScope.launch {
+            val shouldResetPageOffset = resetPageOffset &&
+                (readPositionVersion == null || isReadPositionVersionCurrent(readPositionVersion))
             binding.readView.cancelTouchGestures()
-            binding.readView.upContent(relativePosition, resetPageOffset)
+            binding.readView.upContent(relativePosition, shouldResetPageOffset)
             observeBookmarks()
             upBookmarkIndicator()
             if (relativePosition == 0) {
@@ -1318,13 +1321,24 @@ class ReadBookActivity : BaseReadBookActivity(),
         }
     }
 
+    override fun readPositionVersion(): Long {
+        return binding.readView.getReadPositionVersion()
+    }
+
+    override fun isReadPositionVersionCurrent(version: Long): Boolean {
+        return binding.readView.getReadPositionVersion() == version
+    }
+
     override suspend fun upContentAwait(
         relativePosition: Int,
         resetPageOffset: Boolean,
+        readPositionVersion: Long?,
         success: (() -> Unit)?
     ) = withContext(Main.immediate) {
+        val shouldResetPageOffset = resetPageOffset &&
+            (readPositionVersion == null || isReadPositionVersionCurrent(readPositionVersion))
         binding.readView.cancelTouchGestures()
-        binding.readView.upContent(relativePosition, resetPageOffset)
+        binding.readView.upContent(relativePosition, shouldResetPageOffset)
         observeBookmarks()
         upBookmarkIndicator()
         if (relativePosition == 0) {

--- a/app/src/main/java/io/legado/app/ui/book/read/page/ReadPositionVersion.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/ReadPositionVersion.kt
@@ -1,0 +1,15 @@
+package io.legado.app.ui.book.read.page
+
+internal class ReadPositionVersion {
+
+    @Volatile
+    private var value = 0L
+
+    fun snapshot(): Long = value
+
+    fun markChanged() {
+        value++
+    }
+
+    fun isCurrent(snapshot: Long): Boolean = value == snapshot
+}

--- a/app/src/main/java/io/legado/app/ui/book/read/page/ReadView.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/ReadView.kt
@@ -146,6 +146,7 @@ class ReadView(context: Context, attrs: AttributeSet) :
     val defaultAnimationSpeed = 300
     private var pressDown = false
     private var isMove = false
+    private val readPositionVersion = ReadPositionVersion()
 
     //起始点
     var startX: Float = 0f
@@ -614,6 +615,12 @@ class ReadView(context: Context, attrs: AttributeSet) :
         pageDelegate?.onScroll()
         val offset = touchY - lastY
         touchY -= offset - offset.toInt()
+    }
+
+    fun getReadPositionVersion(): Long = readPositionVersion.snapshot()
+
+    fun markReadPositionChanged() {
+        readPositionVersion.markChanged()
     }
 
     /**

--- a/app/src/main/java/io/legado/app/ui/book/read/page/delegate/HorizontalPageDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/delegate/HorizontalPageDelegate.kt
@@ -83,6 +83,7 @@ abstract class HorizontalPageDelegate(readView: ReadView) : PageDelegate(readVie
             val distance = deltaX * deltaX + deltaY * deltaY
             isMoved = distance > slopSquare
             if (isMoved) {
+                readView.markReadPositionChanged()
                 if (sumX - startX > 0) {
                     //如果上一页不存在
                     if (!hasPrev()) {

--- a/app/src/main/java/io/legado/app/ui/book/read/page/delegate/ScrollPageDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/delegate/ScrollPageDelegate.kt
@@ -87,6 +87,7 @@ class ScrollPageDelegate(readView: ReadView) : PageDelegate(readView) {
             val distance = deltaX * deltaX + deltaY * deltaY
             isMoved = distance > slopSquare
             if (isMoved) {
+                readView.markReadPositionChanged()
                 readView.setStartPoint(event.x, event.y, false)
             }
         }

--- a/app/src/test/java/io/legado/app/model/ReadBookRefreshPositionTest.kt
+++ b/app/src/test/java/io/legado/app/model/ReadBookRefreshPositionTest.kt
@@ -67,6 +67,31 @@ class ReadBookRefreshPositionTest {
         assertFalse(anchorResolver.contains("textChapter.isCompleted"))
     }
 
+    @Test
+    fun `toc refresh carries a scroll version while explicit jumps keep reset`() {
+        val readBook = source("app/src/main/java/io/legado/app/model/ReadBook.kt")
+        val chapterUpdate = readBook.substringAfter("fun onChapterListUpdated(")
+            .substringBefore("private fun shouldApplyReadPositionReset")
+        assertTrue(chapterUpdate.contains("readPositionVersion = callBack?.readPositionVersion()"))
+        assertTrue(readBook.contains("readPositionVersion = readPositionVersion"))
+        assertTrue(readBook.contains("resetPageOffset = resetPageOffset"))
+
+        val openChapter = readBook.substringAfter("fun openChapter(")
+            .substringBefore("private fun curPageChanged")
+        assertTrue(openChapter.contains("loadContent(resetPageOffset = true)"))
+        assertFalse(openChapter.contains("readPositionVersion ="))
+
+        val setProgress = readBook.substringAfter("fun setProgress(")
+            .substringBefore("//暂时保存跳转前进度")
+        assertTrue(setProgress.contains("loadContent(resetPageOffset = true)"))
+        assertFalse(setProgress.contains("readPositionVersion ="))
+
+        val activity = source("app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt")
+        val upContent = activity.substringAfter("override fun upContent(")
+            .substringBefore("override fun readPositionVersion")
+        assertTrue(upContent.contains("isReadPositionVersionCurrent(readPositionVersion)"))
+    }
+
     private fun assertOrder(source: String, vararg expected: String) {
         var position = -1
         expected.forEach { text ->

--- a/app/src/test/java/io/legado/app/ui/book/read/page/ReadPositionVersionTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/page/ReadPositionVersionTest.kt
@@ -1,0 +1,18 @@
+package io.legado.app.ui.book.read.page
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReadPositionVersionTest {
+
+    @Test
+    fun `a late automatic reload loses reset permission after user movement`() {
+        val version = ReadPositionVersion()
+        val requestVersion = version.snapshot()
+
+        assertTrue(version.isCurrent(requestVersion))
+        version.markChanged()
+        assertFalse(version.isCurrent(requestVersion))
+    }
+}


### PR DESCRIPTION
## What changed

- Track a reader-position version when the user crosses the touch slop in scroll or horizontal reading.
- Capture that version only for the automatic `onChapterListUpdated` content reload and carry it through cached and downloaded chapter content.
- Re-check the version immediately before `ReadView.upContent`; if the reader moved after the reload started, do not restore the saved scroll offset.
- Keep explicit `openChapter` and `setProgress` loads on their existing `resetPageOffset = true` path.

The latest #885 diagnostic logs show repeated late `loadContent(... resetPageOffset=true)` callbacks after `upBookToc`; visible positions moved from `497:210` to `497:191`, `497:264` to `497:191`, and `497:347` to `497:290`.

## Validation

- `app:compileAppDebugKotlin --no-daemon --max-workers=1 --console=plain`
- Focused `app:testAppDebugUnitTest`:
  - `ReadPositionVersionTest`
  - `ReadBookRefreshPositionTest`
  - `ScrollReadPositionContractTest`

Fixes #885
