### PR TITLE
fix: prevent stale read-aloud page navigation after rapid turns

### DIFF
--- a/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
+++ b/app/src/main/java/io/legado/app/service/BaseReadAloudService.kt
@@ -60,12 +60,16 @@ import io.legado.app.utils.observeSharedPreferences
 import io.legado.app.utils.postEvent
 import io.legado.app.utils.toastOnUi
 import java.text.BreakIterator
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import splitties.init.appCtx
 import splitties.systemservices.audioManager
 import splitties.systemservices.notificationManager
@@ -205,6 +209,8 @@ abstract class BaseReadAloudService : BaseService(),
     private var registeredPhoneStateListener = false
     private val chapterStopTimer = ChapterStopTimer()
     private var dsJob: Job? = null
+    private var readAloudJob: Coroutine<*>? = null
+    private val readAloudGeneration = AtomicLong()
     private var upNotificationJob: Coroutine<*>? = null
     private var cover: Bitmap =
         BitmapFactory.decodeResource(appCtx.resources, R.drawable.icon_read_book)
@@ -213,6 +219,18 @@ abstract class BaseReadAloudService : BaseService(),
     var paragraphStartPos = 0
     var readAloudByPage = false
         private set
+
+    private data class PreparedReadAloud(
+        val textChapter: TextChapter,
+        val pageIndex: Int,
+        val readAloudNumber: Int,
+        val readAloudByPage: Boolean,
+        val contentList: List<String>,
+        val nowSpeak: Int,
+        val readAloudChapterStart: Int,
+        val paragraphStartPos: Int,
+        val consumedToLast: Boolean
+    )
 
     private val broadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
