### PR TITLE
fix(reader): keep underline settings synchronized after imports

### DIFF
--- a/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
+++ b/app/src/main/java/io/legado/app/help/config/ReadBookConfig.kt
@@ -53,6 +53,14 @@ internal const val MIN_UNDERLINE_DISTANCE = 0f
 internal const val MAX_UNDERLINE_DISTANCE = 30f
 private const val UNDERLINE_CONFIG_VERSION = 1
 
+internal fun underlineConfigReferencesChanged(
+    previous: List<ReadBookConfig.Config>,
+    current: List<ReadBookConfig.Config>,
+): Boolean {
+    if (previous.size != current.size) return true
+    return previous.indices.any { previous[it] !== current[it] }
+}
+
 private fun migrateLegacyUnderline(
     config: ReadBookConfig.Config,
     raw: JsonObject,
@@ -139,6 +147,8 @@ object ReadBookConfig {
     val configList: ArrayList<Config> = arrayListOf()
     lateinit var shareConfig: Config
     private var underlineConfigInitialized = false
+    private var normalizedUnderlineConfigRefs: List<Config> = emptyList()
+    private var normalizedShareConfig: Config? = null
 
     private fun underlineConfigs(): List<Config> {
         val configs = configList.toMutableList()
@@ -148,12 +158,25 @@ object ReadBookConfig {
         return configs
     }
 
+    private fun underlineConfigSourcesChanged(): Boolean {
+        if (underlineConfigReferencesChanged(normalizedUnderlineConfigRefs, configList)) {
+            return true
+        }
+        val share = if (::shareConfig.isInitialized && configList.none { it === shareConfig }) {
+            shareConfig
+        } else {
+            null
+        }
+        return share !== normalizedShareConfig
+    }
+
     private fun normalizeUnderlineConfig() {
         val shareNeedsInit = ::shareConfig.isInitialized &&
             shareConfig.underlineConfigVersion < UNDERLINE_CONFIG_VERSION
         if (underlineConfigInitialized &&
             !configList.any { it.underlineConfigVersion < UNDERLINE_CONFIG_VERSION } &&
-            !shareNeedsInit
+            !shareNeedsInit &&
+            !underlineConfigSourcesChanged()
         ) {
             return
         }
@@ -162,6 +185,12 @@ object ReadBookConfig {
             appCtx.getPrefInt(PreferKey.readStyleSelect)
         )
         underlineConfigInitialized = true
+        normalizedUnderlineConfigRefs = configList.toList()
+        normalizedShareConfig = if (::shareConfig.isInitialized && configList.none { it === shareConfig }) {
+            shareConfig
+        } else {
+            null
+        }
     }
 
     private inline fun updateUnderlineConfig(update: Config.() -> Unit) {
@@ -208,6 +237,8 @@ object ReadBookConfig {
     fun initConfigs() {
         // A restored/imported config can contain the legacy per-style underline value.
         underlineConfigInitialized = false
+        normalizedUnderlineConfigRefs = emptyList()
+        normalizedShareConfig = null
         val configFile = File(configFilePath)
         var configs: List<Config>? = null
         if (configFile.exists()) {
@@ -226,6 +257,8 @@ object ReadBookConfig {
 
     fun initShareConfig() {
         underlineConfigInitialized = false
+        normalizedUnderlineConfigRefs = emptyList()
+        normalizedShareConfig = null
         val configFile = File(shareConfigFilePath)
         var c: Config? = null
         if (configFile.exists()) {

--- a/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextLine.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextLine.kt
@@ -32,6 +32,25 @@ import io.legado.app.ui.book.read.page.provider.ChapterProvider
 import io.legado.app.utils.canvasrecorder.CanvasRecorderFactory
 import io.legado.app.utils.canvasrecorder.recordIfNeededThenDraw
 import io.legado.app.utils.dpToPx
+import kotlin.math.ceil
+import kotlin.math.max
+
+internal fun underlineRenderBottom(
+    mode: Int,
+    baseline: Float,
+    distancePx: Float,
+    strokeWidthPx: Float,
+    oneDpPx: Float,
+    waveAmplitudePx: Float,
+): Float {
+    val strokeExtent = when (mode) {
+        UNDERLINE_MODE_DOUBLE,
+        UNDERLINE_MODE_DOUBLE_DASHED -> strokeWidthPx + oneDpPx
+        UNDERLINE_MODE_WAVY -> strokeWidthPx / 2f + waveAmplitudePx
+        else -> strokeWidthPx / 2f
+    }
+    return baseline + distancePx + strokeExtent
+}
 
 /**
  * 行信息
@@ -208,11 +227,40 @@ data class TextLine(
 
     fun draw(view: ContentTextView, canvas: Canvas) {
         if (AppConfig.optimizeRender && !hasOverflowTextStyle) {
-            canvasRecorder.recordIfNeededThenDraw(canvas, view.width, height.toInt()) {
+            canvasRecorder.recordIfNeededThenDraw(canvas, view.width, renderedHeight()) {
                 drawTextLine(view, this)
             }
         } else {
             drawTextLine(view, canvas)
+        }
+    }
+
+    fun renderBottom(): Float = lineTop + renderedHeight()
+
+    private fun renderedHeight(): Int {
+        val mode = activeUnderlineMode() ?: return ceil(height).toInt()
+        val baseline = lineBase - lineTop
+        val bottom = underlineRenderBottom(
+            mode = mode,
+            baseline = baseline,
+            distancePx = ReadBookConfig.underlineDistance.dpToPx(),
+            strokeWidthPx = ReadBookConfig.underlineWidth.dpToPx(),
+            oneDpPx = 1f.dpToPx(),
+            waveAmplitudePx = ReadBookConfig.underlineWidth.dpToPx(),
+        )
+        return ceil(max(height, bottom)).toInt()
+    }
+
+    private fun activeUnderlineMode(): Int? {
+        val mode = ReadBookConfig.underlineMode
+        if (mode == UNDERLINE_MODE_OFF) return null
+        val enabled = if (isTitle) {
+            ReadBookConfig.underlineTitleEnabled
+        } else {
+            ReadBookConfig.underlineBodyEnabled
+        }
+        return mode.takeIf {
+            enabled && !isImage && !isHtml && ReadBook.book?.isImage != true
         }
     }
 
@@ -241,16 +289,7 @@ data class TextLine(
             PaintPool.recycle(underlinePaint)
         }
 
-        val underlineMode = ReadBookConfig.underlineMode
-        if (underlineMode == UNDERLINE_MODE_OFF) return
-        val underlineEnabled = if (isTitle) {
-            ReadBookConfig.underlineTitleEnabled
-        } else {
-            ReadBookConfig.underlineBodyEnabled
-        }
-        if (underlineEnabled && !isImage && !isHtml && ReadBook.book?.isImage != true) {
-            drawUnderline(canvas, underlineMode)
-        }
+        activeUnderlineMode()?.let { drawUnderline(canvas, it) }
     }
 
     @SuppressLint("NewApi")

--- a/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextPage.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/entities/TextPage.kt
@@ -345,11 +345,12 @@ data class TextPage(
         val overflow = 10.dpToPx().toFloat()
         for (i in lines.indices) {
             val line = lines[i]
+            val renderBottom = line.renderBottom()
             if (line.onlyTextColumn && !line.hasOverflowTextStyle && canvas.quickReject(
                     0f,
                     line.lineTop - overflow,
                     view.width.toFloat(),
-                    line.lineBottom + overflow,
+                    renderBottom + overflow,
                     Canvas.EdgeType.AA
                 )
             ) {
@@ -400,10 +401,6 @@ data class TextPage(
     }
 
     fun upRenderHeight() {
-        renderHeight = ceil(lines.last().lineBottom).toInt()
-        if (leftLineSize > 0 && leftLineSize != lines.size) {
-            val leftHeight = ceil(lines[leftLineSize - 1].lineBottom).toInt()
-            renderHeight = max(renderHeight, leftHeight)
-        }
+        renderHeight = ceil(lines.maxOf { it.renderBottom() }).toInt()
     }
 }

--- a/app/src/test/java/io/legado/app/ui/book/read/config/UnderlineConfigTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/config/UnderlineConfigTest.kt
@@ -4,6 +4,11 @@ import io.legado.app.help.config.ReadBookConfig
 import io.legado.app.help.config.normalizeUnderlineConfigs
 import io.legado.app.help.config.parseReadConfigArray
 import io.legado.app.help.config.parseReadConfigObject
+import io.legado.app.help.config.underlineConfigReferencesChanged
+import io.legado.app.help.config.UNDERLINE_MODE_DOUBLE
+import io.legado.app.help.config.UNDERLINE_MODE_SOLID
+import io.legado.app.help.config.UNDERLINE_MODE_WAVY
+import io.legado.app.ui.book.read.page.entities.underlineRenderBottom
 import io.legado.app.utils.GSON
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -106,6 +111,55 @@ class UnderlineConfigTest {
     }
 
     @Test
+    fun `replacing an already normalized style invalidates the source snapshot`() {
+        val old = ReadBookConfig.Config(underlineConfigVersion = 1)
+        val replacement = ReadBookConfig.Config(underlineConfigVersion = 1)
+
+        assertFalse(underlineConfigReferencesChanged(listOf(old), listOf(old)))
+        assertTrue(underlineConfigReferencesChanged(listOf(old), listOf(replacement)))
+    }
+
+    @Test
+    fun `render bounds include configured underline distance and double stroke`() {
+        assertEquals(
+            21f,
+            underlineRenderBottom(
+                mode = UNDERLINE_MODE_SOLID,
+                baseline = 16f,
+                distancePx = 4f,
+                strokeWidthPx = 2f,
+                oneDpPx = 1f,
+                waveAmplitudePx = 2f,
+            ),
+            0.001f
+        )
+        assertEquals(
+            23f,
+            underlineRenderBottom(
+                mode = UNDERLINE_MODE_DOUBLE,
+                baseline = 16f,
+                distancePx = 4f,
+                strokeWidthPx = 2f,
+                oneDpPx = 1f,
+                waveAmplitudePx = 2f,
+            ),
+            0.001f
+        )
+        assertEquals(
+            29f,
+            underlineRenderBottom(
+                mode = UNDERLINE_MODE_WAVY,
+                baseline = 16f,
+                distancePx = 4f,
+                strokeWidthPx = 6f,
+                oneDpPx = 1f,
+                waveAmplitudePx = 6f,
+            ),
+            0.001f
+        )
+    }
+
+    @Test
     fun `dialog exposes all underline controls and renderer uses baseline distance`() {
         val layout = projectFile("src/main/res/layout/dialog_read_bg_text.xml")
         val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(layout)
@@ -125,6 +179,12 @@ class UnderlineConfigTest {
         assertFalse(renderer.contains("ChapterProvider.lineSpacingExtra * 10 - 11"))
         assertTrue(renderer.contains("ReadBookConfig.underlineTitleEnabled"))
         assertTrue(renderer.contains("ReadBookConfig.underlineBodyEnabled"))
+        assertTrue(renderer.contains("canvasRecorder.recordIfNeededThenDraw(canvas, view.width, renderedHeight())"))
+        assertTrue(renderer.contains("fun renderBottom(): Float = lineTop + renderedHeight()"))
+        assertTrue(renderer.contains("waveAmplitudePx = ReadBookConfig.underlineWidth.dpToPx()"))
+        val page = projectFile("src/main/java/io/legado/app/ui/book/read/page/entities/TextPage.kt").readText()
+        assertTrue(page.contains("lines.maxOf { it.renderBottom() }"))
+        assertTrue(page.contains("renderBottom + overflow"))
     }
 
     private fun projectFile(pathInApp: String): File {


### PR DESCRIPTION
## Summary
- invalidate underline normalization when imported Config objects are replaced, appended, or removed after startup
- size optimized line/page recorders and quick-reject bounds from the actual underline geometry, including wide wave and double styles
- add regression coverage for identity invalidation and render bounds

## Validation
- `:app:compileAppDebugKotlin --no-daemon --no-configuration-cache --max-workers=1`
- `:app:testAppDebugUnitTest --tests io.legado.app.ui.book.read.config.UnderlineConfigTest --tests io.legado.app.ui.association.ReadConfigImportTest --no-daemon --no-configuration-cache --max-workers=1`
- `git diff --check`

Refs #1011
