### PR TITLE
feat(reader): customize text underline styling

### DIFF
--- a/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
@@ -5,6 +5,8 @@ import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import androidx.annotation.Keep
 import androidx.core.graphics.toColorInt
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import io.legado.app.R
 import io.legado.app.constant.AppLog
 import io.legado.app.constant.PageAnim
@@ -36,6 +38,94 @@ import splitties.init.appCtx
 import java.io.File
 import androidx.core.graphics.drawable.toDrawable
 
+internal const val UNDERLINE_MODE_OFF = 0
+internal const val UNDERLINE_MODE_SOLID = 1
+internal const val UNDERLINE_MODE_DASHED = 2
+internal const val UNDERLINE_MODE_DOTTED = 3
+internal const val UNDERLINE_MODE_DOUBLE = 4
+internal const val UNDERLINE_MODE_WAVY = 5
+internal const val UNDERLINE_MODE_DOUBLE_DASHED = 6
+internal const val DEFAULT_UNDERLINE_WIDTH = 1f
+internal const val MIN_UNDERLINE_WIDTH = 1f
+internal const val MAX_UNDERLINE_WIDTH = 10f
+internal const val DEFAULT_UNDERLINE_DISTANCE = 4f
+internal const val MIN_UNDERLINE_DISTANCE = 0f
+internal const val MAX_UNDERLINE_DISTANCE = 30f
+private const val UNDERLINE_CONFIG_VERSION = 1
+
+private fun migrateLegacyUnderline(
+    config: ReadBookConfig.Config,
+    raw: JsonObject,
+): ReadBookConfig.Config {
+    if (config.underlineConfigVersion == 0 && raw.get("underline")?.isJsonPrimitive == true) {
+        val value = raw.getAsJsonPrimitive("underline")
+        if (value.isBoolean) {
+            config.underlineMode = if (value.asBoolean) UNDERLINE_MODE_SOLID else UNDERLINE_MODE_OFF
+        }
+    }
+    return config
+}
+
+internal fun parseReadConfigArray(json: String): Result<List<ReadBookConfig.Config>> = runCatching {
+    val configs = GSON.fromJsonArray<ReadBookConfig.Config>(json).getOrThrow()
+    val raw = JsonParser.parseString(json).asJsonArray
+    configs.mapIndexed { index, config ->
+        raw.get(index).takeIf { it.isJsonObject }?.asJsonObject
+            ?.let { migrateLegacyUnderline(config, it) }
+            ?: config
+    }
+}
+
+internal fun parseReadConfigObject(json: String): Result<ReadBookConfig.Config> = runCatching {
+    val config = GSON.fromJsonObject<ReadBookConfig.Config>(json).getOrThrow()
+    val raw = JsonParser.parseString(json).asJsonObject
+    migrateLegacyUnderline(config, raw)
+}
+
+/**
+ * Converts the old per-style underline field into one shared, backup-friendly value.
+ * New fields live on every Config so existing readConfig.json archives remain readable.
+ */
+internal fun normalizeUnderlineConfigs(
+    configs: List<ReadBookConfig.Config>,
+    legacyIndex: Int = 0,
+) {
+    if (configs.isEmpty()) return
+    val preferred = configs.getOrNull(legacyIndex)
+    val source = preferred?.takeIf {
+        it.underlineConfigVersion >= UNDERLINE_CONFIG_VERSION
+    } ?: configs.firstOrNull { it.underlineConfigVersion >= UNDERLINE_CONFIG_VERSION }
+        ?: preferred?.takeIf { it.underlineMode != UNDERLINE_MODE_OFF }
+        ?: configs.firstOrNull { it.underlineMode != UNDERLINE_MODE_OFF }
+        ?: configs.first()
+    val hasNewConfig = source.underlineConfigVersion >= UNDERLINE_CONFIG_VERSION
+    val mode = source.underlineMode.coerceIn(UNDERLINE_MODE_OFF, UNDERLINE_MODE_DOUBLE_DASHED)
+    val color = if (hasNewConfig) source.underlineColor else 0
+    val colorSet = hasNewConfig && source.underlineColorSet
+    val width = if (hasNewConfig) {
+        source.underlineWidth.coerceIn(MIN_UNDERLINE_WIDTH, MAX_UNDERLINE_WIDTH)
+    } else {
+        DEFAULT_UNDERLINE_WIDTH
+    }
+    val distance = if (hasNewConfig) {
+        source.underlineDistance.coerceIn(MIN_UNDERLINE_DISTANCE, MAX_UNDERLINE_DISTANCE)
+    } else {
+        DEFAULT_UNDERLINE_DISTANCE
+    }
+    val bodyEnabled = if (hasNewConfig) source.underlineBodyEnabled else true
+    val titleEnabled = if (hasNewConfig) source.underlineTitleEnabled else true
+    configs.forEach {
+        it.underlineMode = mode
+        it.underlineColor = color
+        it.underlineColorSet = colorSet
+        it.underlineWidth = width
+        it.underlineDistance = distance
+        it.underlineBodyEnabled = bodyEnabled
+        it.underlineTitleEnabled = titleEnabled
+        it.underlineConfigVersion = UNDERLINE_CONFIG_VERSION
+    }
+}
+
 /**
  * 阅读界面配置
  */
