### PR TITLE
feat: batch manage replacement rule groups

### DIFF
--- a/app/src/main/java/io/legado/app/data/entities/ReplaceRule.kt
+++ b/app/src/main/java/io/legado/app/data/entities/ReplaceRule.kt
@@ -9,7 +9,9 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import io.legado.app.R
 import io.legado.app.constant.AppLog
+import io.legado.app.constant.AppPattern
 import io.legado.app.exception.NoStackTraceException
+import io.legado.app.utils.splitNotBlank
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import splitties.init.appCtx
@@ -91,6 +93,25 @@ data class ReplaceRule(
         } else {
             String.format("%s (%s)", name, group)
         }
+    }
+
+    fun addGroup(groups: String): ReplaceRule {
+        group?.splitNotBlank(AppPattern.splitGroupRegex)
+            ?.toCollection(linkedSetOf())?.let {
+                it.addAll(groups.splitNotBlank(AppPattern.splitGroupRegex))
+                group = it.joinToString(",")
+            }
+        if (group.isNullOrBlank()) group = groups
+        return this
+    }
+
+    fun removeGroup(groups: String): ReplaceRule {
+        group?.splitNotBlank(AppPattern.splitGroupRegex)
+            ?.toCollection(linkedSetOf())?.let {
+                it.removeAll(groups.splitNotBlank(AppPattern.splitGroupRegex).toSet())
+                group = it.joinToString(",")
+            }
+        return this
     }
 
     fun isValid(): Boolean {

--- a/app/src/main/java/io/legado/app/ui/highlight/HighlightRuleActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/highlight/HighlightRuleActivity.kt
@@ -76,7 +76,10 @@ class HighlightRuleActivity :
 
     private fun initSelectActionView() {
         binding.selectActionBar.setMainActionText(R.string.delete)
-        binding.selectActionBar.inflateMenu(R.menu.replace_rule_sel)
+        binding.selectActionBar.inflateMenu(R.menu.replace_rule_sel)?.apply {
+            findItem(R.id.menu_add_group)?.isVisible = false
+            findItem(R.id.menu_remove_group)?.isVisible = false
+        }
         binding.selectActionBar.setOnMenuItemClickListener(this)
         binding.selectActionBar.setCallBack(this)
     }

--- a/app/src/main/java/io/legado/app/ui/replace/ReplaceRuleActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/replace/ReplaceRuleActivity.kt
@@ -40,6 +40,7 @@ import io.legado.app.ui.widget.recycler.VerticalDivider
 import io.legado.app.utils.ACache
 import io.legado.app.utils.GSON
 import io.legado.app.utils.applyTint
+import io.legado.app.utils.dpToPx
 import io.legado.app.utils.isAbsUrl
 import io.legado.app.utils.launch
 import io.legado.app.utils.sendToClip
@@ -289,6 +290,8 @@ class ReplaceRuleActivity : VMBaseActivity<ActivityReplaceRuleBinding, ReplaceRu
         when (item?.itemId) {
             R.id.menu_enable_selection -> viewModel.enableSelection(adapter.selection)
             R.id.menu_disable_selection -> viewModel.disableSelection(adapter.selection)
+            R.id.menu_add_group -> selectionAddToGroups()
+            R.id.menu_remove_group -> selectionRemoveFromGroups()
             R.id.menu_top_sel -> viewModel.topSelect(adapter.selection)
             R.id.menu_bottom_sel -> viewModel.bottomSelect(adapter.selection)
             R.id.menu_export_selection -> exportResult.launch {
@@ -301,6 +304,46 @@ class ReplaceRuleActivity : VMBaseActivity<ActivityReplaceRuleBinding, ReplaceRu
             }
         }
         return false
+    }
+
+    @SuppressLint("InflateParams")
+    private fun selectionAddToGroups() {
+        alert(titleResource = R.string.add_group) {
+            val alertBinding = DialogEditTextBinding.inflate(layoutInflater).apply {
+                editView.setHint(R.string.group_name)
+                editView.setFilterValues(groups.toList())
+                editView.dropDownHeight = 180.dpToPx()
+            }
+            customView { alertBinding.root }
+            okButton {
+                alertBinding.editView.text?.toString()?.let {
+                    if (it.isNotEmpty()) {
+                        viewModel.selectionAddToGroups(adapter.selection, it)
+                    }
+                }
+            }
+            cancelButton()
+        }
+    }
+
+    @SuppressLint("InflateParams")
+    private fun selectionRemoveFromGroups() {
+        alert(titleResource = R.string.remove_group) {
+            val alertBinding = DialogEditTextBinding.inflate(layoutInflater).apply {
+                editView.setHint(R.string.group_name)
+                editView.setFilterValues(groups.toList())
+                editView.dropDownHeight = 180.dpToPx()
+            }
+            customView { alertBinding.root }
+            okButton {
+                alertBinding.editView.text?.toString()?.let {
+                    if (it.isNotEmpty()) {
+                        viewModel.selectionRemoveFromGroups(adapter.selection, it)
+                    }
+                }
+            }
+            cancelButton()
+        }
     }
 
     private fun upGroupMenu() = groupMenu?.transaction { menu ->

--- a/app/src/main/java/io/legado/app/ui/replace/ReplaceRuleViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/replace/ReplaceRuleViewModel.kt
@@ -88,6 +88,24 @@ class ReplaceRuleViewModel(application: Application) : BaseViewModel(application
         }
     }
 
