### PR TITLE
fix: persist toc expansion after leaving view

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/toc/TocViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/toc/TocViewModel.kt
@@ -11,7 +11,11 @@ import io.legado.app.data.appDb
 import io.legado.app.data.entities.Book
 import io.legado.app.help.book.update
 import io.legado.app.exception.NoStackTraceException
+import io.legado.app.help.globalExecutor
+import io.legado.app.model.AudioPlay
 import io.legado.app.model.ReadBook
+import io.legado.app.model.ReadManga
+import io.legado.app.model.VideoPlay
 import io.legado.app.model.localBook.LocalBook
 import io.legado.app.utils.FileDoc
 import io.legado.app.utils.GSON
@@ -73,15 +77,25 @@ class TocViewModel(application: Application) : BaseViewModel(application) {
     fun setTocExpanded(expanded: Boolean) {
         val book = bookData.value ?: return
         book.setTocExpanded(expanded)
-        execute {
-            appDb.bookDao.updateTocExpanded(book.bookUrl, expanded)
-        }.onSuccess {
-            chapterListCallBack?.upChapterList(
-                searchKey,
-                resetCollapse = true,
-                replaceAll = true,
-            )
+        updateActiveReaderBooks(book.bookUrl, expanded)
+        chapterListCallBack?.upChapterList(
+            searchKey,
+            resetCollapse = true,
+            replaceAll = true,
+        )
+        globalExecutor.execute {
+            runCatching {
+                appDb.bookDao.updateTocExpanded(book.bookUrl, expanded)
+            }.onFailure {
+                AppLog.put("保存目录展开设置失败\n${it.localizedMessage}", it)
+            }
         }
+    }
+
+    private fun updateActiveReaderBooks(bookUrl: String, expanded: Boolean) {
+        listOf(ReadBook.book, ReadManga.book, AudioPlay.book, VideoPlay.book)
+            .filter { it?.bookUrl == bookUrl }
+            .forEach { it?.setTocExpanded(expanded) }
     }
 
     fun startChapterListSearch(newText: String?) {

--- a/app/src/test/java/io/legado/app/ui/book/toc/TocExpansionPersistenceLifecycleTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/toc/TocExpansionPersistenceLifecycleTest.kt
@@ -1,0 +1,31 @@
+package io.legado.app.ui.book.toc
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class TocExpansionPersistenceLifecycleTest {
+
+    @Test
+    fun `toc preference outlives the directory view model and updates active readers`() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/ui/book/toc/TocViewModel.kt"
+        ).readText()
+        val setBlock = source.substringAfter("fun setTocExpanded")
+            .substringBefore("fun startChapterListSearch")
+
+        assertTrue(setBlock.contains("globalExecutor.execute"))
+        assertTrue(setBlock.contains("bookDao.updateTocExpanded(book.bookUrl, expanded)"))
+        assertTrue(setBlock.contains("updateActiveReaderBooks(book.bookUrl, expanded)"))
+        assertTrue(source.contains("ReadBook.book"))
+        assertTrue(source.contains("ReadManga.book"))
+        assertTrue(source.contains("AudioPlay.book"))
+        assertTrue(source.contains("VideoPlay.book"))
+    }
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+    }
+}


### PR DESCRIPTION
Closes #1042\n\n## Cause\nThe TOC preference write was tied to TocViewModel scope and could be cancelled when leaving the TOC. Reader save paths could also write a stale full Book afterward.\n\n## Fix\n- Persist the readConfig-only update on the process-level serialized executor.\n- Synchronize the active text, manga, audio, and video reader Book objects before any later save.\n- Refresh the TOC immediately and add a source contract regression test.\n\n## Validation\n- :app:testAppDebugUnitTest --tests io.legado.app.ui.book.toc.TocExpansionPreferenceTest --tests io.legado.app.ui.book.toc.TocExpansionPersistenceLifecycleTest --tests io.legado.app.ui.book.toc.TocListStateTest\n- 23 tests passed; git diff --check passed.