### PR TITLE
fix: propagate EPUB zip entry errors

### DIFF
--- a/app/src/test/java/io/legado/app/model/localBook/EpubZipErrorPropagationTest.kt
+++ b/app/src/test/java/io/legado/app/model/localBook/EpubZipErrorPropagationTest.kt
@@ -1,0 +1,37 @@
+package io.legado.app.model.localBook
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class EpubZipErrorPropagationTest {
+
+    @Test
+    fun `zip entry enumeration keeps malformed archive errors visible`() {
+        val root = repositoryRoot()
+        val androidZipFile = File(
+            root,
+            "modules/book/src/main/java/me/ag2s/epublib/util/zip/AndroidZipFile.java",
+        ).readText()
+        val zipFileWrapper = File(
+            root,
+            "modules/book/src/main/java/me/ag2s/epublib/util/zip/ZipFileWrapper.java",
+        ).readText()
+        val resourcesLoader = File(
+            root,
+            "modules/book/src/main/java/me/ag2s/epublib/epub/ResourcesLoader.java",
+        ).readText()
+
+        assertTrue(androidZipFile.contains("public Enumeration<AndroidZipEntry> entries() throws IOException"))
+        assertTrue(zipFileWrapper.contains("public Enumeration entries() throws IOException"))
+        assertTrue(resourcesLoader.contains("public static Resources loadResources(") &&
+            resourcesLoader.contains("    ) throws IOException") &&
+            resourcesLoader.contains("Enumeration entries = zipFileWrapper.entries();"))
+    }
+
+    private fun repositoryRoot(): File {
+        val userDirectory = File(requireNotNull(System.getProperty("user.dir"))).absoluteFile
+        return generateSequence(userDirectory) { it.parentFile }
+            .first { File(it, "app/src/main").isDirectory }
+    }
+}

--- a/modules/book/src/main/java/me/ag2s/epublib/util/zip/AndroidZipFile.java
+++ b/modules/book/src/main/java/me/ag2s/epublib/util/zip/AndroidZipFile.java
@@ -292,13 +292,11 @@ public class AndroidZipFile implements ZipConstants {
 
     /**
      * Returns an enumeration of all Zip entries in this Zip file.
+     *
+     * @throws IOException if the central directory cannot be read
      */
-    public Enumeration<AndroidZipEntry> entries() {
-        try {
-            return new ZipEntryEnumeration(getEntries().values().iterator());
-        } catch (IOException ioe) {
-            return null;
-        }
+    public Enumeration<AndroidZipEntry> entries() throws IOException {
+        return new ZipEntryEnumeration(getEntries().values().iterator());
     }
 
     /**

--- a/modules/book/src/main/java/me/ag2s/epublib/util/zip/ZipFileWrapper.java
+++ b/modules/book/src/main/java/me/ag2s/epublib/util/zip/ZipFileWrapper.java
@@ -67,7 +67,7 @@ public class ZipFileWrapper {
         }
     }
 
-    public Enumeration entries() {
+    public Enumeration entries() throws IOException {
         checkType();
         if (zipFile instanceof java.util.zip.ZipFile) {
             return ((ZipFile) zipFile).entries();


### PR DESCRIPTION
## Summary\n- propagate AndroidZipFile central-directory IOExceptions instead of returning null\n- let ZipFileWrapper and the existing ResourcesLoader IOException path preserve the original failure\n- add a focused source contract regression test\n\nThe reporter sample is an incomplete ZIP/EPUB and remains unreadable, but this prevents the misleading Enumeration NPE and exposes the actual archive error.\n\n## Validation\n- .\\gradlew.bat :modules:book:compileDebugJavaWithJavac :app:testAppDebugUnitTest --tests io.legado.app.model.localBook.EpubZipErrorPropagationTest --no-daemon --no-configuration-cache --max-workers=1 --console=plain\n- git diff --check\n\nCloses #1036