+    fun selectionAddToGroups(rules: List<ReplaceRule>, groups: String) {
+        execute {
+            val array = Array(rules.size) {
+                rules[it].copy().addGroup(groups)
+            }
+            appDb.replaceRuleDao.update(*array)
+        }
+    }
+
+    fun selectionRemoveFromGroups(rules: List<ReplaceRule>, groups: String) {
+        execute {
+            val array = Array(rules.size) {
+                rules[it].copy().removeGroup(groups)
+            }
+            appDb.replaceRuleDao.update(*array)
+        }
+    }
+
     fun delSelection(rules: List<ReplaceRule>) {
         execute {
             appDb.replaceRuleDao.delete(*rules.toTypedArray())

--- a/app/src/main/res/menu/replace_rule_sel.xml
+++ b/app/src/main/res/menu/replace_rule_sel.xml
@@ -13,6 +13,16 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/menu_add_group"
+        android:title="@string/add_group"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/menu_remove_group"
+        android:title="@string/remove_group"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/menu_top_sel"
         android:title="@string/selection_to_top"
         app:showAsAction="never" />

--- a/app/src/test/java/io/legado/app/data/entities/SourceGroupOrderTest.kt
+++ b/app/src/test/java/io/legado/app/data/entities/SourceGroupOrderTest.kt
@@ -27,5 +27,12 @@ class SourceGroupOrderTest {
         rssSource.sourceGroup = "C,B,A"
         rssSource.removeGroup("B")
         assertEquals("C,A", rssSource.sourceGroup)
+
+        val replaceRule = ReplaceRule(group = "B,A")
+        replaceRule.addGroup("A；C")
+        assertEquals("B,A,C", replaceRule.group)
+        replaceRule.group = "C,B,A"
+        replaceRule.removeGroup("B")
+        assertEquals("C,A", replaceRule.group)
     }
 }

--- a/app/src/test/java/io/legado/app/ui/menu/SelectActionBarPopupActionMigrationTest.kt
+++ b/app/src/test/java/io/legado/app/ui/menu/SelectActionBarPopupActionMigrationTest.kt
@@ -149,6 +149,8 @@ class SelectActionBarPopupActionMigrationTest {
             "replace_rule_sel.xml" to listOf(
                 "@+id/menu_enable_selection",
                 "@+id/menu_disable_selection",
+                "@+id/menu_add_group",
+                "@+id/menu_remove_group",
                 "@+id/menu_top_sel",
                 "@+id/menu_bottom_sel",
                 "@+id/menu_export_selection"

--- a/app/src/test/java/io/legado/app/ui/replace/ReplaceRuleViewModelGroupContractTest.kt
+++ b/app/src/test/java/io/legado/app/ui/replace/ReplaceRuleViewModelGroupContractTest.kt
@@ -32,6 +32,24 @@ class ReplaceRuleViewModelGroupContractTest {
         assertTrue(bottom.contains("it.order = maxOrder++"))
     }
 
+    @Test
+    fun `selection group actions copy rules and update only group members`() {
+        assertTrue(
+            source.contains(
+                "fun selectionAddToGroups(rules: List<ReplaceRule>, groups: String)"
+            )
+        )
+        assertTrue(
+            source.contains(
+                "fun selectionRemoveFromGroups(rules: List<ReplaceRule>, groups: String)"
+            )
+        )
+        assertTrue(source.contains("rules[it].copy().addGroup(groups)"))
+        assertTrue(source.contains("rules[it].copy().removeGroup(groups)"))
+        assertFalse(source.contains("scope = groups"))
+        assertFalse(source.contains("excludeScope = groups"))
+    }
+
     private fun projectFile(pathInApp: String): File {
         return listOf(File(pathInApp), File("app/$pathInApp"))
             .firstOrNull { it.isFile }


### PR DESCRIPTION
## Summary

- Add batch add/remove group actions for selected replacement rules.
- Reuse existing group separators, deduplicate additions, and remove exact group members.
- Keep scope/excludeScope batch editing out of this PR because their current raw substring contract needs a separate compatibility decision.

## Validation

- Added entity and ViewModel/menu contract coverage.
- Focused Android unit tests are running locally.
- No database schema or backup format changes.

Part of #1026; this PR does not close the issue because RSS replacement and scope/exclude stages are tracked separately.