### PR TITLE
feat: locate current book source on open

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceAdapter.kt
@@ -16,7 +16,9 @@ import io.legado.app.data.entities.SearchBook
 import io.legado.app.databinding.ItemChangeSourceBinding
 import io.legado.app.help.config.AppConfig
 import io.legado.app.lib.dialogs.alert
+import io.legado.app.lib.theme.accentColor
 import io.legado.app.ui.widget.popupActionMenu
+import io.legado.app.utils.ColorUtils
 import io.legado.app.utils.getCompatColor
 import io.legado.app.utils.gone
 import io.legado.app.utils.invisible
@@ -64,7 +66,12 @@ class ChangeBookSourceAdapter(
                 tvLast.text = item.getDisplayLastChapterTitle()
                 tvCurrentChapterWordCount.text = item.chapterWordCountText
                 tvRespondTime.text = context.getString(R.string.respondTime, item.respondTime)
-                if (callBack.oldBookUrl == item.bookUrl) {
+                val isCurrent = callBack.oldBookUrl == item.bookUrl
+                viewSelectedBackground.setBackgroundColor(
+                    ColorUtils.withAlpha(context.accentColor, 0.1f)
+                )
+                viewSelectedBackground.visibility = if (isCurrent) View.VISIBLE else View.INVISIBLE
+                if (isCurrent) {
                     ivChecked.visible()
                 } else {
                     ivChecked.invisible()
@@ -76,10 +83,11 @@ class ChangeBookSourceAdapter(
                         when (it) {
                             "name" -> tvOrigin.text = item.originName
                             "latest" -> tvLast.text = item.getDisplayLastChapterTitle()
-                            "upCurSource" -> if (callBack.oldBookUrl == item.bookUrl) {
-                                ivChecked.visible()
-                            } else {
-                                ivChecked.invisible()
+                            "upCurSource" -> {
+                                val isCurrent = callBack.oldBookUrl == item.bookUrl
+                                viewSelectedBackground.visibility =
+                                    if (isCurrent) View.VISIBLE else View.INVISIBLE
+                                if (isCurrent) ivChecked.visible() else ivChecked.invisible()
                             }
                         }
                     }

--- a/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/changesource/ChangeBookSourceDialog.kt
@@ -76,6 +76,7 @@ class ChangeBookSourceDialog() : BaseDialogFragment(R.layout.dialog_book_change_
     private var searchFinishDialog: AlertDialog? = null
     private var typeMismatchDialog: AlertDialog? = null
     private var adapterDataObserver: RecyclerView.AdapterDataObserver? = null
+    private var autoScrollCurrentSource = true
     private val adapter by lazy { ChangeBookSourceAdapter(requireContext(), viewModel, this) }
     private val editSourceResult =
         registerForActivityResult(StartActivityContract(BookSourceEditActivity::class.java)) {
@@ -88,6 +89,7 @@ class ChangeBookSourceDialog() : BaseDialogFragment(R.layout.dialog_book_change_
     }
 
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
+        autoScrollCurrentSource = true
         binding.toolBar.setBackgroundColor(primaryColor)
         viewModel.initData(arguments, callBack?.oldBook, activity is ReadBookActivity)
         showTitle()
@@ -270,6 +272,11 @@ class ChangeBookSourceDialog() : BaseDialogFragment(R.layout.dialog_book_change_
             owner.lifecycle.currentStateFlow.first { it.isAtLeast(STARTED) }
             viewModel.searchDataFlow.conflate().collect {
                 adapter.setItems(it)
+                if (autoScrollCurrentSource && it.isNotEmpty()) {
+                    binding.recyclerView.post {
+                        if (scrollToDurSource()) autoScrollCurrentSource = false
+                    }
+                }
                 delay(1000)
             }
         }
@@ -417,14 +424,15 @@ class ChangeBookSourceDialog() : BaseDialogFragment(R.layout.dialog_book_change_
         return false
     }
 
-    private fun scrollToDurSource() {
+    private fun scrollToDurSource(): Boolean {
         adapter.getItems().forEachIndexed { index, searchBook ->
             if (searchBook.bookUrl == oldBookUrl) {
                 (binding.recyclerView.layoutManager as LinearLayoutManager)
                     .scrollToPositionWithOffset(index, 60.dpToPx())
-                return
+                return true
             }
         }
+        return false
     }
 
     override fun changeTo(searchBook: SearchBook) {

--- a/app/src/main/res/layout/item_change_source.xml
+++ b/app/src/main/res/layout/item_change_source.xml
@@ -7,6 +7,17 @@
     android:background="?android:attr/selectableItemBackground"
     tools:ignore="RtlHardcoded,RtlSymmetry">
 
+    <View
+        android:id="@+id/view_selected_background"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@color/transparent"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/iv_good"
         android:layout_width="30dp"

--- a/app/src/test/java/io/legado/app/ui/book/changesource/ChangeSourceViewLifecycleContractTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/changesource/ChangeSourceViewLifecycleContractTest.kt
@@ -51,6 +51,33 @@ class ChangeSourceViewLifecycleContractTest {
     }
 
     @Test
+    fun `book source dialog locates the current source after first results`() {
+        val dialog = source("ChangeBookSourceDialog.kt")
+        val collector = dialog.section(
+            "viewModel.searchDataFlow",
+            "viewModel.changeSourceProgress",
+        )
+
+        assertTrue(dialog.contains("private var autoScrollCurrentSource = true"))
+        assertTrue(collector.contains("if (autoScrollCurrentSource && it.isNotEmpty())"))
+        assertTrue(collector.contains("binding.recyclerView.post"))
+        assertTrue(collector.contains("if (scrollToDurSource()) autoScrollCurrentSource = false"))
+        assertTrue(dialog.contains("autoScrollCurrentSource = true"))
+        assertTrue(
+            dialog.section("private fun scrollToDurSource(): Boolean", "override fun changeTo")
+                .contains("if (searchBook.bookUrl == oldBookUrl)")
+        )
+    }
+
+    @Test
+    fun `current book source keeps a subtle background and check mark`() {
+        val adapter = source("ChangeBookSourceAdapter.kt")
+        assertTrue(adapter.contains("viewSelectedBackground"))
+        assertTrue(adapter.contains("ColorUtils.withAlpha(context.accentColor, 0.1f)"))
+        assertTrue(adapter.contains("ivChecked.visible()"))
+    }
+
+    @Test
     fun `pending business results wait for the current host to resume`() {
         val book = source("ChangeBookSourceDialog.kt")
         val chapter = source("ChangeChapterSourceDialog.kt")


### PR DESCRIPTION
## 变更说明

换源界面打开后总是从列表首条开始，当前书源只在点击底部“当前源”后才定位；当前项也只有右侧勾选，长列表中不易识别。实现首次结果稳定后自动定位当前源，找不到时保持现有首条兜底，并用主题强调色弱背景突出当前项。

关联 Issue：#963

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档
- [ ] 构建或依赖
- [ ] 重构或维护

## 涉及平台

- [x] Android
- [ ] Web
- [ ] Android 与 Web

## 涉及模块

- [ ] 阅读文本与翻页
- [ ] 漫画阅读
- [ ] 朗读与音频
- [ ] 书架与书籍管理
- [x] 书源与规则解析
- [ ] Web 服务与前端
- [ ] 备份、同步与数据
- [ ] 构建、安装与更新
- [ ] 其他或不确定

## 影响类型

- [ ] 崩溃或无响应
- [ ] 数据丢失或损坏
- [ ] 兼容性
- [x] 性能或耗电
- [x] 界面或交互
- [ ] 功能结果错误
- [ ] 无用户可见影响

## 实现内容

- 首轮非空搜索结果提交后，异步复用现有 `scrollToDurSource()` 定位当前 `oldBookUrl`。
- 当前源在后续结果中才出现时继续尝试；列表中不存在时不强行滚动，保留首条默认位置。
- 当前源行增加主题强调色 10% 背景，RecyclerView 复用时清除非当前行背景，并保留右侧勾选标识。

## 验证

- [x] `:app:testAppDebugUnitTest --tests io.legado.app.ui.book.changesource.ChangeSourceViewLifecycleContractTest`
- [x] 18 项契约测试全部通过。
- [x] `git diff --check` 通过。
- [x] 未引入无关改动。