@@ -276,6 +294,8 @@ abstract class BaseReadAloudService : BaseService(),
     }
 
     override fun onDestroy() {
+        readAloudGeneration.incrementAndGet()
+        readAloudJob?.cancel()
         super.onDestroy()
         restoreReadAloudFollow()
         updateReadAloudChapterIndex(-1)
@@ -339,21 +359,19 @@ abstract class BaseReadAloudService : BaseService(),
         startPos: Int,
         rewindToSentenceStart: Boolean
     ) {
+        val generation = readAloudGeneration.incrementAndGet()
+        val toLast = this@BaseReadAloudService.toLast
+        readAloudJob?.cancel()
         playStop()
         restoreReadAloudFollow()
-        execute(executeContext = IO) {
-            this@BaseReadAloudService.pageIndex = pageIndex
-            textChapter = ReadBook.curTextChapter
-            val textChapter = textChapter ?: return@execute
-            if (!textChapter.isCompleted) {
-                return@execute
-            }
-            updateReadAloudChapterIndex(textChapter.chapter.index)
-            readAloudNumber = textChapter.getReadLength(pageIndex) + startPos
-            readAloudByPage = getPrefBoolean(PreferKey.readAloudByPage)
-            contentList = textChapter.getNeedReadAloud(0, readAloudByPage, 0)
+        readAloudJob = execute(executeContext = IO) {
+            val textChapter = ReadBook.curTextChapter ?: return@execute
+            if (!textChapter.isCompleted) return@execute
+            val readAloudByPage = getPrefBoolean(PreferKey.readAloudByPage)
+            val contentList = textChapter.getNeedReadAloud(0, readAloudByPage, 0)
                 .split("\n")
                 .filter { it.isNotEmpty() }
+            var readAloudNumber = textChapter.getReadLength(pageIndex) + startPos
             var pos = startPos
             val page = textChapter.getPage(pageIndex)!!
             if (pos > 0) {
@@ -363,7 +381,7 @@ abstract class BaseReadAloudService : BaseService(),
                     pos = tmp
                 }
             }
-            nowSpeak = textChapter.getParagraphNum(readAloudNumber + 1, readAloudByPage) - 1
+            var nowSpeak = textChapter.getParagraphNum(readAloudNumber + 1, readAloudByPage) - 1
             if (shouldRewindReadAloudToSentenceStart(
                     rewindToSentenceStart,
                     readAloudByPage,
@@ -381,9 +399,10 @@ abstract class BaseReadAloudService : BaseService(),
                 pos = page.chapterPosition -
                         textChapter.paragraphs[nowSpeak].chapterPosition
             }
-            readAloudChapterStart = readAloudNumber
+            val readAloudChapterStart = readAloudNumber
+            var consumedToLast = false
             if (toLast) {
-                toLast = false
+                consumedToLast = true
                 readAloudNumber = textChapter.getLastParagraphPosition()
                 nowSpeak = contentList.lastIndex
                 if (page.paragraphs.size == 1) {
@@ -391,12 +410,36 @@ abstract class BaseReadAloudService : BaseService(),
                             textChapter.paragraphs[nowSpeak].chapterPosition
                 }
             }
-            paragraphStartPos = pos
-            launch(Main) {
+            val prepared = PreparedReadAloud(
+                textChapter = textChapter,
+                pageIndex = pageIndex,
+                readAloudNumber = readAloudNumber,
+                readAloudByPage = readAloudByPage,
+                contentList = contentList,
+                nowSpeak = nowSpeak,
+                readAloudChapterStart = readAloudChapterStart,
+                paragraphStartPos = pos,
+                consumedToLast = consumedToLast
+            )
+            ensureActive()
+            withContext(Main.immediate) {
+                if (generation != readAloudGeneration.get()) return@withContext
+                this@BaseReadAloudService.pageIndex = prepared.pageIndex
+                this@BaseReadAloudService.textChapter = prepared.textChapter
+                this@BaseReadAloudService.readAloudNumber = prepared.readAloudNumber
+                this@BaseReadAloudService.readAloudByPage = prepared.readAloudByPage
+                this@BaseReadAloudService.contentList = prepared.contentList
+                this@BaseReadAloudService.nowSpeak = prepared.nowSpeak
+                updateReadAloudChapterIndex(prepared.textChapter.chapter.index)
+                BaseReadAloudService.readAloudChapterStart = prepared.readAloudChapterStart
+                this@BaseReadAloudService.paragraphStartPos = prepared.paragraphStartPos
+                if (prepared.consumedToLast) this@BaseReadAloudService.toLast = false
                 if (play) play() else pageChanged = true
             }
-        }.onError {
-            AppLog.put("启动朗读出错\n${it.localizedMessage}", it, true)
+        }.onError(Main) {
+            if (it !is CancellationException && generation == readAloudGeneration.get()) {
+                AppLog.put("启动朗读出错\n${it.localizedMessage}", it, true)
+            }
         }
     }
 

--- a/app/src/main/java/io/legado/app/service/TTSReadAloudService.kt
+++ b/app/src/main/java/io/legado/app/service/TTSReadAloudService.kt
@@ -16,11 +16,13 @@ import io.legado.app.model.ReadAloud
 import io.legado.app.model.ReadBook
 import io.legado.app.utils.GSON
 import io.legado.app.utils.LogUtils
+import io.legado.app.utils.buildMainHandler
 import io.legado.app.utils.fromJsonObject
 import io.legado.app.utils.servicePendingIntent
 import io.legado.app.utils.toastOnUi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
+import java.util.concurrent.atomic.AtomicLong
 
 internal fun pendingSpeechPageMoves(currentPageIndex: Int, targetPageIndex: Int): Int =
     (targetPageIndex - currentPageIndex).coerceAtLeast(0)
@@ -34,6 +36,8 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
     private var ttsInitFinish = false
     private val ttsUtteranceListener = TTSUtteranceListener()
     private var speakJob: Coroutine<*>? = null
+    private val playbackSessionId = AtomicLong()
+    private val callbackHandler by lazy { buildMainHandler() }
     private val TAG = "TTSReadAloudService"
 
     override fun onCreate() {
@@ -65,6 +69,7 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
 
     @Synchronized
     fun clearTTS() {
+        playbackSessionId.incrementAndGet()
         textToSpeech?.runCatching {
             stop()
             shutdown()
@@ -87,6 +92,7 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
 
     @Synchronized
     override fun play() {
+        val sessionId = playbackSessionId.incrementAndGet()
         if (!ttsInitFinish) return
         if (!requestFocus()) return
         if (contentList.isEmpty()) {
@@ -97,28 +103,31 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
         super.play()
         MediaHelp.playSilentSound(this@TTSReadAloudService)
         speakJob?.cancel()
+        val startSpeak = nowSpeak
+        val startParagraphPos = paragraphStartPos
         speakJob = execute {
             LogUtils.d(TAG, "朗读列表大小 ${contentList.size}")
             LogUtils.d(TAG, "朗读页数 ${textChapter?.pageSize}")
-            val tts = textToSpeech ?: throw NoStackTraceException("tts is null")
+            if (textToSpeech == null) throw NoStackTraceException("tts is null")
             val contentList = contentList
             var isAddedText = false
-            for (i in nowSpeak until contentList.size) {
+            for (i in startSpeak until contentList.size) {
                 ensureActive()
+                if (!isCurrentPlayback(sessionId)) return@execute
                 var text = contentList[i]
-                if (paragraphStartPos > 0 && i == nowSpeak) {
-                    text = text.substring(paragraphStartPos)
+                if (startParagraphPos > 0 && i == startSpeak) {
+                    text = text.substring(startParagraphPos)
                 }
                 if (text.matches(AppPattern.notReadAloudRegex)) {
                     continue
                 }
                 if (!isAddedText) {
-                    val result = tts.runCatching {
-                        speak(text, TextToSpeech.QUEUE_FLUSH, null, AppConst.APP_TAG + i)
-                    }.getOrElse {
-                        AppLog.put("tts出错\n${it.localizedMessage}", it, true)
-                        TextToSpeech.ERROR
-                    }
+                    val result = speakCurrent(
+                        sessionId,
+                        text,
+                        TextToSpeech.QUEUE_FLUSH,
+                        i
+                    ) ?: return@execute
                     if (result == TextToSpeech.ERROR) {
                         AppLog.put("tts出错 尝试重新初始化")
                         clearTTS()
@@ -126,12 +135,12 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
                         return@execute
                     }
                 } else {
-                    val result = tts.runCatching {
-                        speak(text, TextToSpeech.QUEUE_ADD, null, AppConst.APP_TAG + i)
-                    }.getOrElse {
-                        AppLog.put("tts出错\n${it.localizedMessage}", it, true)
-                        TextToSpeech.ERROR
-                    }
+                    val result = speakCurrent(
+                        sessionId,
+                        text,
+                        TextToSpeech.QUEUE_ADD,
+                        i
+                    ) ?: return@execute
                     if (result == TextToSpeech.ERROR) {
                         AppLog.put("tts朗读出错:$text")
                     }
@@ -139,17 +148,20 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
                 isAddedText = true
             }
             LogUtils.d(TAG, "朗读内容添加完成")
-            if (!isAddedText) {
+            if (!isAddedText && isCurrentPlayback(sessionId)) {
                 playStop()
+                val stoppedSessionId = playbackSessionId.get()
                 delay(1000)
-                nextChapter(auto = true)
+                if (stoppedSessionId == playbackSessionId.get()) nextChapter(auto = true)
             }
         }.onError {
             AppLog.put("tts朗读出错\n${it.localizedMessage}", it, true)
         }
     }
 
+    @Synchronized
     override fun playStop() {
+        playbackSessionId.incrementAndGet()
         speakJob?.cancel()
         textToSpeech?.runCatching {
             stop()
@@ -176,10 +188,7 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
      */
     override fun pauseReadAloud(abandonFocus: Boolean) {
         super.pauseReadAloud(abandonFocus)
-        speakJob?.cancel()
-        textToSpeech?.runCatching {
-            stop()
-        }
+        playStop()
     }
 
     /**
@@ -200,47 +209,55 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
         private var rangeCallbackLogged = false
 
         override fun onStart(s: String) {
-            val msg = "onStart nowSpeak:$nowSpeak pageIndex:$pageIndex utteranceId:$s"
-            LogUtils.d(TAG, msg)
-            if (AppConfig.recordLog && !startCallbackLogged) {
-                startCallbackLogged = true
-                AppLog.putDebug("$TAG $msg")
-            }
-            if (textChapter != null) {
-                if (contentList[nowSpeak].matches(AppPattern.notReadAloudRegex)) {
-                    nextParagraph()
+            dispatchCurrentCallback(s) {
+                val msg = "onStart nowSpeak:$nowSpeak pageIndex:$pageIndex utteranceId:$s"
+                LogUtils.d(TAG, msg)
+                if (AppConfig.recordLog && !startCallbackLogged) {
+                    startCallbackLogged = true
+                    AppLog.putDebug("$TAG $msg")
                 }
-                moveToSpeechPage(readAloudNumber)
-                upTtsProgress(readAloudNumber + 1)
+                if (textChapter != null) {
+                    if (contentList[nowSpeak].matches(AppPattern.notReadAloudRegex)) {
+                        nextParagraph()
+                    }
+                    moveToSpeechPage(readAloudNumber)
+                    upTtsProgress(readAloudNumber + 1)
+                }
             }
         }
 
         override fun onDone(s: String) {
-            LogUtils.d(TAG, "onDone utteranceId:$s")
-            nextParagraph()
+            dispatchCurrentCallback(s) {
+                LogUtils.d(TAG, "onDone utteranceId:$s")
+                nextParagraph()
+            }
         }
 
         override fun onRangeStart(utteranceId: String?, start: Int, end: Int, frame: Int) {
             super.onRangeStart(utteranceId, start, end, frame)
-            val msg =
-                "onRangeStart nowSpeak:$nowSpeak pageIndex:$pageIndex utteranceId:$utteranceId start:$start end:$end frame:$frame"
-            LogUtils.d(TAG, msg)
-            if (AppConfig.recordLog && !rangeCallbackLogged) {
-                rangeCallbackLogged = true
-                AppLog.putDebug("$TAG $msg")
-            }
-            val position = readAloudNumber + start
-            if (moveToSpeechPage(position)) {
-                upTtsProgress(position)
+            dispatchCurrentCallback(utteranceId) {
+                val msg =
+                    "onRangeStart nowSpeak:$nowSpeak pageIndex:$pageIndex utteranceId:$utteranceId start:$start end:$end frame:$frame"
+                LogUtils.d(TAG, msg)
+                if (AppConfig.recordLog && !rangeCallbackLogged) {
+                    rangeCallbackLogged = true
+                    AppLog.putDebug("$TAG $msg")
+                }
+                val position = readAloudNumber + start
+                if (moveToSpeechPage(position)) {
+                    upTtsProgress(position)
+                }
             }
         }
 
         override fun onError(utteranceId: String?, errorCode: Int) {
-            LogUtils.d(
-                TAG,
-                "onError nowSpeak:$nowSpeak pageIndex:$pageIndex utteranceId:$utteranceId errorCode:$errorCode"
-            )
-            nextParagraph()
+            dispatchCurrentCallback(utteranceId) {
+                LogUtils.d(
+                    TAG,
+                    "onError nowSpeak:$nowSpeak pageIndex:$pageIndex utteranceId:$utteranceId errorCode:$errorCode"
+                )
+                nextParagraph()
+            }
         }
 
         private fun nextParagraph() {
@@ -258,8 +275,10 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
 
         @Deprecated("Deprecated in Java")
         override fun onError(s: String) {
-            LogUtils.d(TAG, "onError nowSpeak:$nowSpeak pageIndex:$pageIndex s:$s")
-            nextParagraph()
+            dispatchCurrentCallback(s) {
+                LogUtils.d(TAG, "onError nowSpeak:$nowSpeak pageIndex:$pageIndex s:$s")
+                nextParagraph()
+            }
         }
 
         private fun moveToSpeechPage(position: Int): Boolean {
@@ -272,6 +291,48 @@ class TTSReadAloudService : BaseReadAloudService(), TextToSpeech.OnInitListener 
             return moves > 0
         }
 
+    }
+
+    private fun utteranceId(sessionId: Long, index: Int): String {
+        return "${AppConst.APP_TAG}:$sessionId:$index"
+    }
+
+    private fun speakCurrent(
+        sessionId: Long,
+        text: String,
+        queueMode: Int,
+        index: Int
+    ): Int? {
+        synchronized(this) {
+            if (!isCurrentPlayback(sessionId)) return null
+            val tts = textToSpeech ?: return TextToSpeech.ERROR
+            return tts.runCatching {
+                speak(text, queueMode, null, utteranceId(sessionId, index))
+            }.getOrElse {
+                AppLog.put("tts出错\n${it.localizedMessage}", it, true)
+                TextToSpeech.ERROR
+            }
+        }
+    }
+
+    private fun isCurrentPlayback(sessionId: Long): Boolean {
+        return sessionId == playbackSessionId.get()
+    }
+
+    private fun dispatchCurrentCallback(utteranceId: String?, block: () -> Unit) {
+        val prefix = "${AppConst.APP_TAG}:"
+        val sessionId = utteranceId
+            ?.takeIf { it.startsWith(prefix) }
+            ?.substringAfter(prefix)
+            ?.substringBefore(':')
+            ?.toLongOrNull()
+            ?: return
+        if (sessionId != playbackSessionId.get()) return
+        callbackHandler.post {
+            synchronized(this) {
+                if (sessionId == playbackSessionId.get()) block()
+            }
+        }
     }
 
     override fun aloudServicePendingIntent(actionStr: String): PendingIntent? {

--- a/app/src/test/java/io/legado/app/service/ReadAloudFollowPositionRegressionTest.kt
+++ b/app/src/test/java/io/legado/app/service/ReadAloudFollowPositionRegressionTest.kt
@@ -52,6 +52,27 @@ class ReadAloudFollowPositionRegressionTest {
         assertTrue(serviceKt.contains("loadSpeechChapterOnly(speechChapterIndex() + 1)"))
     }
 
+    @Test
+    fun rapidPageRestartsCancelStaleReadAloudPreparation() {
+        val serviceKt = readProjectFile("src/main/java/io/legado/app/service/BaseReadAloudService.kt")
+        val preparation = serviceKt.substringAfter("private fun newReadAloud(")
+            .substringBefore("    @SuppressLint")
+
+        assertTrue(preparation.contains("readAloudJob?.cancel()"))
+        assertTrue(preparation.contains("readAloudJob = execute(executeContext = IO)"))
+        assertTrue(serviceKt.contains("private val readAloudGeneration = AtomicLong()"))
+        assertTrue(preparation.contains("val prepared = PreparedReadAloud("))
+        assertTrue(preparation.contains("withContext(Main.immediate)"))
+        val generationGate = preparation.indexOf(
+            "if (generation != readAloudGeneration.get()) return@withContext"
+        )
+        val firstCommit = preparation.indexOf("this@BaseReadAloudService.pageIndex")
+        assertTrue(generationGate >= 0 && generationGate < firstCommit)
+        assertTrue(
+            preparation.indexOf("readAloudJob?.cancel()") < preparation.indexOf("playStop()")
+        )
+    }
+
     private fun readProjectFile(pathInApp: String): String {
         val candidates = listOf(
             File(pathInApp),

--- a/app/src/test/java/io/legado/app/service/TtsPageFollowTest.kt
+++ b/app/src/test/java/io/legado/app/service/TtsPageFollowTest.kt
@@ -27,4 +27,26 @@ class TtsPageFollowTest {
         assertTrue(service.contains("AppConfig.recordLog && !rangeCallbackLogged"))
         assertTrue(service.contains("AppLog.putDebug(\"\$TAG \$msg\")"))
     }
+
+    @Test
+    fun `stale tts callbacks cannot mutate a newer playback session`() {
+        val service = listOf(
+            File("src/main/java/io/legado/app/service/TTSReadAloudService.kt"),
+            File("app/src/main/java/io/legado/app/service/TTSReadAloudService.kt")
+        ).first(File::isFile).readText()
+
+        assertTrue(service.contains("private val playbackSessionId = AtomicLong()"))
+        assertTrue(service.contains("speakCurrent("))
+        assertTrue(service.contains("TextToSpeech.QUEUE_FLUSH"))
+        assertTrue(service.contains("utteranceId(sessionId, index)"))
+        assertTrue(service.contains("callbackHandler.post"))
+        assertTrue(service.contains("if (sessionId != playbackSessionId.get()) return"))
+        assertTrue(service.contains("if (sessionId == playbackSessionId.get()) block()"))
+        assertTrue(
+            service.substringAfter("private fun dispatchCurrentCallback")
+                .contains("synchronized(this)")
+        )
+        assertTrue(service.contains("private fun speakCurrent("))
+        assertTrue(service.contains("synchronized(this)"))
+    }
 }


### PR DESCRIPTION
## Summary
- prevent cancelled read-aloud preparation jobs from committing stale cursor state after rapid manual page turns
- commit one prepared snapshot on Main.immediate behind a generation fence
- serialize system TTS queue writes and ignore stale utterance callbacks from older playback sessions

Fixes #1027

## Validation
- .\\gradlew.bat :app:testAppDebugUnitTest --tests io.legado.app.service.ReadAloudFollowPositionRegressionTest --tests io.legado.app.service.ReadAloudSentenceStartTest --tests io.legado.app.service.ReadAloudSpeakingPositionSourceTest --tests io.legado.app.service.ReadAloudFollowStateTest --tests io.legado.app.model.ReadAloudManualPagePolicyTest --tests io.legado.app.service.HttpTtsPauseTest --tests io.legado.app.service.TtsPageFollowTest --no-daemon --no-configuration-cache --max-workers=1 --console=plain
- BUILD SUCCESSFUL

The issue report has no logcat or recording, so this targets the two concrete stale-preparation and callback-session races found in the current code. The reporter is asked to confirm TTS engine, page animation/input path, and recordLog output on the affected device.