### PR TITLE
fix: preserve reader position on config refresh

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
@@ -2734,7 +2734,10 @@ class ReadBookActivity : BaseReadBookActivity(),
                     3 -> readView.upBgAlpha()
                     4 -> readView.upPageSlopSquare()
                     5 -> if (isInitFinish) {
-                        ReadBook.loadContent(resetPageOffset = ReadBook.isScroll)
+                        ReadBook.loadContent(
+                            resetPageOffset = ReadBook.isScroll,
+                            readPositionVersion = readView.getReadPositionVersion(),
+                        )
                     }
                     6 -> readView.upContent(resetPageOffset = false)
                     8 -> ChapterProvider.upStyle()

--- a/app/src/test/java/io/legado/app/ui/book/read/page/ScrollReadPositionContractTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/page/ScrollReadPositionContractTest.kt
@@ -43,6 +43,11 @@ class ScrollReadPositionContractTest {
             configUpdate.indexOf("updateScrollReadPosition()") <
                 configUpdate.indexOf("values.forEach")
         )
+        assertTrue(
+            configUpdate.contains(
+                "readPositionVersion = readView.getReadPositionVersion()"
+            )
+        )
 
         val pageView = source("app/src/main/java/io/legado/app/ui/book/read/page/PageView.kt")
         assertTrue(pageView.contains("chapterPosition: Int = ReadBook.durChapterPos"))


### PR DESCRIPTION
Addresses #885 follow-up.\n\nThe latest 2026-08-25 logs repeatedly show UP_CONFIG value 5 during cold-start reader refresh. The existing #972 protection covers chapter-list refresh, but this async config-refresh path did not pass the reader-position version, so a late callback could reset a position after user movement.\n\nThis change passes the current version through the existing loadContent guard. Explicit chapter/progress jumps keep their existing behavior.\n\nValidation:\n- .\\gradlew.bat :app:testAppDebugUnitTest --tests io.legado.app.model.ReadBookRefreshPositionTest --tests io.legado.app.ui.book.read.page.ReadPositionVersionTest --tests io.legado.app.ui.book.read.page.ScrollReadPositionContractTest --no-daemon --max-workers=1 --console=plain\n- .github/scripts/test-extract-latest-update.sh