@@ -48,10 +138,48 @@ object ReadBookConfig {
     val shareConfigFilePath = FileUtils.getPath(appCtx.filesDir, shareConfigFileName)
     val configList: ArrayList<Config> = arrayListOf()
     lateinit var shareConfig: Config
+    private var underlineConfigInitialized = false
+
+    private fun underlineConfigs(): List<Config> {
+        val configs = configList.toMutableList()
+        if (::shareConfig.isInitialized && configs.none { it === shareConfig }) {
+            configs += shareConfig
+        }
+        return configs
+    }
+
+    private fun normalizeUnderlineConfig() {
+        val shareNeedsInit = ::shareConfig.isInitialized &&
+            shareConfig.underlineConfigVersion < UNDERLINE_CONFIG_VERSION
+        if (underlineConfigInitialized &&
+            !configList.any { it.underlineConfigVersion < UNDERLINE_CONFIG_VERSION } &&
+            !shareNeedsInit
+        ) {
+            return
+        }
+        normalizeUnderlineConfigs(
+            underlineConfigs(),
+            appCtx.getPrefInt(PreferKey.readStyleSelect)
+        )
+        underlineConfigInitialized = true
+    }
+
+    private inline fun updateUnderlineConfig(update: Config.() -> Unit) {
+        normalizeUnderlineConfig()
+        underlineConfigs().forEach(update)
+    }
+
+    private fun underlineConfig(): Config? {
+        normalizeUnderlineConfig()
+        return configList.firstOrNull()
+            ?: if (::shareConfig.isInitialized) shareConfig else null
+    }
+
     var durConfig
         get() = getConfig(styleSelect)
         set(value) {
             configList[styleSelect] = value
+            underlineConfigInitialized = false
             if (shareLayout) {
                 shareConfig = value
             }
@@ -78,12 +206,14 @@ object ReadBookConfig {
     }
 
     fun initConfigs() {
+        // A restored/imported config can contain the legacy per-style underline value.
+        underlineConfigInitialized = false
         val configFile = File(configFilePath)
         var configs: List<Config>? = null
         if (configFile.exists()) {
             try {
                 val json = configFile.readText()
-                configs = GSON.fromJsonArray<Config>(json).getOrThrow()
+                configs = parseReadConfigArray(json).getOrThrow()
             } catch (e: Exception) {
                 AppLog.put("读取排版配置文件出错", e)
             }
@@ -95,17 +225,19 @@ object ReadBookConfig {
     }
 
     fun initShareConfig() {
+        underlineConfigInitialized = false
         val configFile = File(shareConfigFilePath)
         var c: Config? = null
         if (configFile.exists()) {
             try {
                 val json = configFile.readText()
-                c = GSON.fromJsonObject<Config>(json).getOrThrow()
+                c = parseReadConfigObject(json).getOrThrow()
             } catch (e: Exception) {
                 e.printOnDebug()
             }
         }
         shareConfig = c ?: configList.getOrNull(5) ?: Config()
+        normalizeUnderlineConfig()
     }
 
     fun upBg(width: Int, height: Int) {
@@ -132,6 +264,7 @@ object ReadBookConfig {
 
     @Synchronized
     internal fun saveNow() {
+        normalizeUnderlineConfig()
         GSON.toJson(configList).let {
             FileUtils.delete(configFilePath)
             FileUtils.createFileIfNotExist(configFilePath).writeText(it)
@@ -397,9 +530,49 @@ object ReadBookConfig {
         }
 
     var underlineMode: Int
-        get() = config.underlineMode
+        get() = underlineConfig()?.underlineMode ?: 0
         set(value) {
-            config.underlineMode = value
+            updateUnderlineConfig { underlineMode = value.coerceIn(UNDERLINE_MODE_OFF, UNDERLINE_MODE_DOUBLE_DASHED) }
+        }
+
+    var underlineColor: Int
+        get() = underlineConfig()?.underlineColor ?: 0
+        set(value) {
+            updateUnderlineConfig {
+                underlineColor = value
+                underlineColorSet = true
+            }
+        }
+
+    val underlineColorSet: Boolean
+        get() = underlineConfig()?.underlineColorSet == true
+
+    var underlineWidth: Float
+        get() = underlineConfig()?.underlineWidth ?: DEFAULT_UNDERLINE_WIDTH
+        set(value) {
+            updateUnderlineConfig {
+                underlineWidth = value.coerceIn(MIN_UNDERLINE_WIDTH, MAX_UNDERLINE_WIDTH)
+            }
+        }
+
+    var underlineDistance: Float
+        get() = underlineConfig()?.underlineDistance ?: DEFAULT_UNDERLINE_DISTANCE
+        set(value) {
+            updateUnderlineConfig {
+                underlineDistance = value.coerceIn(MIN_UNDERLINE_DISTANCE, MAX_UNDERLINE_DISTANCE)
+            }
+        }
+
+    var underlineBodyEnabled: Boolean
+        get() = underlineConfig()?.underlineBodyEnabled ?: true
+        set(value) {
+            updateUnderlineConfig { underlineBodyEnabled = value }
+        }
+
+    var underlineTitleEnabled: Boolean
+        get() = underlineConfig()?.underlineTitleEnabled ?: true
+        set(value) {
+            updateUnderlineConfig { underlineTitleEnabled = value }
         }
 
     var reviewIconColor: Int
@@ -505,6 +678,7 @@ object ReadBookConfig {
         }
 
     fun getExportConfig(): Config {
+        normalizeUnderlineConfig()
         val exportConfig = durConfig.copy()
         if (shareLayout) {
             exportConfig.textFont = shareConfig.textFont
@@ -523,6 +697,14 @@ object ReadBookConfig {
             exportConfig.titleNumberSpacing = shareConfig.titleNumberSpacing
             exportConfig.titleTopSpacing = shareConfig.titleTopSpacing
             exportConfig.titleBottomSpacing = shareConfig.titleBottomSpacing
+            exportConfig.underlineMode = shareConfig.underlineMode
+            exportConfig.underlineColor = shareConfig.underlineColor
+            exportConfig.underlineColorSet = shareConfig.underlineColorSet
+            exportConfig.underlineWidth = shareConfig.underlineWidth
+            exportConfig.underlineDistance = shareConfig.underlineDistance
+            exportConfig.underlineBodyEnabled = shareConfig.underlineBodyEnabled
+            exportConfig.underlineTitleEnabled = shareConfig.underlineTitleEnabled
+            exportConfig.underlineConfigVersion = shareConfig.underlineConfigVersion
             exportConfig.paddingBottom = shareConfig.paddingBottom
             exportConfig.paddingLeft = shareConfig.paddingLeft
             exportConfig.paddingRight = shareConfig.paddingRight
@@ -569,7 +751,7 @@ object ReadBookConfig {
         configDir.createFolderReplace()
         ZipUtils.unZipToPath(zipFile, configDir)
         val configFile = configDir.getFile(configFileName)
-        val config: Config = GSON.fromJsonObject<Config>(configFile.readText()).getOrThrow()
+        val config: Config = parseReadConfigObject(configFile.readText()).getOrThrow()
         if (config.textFont.isNotEmpty()) {
             val fontName = config.textFont
             val fontPath =
@@ -675,7 +857,14 @@ object ReadBookConfig {
         var titleTopSpacing: Int = 0,
         var titleBottomSpacing: Int = 0,
         var paragraphIndent: String = "　　",//段落缩进
-        var underlineMode: Int = 0, //下划线
+        var underlineMode: Int = 0, //下划线（旧字段，保留兼容）
+        var underlineColor: Int = 0,
+        var underlineColorSet: Boolean = false,
+        var underlineWidth: Float = DEFAULT_UNDERLINE_WIDTH,
+        var underlineDistance: Float = DEFAULT_UNDERLINE_DISTANCE,
+        var underlineBodyEnabled: Boolean = true,
+        var underlineTitleEnabled: Boolean = true,
+        var underlineConfigVersion: Int = 0,
         var reviewIconColor: Int = 0, //段评内置图标颜色(0=跟随主题)
         var reviewIconSvg: String = "",
         var reviewIconSvgTemplates: List<ReviewIconSvgTemplate> = emptyList(),
@@ -1000,6 +1189,13 @@ object ReadBookConfig {
             "titleBottomSpacing" to titleBottomSpacing,
             "paragraphIndent" to paragraphIndent,
             "underlineMode" to underlineMode,
+            "underlineColor" to underlineColor,
+            "underlineColorSet" to underlineColorSet,
+            "underlineWidth" to underlineWidth,
+            "underlineDistance" to underlineDistance,
+            "underlineBodyEnabled" to underlineBodyEnabled,
+            "underlineTitleEnabled" to underlineTitleEnabled,
+            "underlineConfigVersion" to underlineConfigVersion,
             "reviewIconColor" to reviewIconColor,
             "reviewIconSvg" to reviewIconSvg,
             "reviewIconSvgTemplates" to reviewIconSvgTemplates,

--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
@@ -97,6 +97,7 @@ import io.legado.app.ui.book.read.config.BgTextConfigDialog.Companion.BG_COLOR
 import io.legado.app.ui.book.read.config.BgTextConfigDialog.Companion.REVIEW_ICON_COLOR
 import io.legado.app.ui.book.read.config.BgTextConfigDialog.Companion.TEXT_ACCENT_COLOR
 import io.legado.app.ui.book.read.config.BgTextConfigDialog.Companion.TEXT_COLOR
+import io.legado.app.ui.book.read.config.BgTextConfigDialog.Companion.UNDERLINE_COLOR
 import io.legado.app.ui.book.read.config.MoreConfigDialog
 import io.legado.app.ui.book.read.config.ReadAloudDialog
 import io.legado.app.ui.book.read.config.ReadStyleDialog
@@ -2271,6 +2272,11 @@ class ReadBookActivity : BaseReadBookActivity(),
             REVIEW_ICON_COLOR -> {
                 ReadBookConfig.reviewIconColor = color
                 postEvent(EventBus.UP_CONFIG, arrayListOf(8, 9, 11))
+            }
+
+            UNDERLINE_COLOR -> {
+                ReadBookConfig.underlineColor = color
+                postEvent(EventBus.UP_CONFIG, arrayListOf(6, 9, 11))
             }
 
             HighlightStyleDialog.HL_FILL,

--- a/app/src/main/java/io/legado/app/ui/book/read/config/BgTextConfigDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/config/BgTextConfigDialog.kt
@@ -80,6 +80,7 @@ import io.legado.app.help.http.newCallResponse
 import io.legado.app.model.analyzeRule.AnalyzeUrl
 import io.legado.app.utils.setSelectionSafely
 import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 class BgTextConfigDialog : BaseDialogFragment(R.layout.dialog_read_bg_text) {
 
@@ -88,6 +89,7 @@ class BgTextConfigDialog : BaseDialogFragment(R.layout.dialog_read_bg_text) {
         const val BG_COLOR = 122
         const val TEXT_ACCENT_COLOR = 123
         const val REVIEW_ICON_COLOR = 124
+        const val UNDERLINE_COLOR = 125
     }
 
     private val binding by viewBinding(DialogReadBgTextBinding::bind)
@@ -159,10 +161,27 @@ class BgTextConfigDialog : BaseDialogFragment(R.layout.dialog_read_bg_text) {
         ivDelete.setColorFilter(primaryTextColor, PorterDuff.Mode.SRC_IN)
         tvBgAlpha.setTextColor(primaryTextColor)
         tvBgImage.setTextColor(primaryTextColor)
+        tvUnderlineColor.setTextColor(primaryTextColor)
+        swUnderlineBody.setTextColor(primaryTextColor)
+        swUnderlineTitle.setTextColor(primaryTextColor)
+        dsbUnderlineWidth.valueFormat = { "${(1f + it / 2f)}dp" }
+        dsbUnderlineDistance.valueFormat = { "${(it / 2f)}dp" }
         if (ReadBook.book?.isImage == true) {
+            underlineStyleRow.isGone = true
+            underlineActionsRow.isGone = true
+            dsbUnderlineWidth.isGone = true
+            dsbUnderlineDistance.isGone = true
             spUnderline.isGone = true
         } else {
-            val textStyles = arrayOf("关闭", "实线", "虚线")
+            val textStyles = arrayOf(
+                getString(R.string.highlight_action_trigger_off),
+                getString(R.string.highlight_underline_solid),
+                getString(R.string.highlight_underline_dashed),
+                getString(R.string.highlight_underline_dotted),
+                getString(R.string.highlight_underline_double),
+                getString(R.string.highlight_underline_wavy),
+                getString(R.string.underline_double_dashed)
+            )
             val adapter = object : ArrayAdapter<String>(requireContext(), R.layout.item_text_common, textStyles) {
                 override fun getDropDownView(
                     position: Int,
@@ -186,7 +205,7 @@ class BgTextConfigDialog : BaseDialogFragment(R.layout.dialog_read_bg_text) {
                         isInitializing = false
                         return
                     }
-                    ReadBookConfig.durConfig.underlineMode = position
+                    ReadBookConfig.underlineMode = position
                     postEvent(EventBus.UP_CONFIG, arrayListOf(6, 9, 11))
                 }
                 override fun onNothingSelected(parent: AdapterView<*>) { }
@@ -215,7 +234,20 @@ class BgTextConfigDialog : BaseDialogFragment(R.layout.dialog_read_bg_text) {
     private fun initData() = with(ReadBookConfig.durConfig) {
         binding.tvName.text = name.ifBlank { "文字" }
         binding.swDarkStatusIcon.isChecked = curStatusIconDark()
-        binding.spUnderline.setSelectionSafely(underlineMode)
+        binding.spUnderline.setSelectionSafely(ReadBookConfig.underlineMode)
+        binding.dsbUnderlineWidth.progress =
+            ((ReadBookConfig.underlineWidth - 1f) * 2f).roundToInt().coerceIn(0, 18)
+        binding.dsbUnderlineDistance.progress =
+            (ReadBookConfig.underlineDistance * 2f).roundToInt().coerceIn(0, 60)
+        binding.swUnderlineBody.isChecked = ReadBookConfig.underlineBodyEnabled
+        binding.swUnderlineTitle.isChecked = ReadBookConfig.underlineTitleEnabled
+        binding.tvUnderlineColor.setTextColor(
+            if (ReadBookConfig.underlineColorSet) {
+                ReadBookConfig.underlineColor
+            } else {
+                ReadBookConfig.textColor
+            }
+        )
         binding.sbBgAlpha.progress = bgAlpha
     }
 
@@ -258,6 +290,17 @@ class BgTextConfigDialog : BaseDialogFragment(R.layout.dialog_read_bg_text) {
                 .setShowAlphaSlider(false)
                 .setDialogType(ColorPickerDialog.TYPE_CUSTOM)
                 .setDialogId(TEXT_COLOR)
+                .show(requireActivity())
+        }
+        binding.tvUnderlineColor.setOnClickListener {
+            ColorPickerDialog.newBuilder()
+                .setColor(
+                    ReadBookConfig.underlineColor.takeIf { ReadBookConfig.underlineColorSet }
+                        ?: ReadBookConfig.textColor
+                )
+                .setShowAlphaSlider(true)
+                .setDialogType(ColorPickerDialog.TYPE_CUSTOM)
+                .setDialogId(UNDERLINE_COLOR)
                 .show(requireActivity())
         }
         binding.tvTextAccentColor.setOnClickListener {
@@ -361,6 +404,22 @@ class BgTextConfigDialog : BaseDialogFragment(R.layout.dialog_read_bg_text) {
                 postEvent(EventBus.UP_CONFIG, arrayListOf(3))
             }
         })
+        binding.dsbUnderlineWidth.onChanged = { progress ->
+            ReadBookConfig.underlineWidth = 1f + progress / 2f
+            postEvent(EventBus.UP_CONFIG, arrayListOf(6, 9, 11))
+        }
+        binding.dsbUnderlineDistance.onChanged = { progress ->
+            ReadBookConfig.underlineDistance = progress / 2f
+            postEvent(EventBus.UP_CONFIG, arrayListOf(6, 9, 11))
+        }
+        binding.swUnderlineBody.setOnUserCheckedChangeListener { checked ->
+            ReadBookConfig.underlineBodyEnabled = checked
+            postEvent(EventBus.UP_CONFIG, arrayListOf(6, 9, 11))
+        }
+        binding.swUnderlineTitle.setOnUserCheckedChangeListener { checked ->
+            ReadBookConfig.underlineTitleEnabled = checked
+            postEvent(EventBus.UP_CONFIG, arrayListOf(6, 9, 11))
+        }
     }
 
     private fun showReviewIconTemplates() {

--- a/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextLine.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextLine.kt
@@ -3,6 +3,8 @@ package io.legado.app.ui.book.read.page.entities
 import android.annotation.SuppressLint
 import android.graphics.Canvas
 import android.graphics.DashPathEffect
+import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.Paint.FontMetrics
 import android.os.Build
 import androidx.annotation.Keep
@@ -11,6 +13,13 @@ import io.legado.app.help.PaintPool
 import io.legado.app.help.book.isImage
 import io.legado.app.help.config.AppConfig
 import io.legado.app.help.config.ReadBookConfig
+import io.legado.app.help.config.UNDERLINE_MODE_DASHED
+import io.legado.app.help.config.UNDERLINE_MODE_DOTTED
+import io.legado.app.help.config.UNDERLINE_MODE_DOUBLE
+import io.legado.app.help.config.UNDERLINE_MODE_DOUBLE_DASHED
+import io.legado.app.help.config.UNDERLINE_MODE_OFF
+import io.legado.app.help.config.UNDERLINE_MODE_SOLID
+import io.legado.app.help.config.UNDERLINE_MODE_WAVY
 import io.legado.app.model.ReadBook
 import io.legado.app.ui.book.read.page.ContentTextView
 import io.legado.app.ui.book.read.page.HighlightDraw
@@ -233,8 +242,13 @@ data class TextLine(
         }
 
         val underlineMode = ReadBookConfig.underlineMode
-        if (underlineMode == 0) return
-        if (!isImage && !isHtml && ReadBook.book?.isImage != true) {
+        if (underlineMode == UNDERLINE_MODE_OFF) return
+        val underlineEnabled = if (isTitle) {
+            ReadBookConfig.underlineTitleEnabled
+        } else {
+            ReadBookConfig.underlineBodyEnabled
+        }
+        if (underlineEnabled && !isImage && !isHtml && ReadBook.book?.isImage != true) {
             drawUnderline(canvas, underlineMode)
         }
     }
@@ -275,30 +289,107 @@ data class TextLine(
      * 绘制下划线
      */
     private fun drawUnderline(canvas: Canvas, underlineMode: Int) {
-        val paint = ChapterProvider.contentPaint
-        val distance = (ChapterProvider.lineSpacingExtra * 10 - 11).coerceIn(-1f, 10f)
-        val lineY = height + distance.dpToPx()
-        if (underlineMode == 1) {
-            canvas.drawLine(
-                lineStart + indentWidth,
-                lineY,
-                lineEnd,
-                lineY,
-                paint
-            )
-        } else if (underlineMode == 2) { // 虚线
-            val dashPaint = PaintPool.obtain()
-            dashPaint.set(paint)
-            dashPaint.pathEffect = underlineDashPathEffect
-            canvas.drawLine(
-                lineStart + indentWidth,
-                lineY,
-                lineEnd,
-                lineY,
-                dashPaint
-            )
-            PaintPool.recycle(dashPaint)
+        val x0 = lineStart + indentWidth
+        val x1 = lineEnd
+        if (x1 <= x0) return
+        val paint = PaintPool.obtain()
+        paint.set(textPaint)
+        paint.style = Paint.Style.STROKE
+        paint.pathEffect = null
+        paint.strokeWidth = ReadBookConfig.underlineWidth.dpToPx()
+        paint.color = if (ReadBookConfig.underlineColorSet) {
+            ReadBookConfig.underlineColor
+        } else {
+            textColor
         }
+        paint.isAntiAlias = true
+        val lineY = (lineBase - lineTop) + ReadBookConfig.underlineDistance.dpToPx()
+        when (underlineMode) {
+            UNDERLINE_MODE_SOLID -> canvas.drawLine(x0, lineY, x1, lineY, paint)
+            UNDERLINE_MODE_DASHED -> drawDashedUnderline(canvas, x0, x1, lineY, paint)
+            UNDERLINE_MODE_DOTTED -> drawDottedUnderline(canvas, x0, x1, lineY, paint)
+            UNDERLINE_MODE_DOUBLE -> drawDoubleUnderline(canvas, x0, x1, lineY, paint)
+            UNDERLINE_MODE_WAVY -> drawWavyUnderline(canvas, x0, x1, lineY, paint)
+            UNDERLINE_MODE_DOUBLE_DASHED -> {
+                val separation = paint.strokeWidth + 1f.dpToPx()
+                drawDashedUnderline(canvas, x0, x1, lineY - separation / 2f, paint)
+                drawDashedUnderline(canvas, x0, x1, lineY + separation / 2f, paint)
+            }
+        }
+        PaintPool.recycle(paint)
+    }
+
+    private fun drawDashedUnderline(
+        canvas: Canvas,
+        x0: Float,
+        x1: Float,
+        y: Float,
+        paint: Paint,
+    ) {
+        val dashPaint = PaintPool.obtain()
+        dashPaint.set(paint)
+        dashPaint.pathEffect = underlineDashPathEffect
+        canvas.drawLine(x0, y, x1, y, dashPaint)
+        PaintPool.recycle(dashPaint)
+    }
+
+    private fun drawDottedUnderline(
+        canvas: Canvas,
+        x0: Float,
+        x1: Float,
+        y: Float,
+        paint: Paint,
+    ) {
+        val dotPaint = PaintPool.obtain()
+        dotPaint.set(paint)
+        dotPaint.style = Paint.Style.FILL
+        dotPaint.pathEffect = null
+        val radius = (paint.strokeWidth / 2f).coerceAtLeast(0.5f.dpToPx())
+        val step = (radius * 2.5f).coerceAtLeast(2f.dpToPx())
+        var center = x0 + radius
+        while (center <= x1) {
+            canvas.drawCircle(center, y, radius, dotPaint)
+            center += step
+        }
+        PaintPool.recycle(dotPaint)
+    }
+
+    private fun drawDoubleUnderline(
+        canvas: Canvas,
+        x0: Float,
+        x1: Float,
+        y: Float,
+        paint: Paint,
+    ) {
+        val separation = paint.strokeWidth + 1f.dpToPx()
+        canvas.drawLine(x0, y - separation / 2f, x1, y - separation / 2f, paint)
+        canvas.drawLine(x0, y + separation / 2f, x1, y + separation / 2f, paint)
+    }
+
+    private fun drawWavyUnderline(
+        canvas: Canvas,
+        x0: Float,
+        x1: Float,
+        y: Float,
+        paint: Paint,
+    ) {
+        val points = HighlightGeometry.wavePoints(
+            x0,
+            x1,
+            y,
+            paint.strokeWidth.coerceAtLeast(1f.dpToPx()),
+            6f.dpToPx(),
+            2f.dpToPx()
+        )
+        if (points.size < 4) return
+        val path = Path()
+        path.moveTo(points[0], points[1])
+        var index = 2
+        while (index < points.size) {
+            path.lineTo(points[index], points[index + 1])
+            index += 2
+        }
+        canvas.drawPath(path, paint)
     }
 
     private fun drawHighlightFills(canvas: Canvas) {
@@ -444,7 +535,10 @@ data class TextLine(
         private val atLeastApi26 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
         val atLeastApi28 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
         private val atLeastApi35 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM
-        private val underlineDashPathEffect = DashPathEffect(floatArrayOf(10f, 10f), 0f)
+        private val underlineDashPathEffect = DashPathEffect(
+            floatArrayOf(6f.dpToPx(), 4f.dpToPx()),
+            0f
+        )
         private val wordSpacingWorking by lazy {
             // issue 3785 3846
             val paint = PaintPool.obtain()

--- a/app/src/main/res/layout/dialog_read_bg_text.xml
+++ b/app/src/main/res/layout/dialog_read_bg_text.xml
@@ -63,6 +63,7 @@
         tools:ignore="TouchTargetSizeCheck" />
 
     <LinearLayout
+        android:id="@+id/underline_style_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_vertical"
@@ -82,6 +83,63 @@
             android:layout_height="wrap_content"
             android:theme="@style/Spinner" />
     </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/underline_actions_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="6dp">
+
+        <io.legado.app.ui.widget.text.StrokeTextView
+            android:id="@+id/tv_underline_color"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="6dp"
+            android:layout_weight="1"
+            android:background="?attr/selectableItemBackground"
+            android:gravity="center"
+            android:padding="6dp"
+            android:singleLine="true"
+            android:text="@string/underline_color"
+            android:textSize="14sp"
+            app:isBottomBackground="true" />
+
+        <io.legado.app.lib.theme.view.ThemeSwitch
+            android:id="@+id/sw_underline_body"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/underline_body"
+            tools:ignore="TouchTargetSizeCheck" />
+
+        <io.legado.app.lib.theme.view.ThemeSwitch
+            android:id="@+id/sw_underline_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/underline_title"
+            tools:ignore="TouchTargetSizeCheck" />
+    </LinearLayout>
+
+    <io.legado.app.ui.widget.DetailSeekBar
+        android:id="@+id/dsb_underline_width"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="6dp"
+        app:isBottomBackground="true"
+        app:max="18"
+        app:title="@string/underline_width" />
+
+    <io.legado.app.ui.widget.DetailSeekBar
+        android:id="@+id/dsb_underline_distance"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="6dp"
+        app:isBottomBackground="true"
+        app:max="60"
+        app:title="@string/underline_distance" />
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1396,6 +1396,12 @@
     <string name="create_folder">创建文件夹</string>
     <string name="allow_drop_down_refresh">允许下拉刷新</string>
     <string name="text_underline">文字下划线</string>
+    <string name="underline_color">下划线颜色</string>
+    <string name="underline_width">下划线粗细</string>
+    <string name="underline_distance">下划线距离</string>
+    <string name="underline_body">正文</string>
+    <string name="underline_title">标题</string>
+    <string name="underline_double_dashed">双虚线</string>
     <string name="select_new_source">选中新增源</string>
     <string name="select_update_source">选中更新源</string>
     <string name="set_local_password">设置本地密码</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1403,6 +1403,12 @@
     <string name="only_update_read">仅更新已读完</string>
     <string name="ps_only_update_read">自动刷新时，只更新已读完的书籍</string>
     <string name="text_underline">Text underline</string>
+    <string name="underline_color">Underline color</string>
+    <string name="underline_width">Underline width</string>
+    <string name="underline_distance">Underline distance</string>
+    <string name="underline_body">Body</string>
+    <string name="underline_title">Title</string>
+    <string name="underline_double_dashed">Double dashed</string>
     <string name="select_new_source">Select new source</string>
     <string name="select_update_source">Select update source</string>
     <string name="set_local_password">Setting the local password</string>

--- a/app/src/test/java/io/legado/app/ui/book/read/config/UnderlineConfigTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/config/UnderlineConfigTest.kt
@@ -1,0 +1,133 @@
+package io.legado.app.ui.book.read.config
+
+import io.legado.app.help.config.ReadBookConfig
+import io.legado.app.help.config.normalizeUnderlineConfigs
+import io.legado.app.help.config.parseReadConfigArray
+import io.legado.app.help.config.parseReadConfigObject
+import io.legado.app.utils.GSON
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class UnderlineConfigTest {
+
+    @Test
+    fun `legacy boolean underline survives object and array imports`() {
+        val enabled = parseReadConfigObject("""{"underline":true}""").getOrThrow()
+        val disabled = parseReadConfigArray("""[{"underline":false}]""").getOrThrow().single()
+
+        assertEquals(1, enabled.underlineMode)
+        assertEquals(0, disabled.underlineMode)
+    }
+
+    @Test
+    fun `new underline fields round trip and stay in map export`() {
+        val config = ReadBookConfig.Config(
+            underlineMode = 5,
+            underlineColor = 0x00112233,
+            underlineColorSet = true,
+            underlineWidth = 4.5f,
+            underlineDistance = 12.5f,
+            underlineBodyEnabled = false,
+            underlineTitleEnabled = true,
+            underlineConfigVersion = 1
+        )
+        val restored = parseReadConfigObject(GSON.toJson(config)).getOrThrow()
+
+        assertEquals(config.underlineMode, restored.underlineMode)
+        assertEquals(config.underlineColor, restored.underlineColor)
+        assertEquals(config.underlineWidth, restored.underlineWidth, 0.001f)
+        assertEquals(config.underlineDistance, restored.underlineDistance, 0.001f)
+        assertFalse(restored.underlineBodyEnabled)
+        assertTrue(restored.underlineTitleEnabled)
+        assertEquals(4.5f, config.toMap()["underlineWidth"])
+        assertEquals(12.5f, config.toMap()["underlineDistance"])
+    }
+
+    @Test
+    fun `legacy styles become one shared fixed-distance config`() {
+        val enabled = ReadBookConfig.Config(underlineMode = 2)
+        val disabled = ReadBookConfig.Config()
+
+        normalizeUnderlineConfigs(listOf(enabled, disabled))
+
+        assertEquals(2, enabled.underlineMode)
+        assertEquals(2, disabled.underlineMode)
+        assertEquals(1f, enabled.underlineWidth, 0.001f)
+        assertEquals(4f, enabled.underlineDistance, 0.001f)
+        assertTrue(enabled.underlineBodyEnabled)
+        assertTrue(enabled.underlineTitleEnabled)
+        assertEquals(1, enabled.underlineConfigVersion)
+    }
+
+    @Test
+    fun `new values are clamped while preserving transparent color`() {
+        val first = ReadBookConfig.Config(
+            underlineColor = 0,
+            underlineColorSet = true,
+            underlineWidth = 99f,
+            underlineDistance = -4f,
+            underlineBodyEnabled = false,
+            underlineConfigVersion = 1
+        )
+        val second = ReadBookConfig.Config()
+
+        normalizeUnderlineConfigs(listOf(first, second))
+
+        assertEquals(10f, first.underlineWidth, 0.001f)
+        assertEquals(0f, first.underlineDistance, 0.001f)
+        assertTrue(first.underlineColorSet)
+        assertFalse(second.underlineBodyEnabled)
+        assertTrue(second.underlineColorSet)
+    }
+
+    @Test
+    fun `selected imported style is the global source`() {
+        val existing = ReadBookConfig.Config(
+            underlineMode = 1,
+            underlineWidth = 2f,
+            underlineConfigVersion = 1
+        )
+        val imported = ReadBookConfig.Config(
+            underlineMode = 5,
+            underlineWidth = 6f,
+            underlineConfigVersion = 1
+        )
+
+        normalizeUnderlineConfigs(listOf(existing, imported), legacyIndex = 1)
+
+        assertEquals(5, existing.underlineMode)
+        assertEquals(6f, existing.underlineWidth, 0.001f)
+        assertEquals(5, imported.underlineMode)
+    }
+
+    @Test
+    fun `dialog exposes all underline controls and renderer uses baseline distance`() {
+        val layout = projectFile("src/main/res/layout/dialog_read_bg_text.xml")
+        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(layout)
+        val seekBars = (0 until document.getElementsByTagName("io.legado.app.ui.widget.DetailSeekBar").length)
+            .map { document.getElementsByTagName("io.legado.app.ui.widget.DetailSeekBar").item(it) as Element }
+            .associateBy { it.getAttribute("android:id") }
+
+        assertEquals("18", seekBars["@+id/dsb_underline_width"]?.getAttribute("app:max"))
+        assertEquals("60", seekBars["@+id/dsb_underline_distance"]?.getAttribute("app:max"))
+        assertTrue(layout.readText().contains("@+id/sw_underline_body"))
+        assertTrue(layout.readText().contains("@+id/sw_underline_title"))
+
+        val renderer = projectFile(
+            "src/main/java/io/legado/app/ui/book/read/page/entities/TextLine.kt"
+        ).readText()
+        assertTrue(renderer.contains("(lineBase - lineTop) + ReadBookConfig.underlineDistance.dpToPx()"))
+        assertFalse(renderer.contains("ChapterProvider.lineSpacingExtra * 10 - 11"))
+        assertTrue(renderer.contains("ReadBookConfig.underlineTitleEnabled"))
+        assertTrue(renderer.contains("ReadBookConfig.underlineBodyEnabled"))
+    }
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp")).first { it.isFile }
+    }
+}


### PR DESCRIPTION
Closes #1011

## What changed
- Add global, backup-compatible underline settings with legacy boolean/mode migration.
- Add dp width/distance controls, color picker with alpha, body/title switches, and solid/dashed/dotted/double/wavy/double-dashed rendering.
- Draw from the text baseline so underline distance is independent of paragraph spacing.
- Keep image/HTML exclusions and existing E-Ink read-aloud/search decoration.
- Add JVM/config/XML contract coverage.

## Validation
- `:app:compileAppDebugKotlin`
- Focused `:app:testAppDebugUnitTest` suites for underline, import, style, and highlight contracts.
- `git diff --check`

Width defaults to 1dp, consistent with the confirmed 1..10dp range; distance defaults to 4dp.
