### PR TITLE
fix: reorder replace rule menu

### DIFF
--- a/app/src/main/res/menu/replace_rule.xml
+++ b/app/src/main/res/menu/replace_rule.xml
@@ -37,12 +37,6 @@
     </item>
 
     <item
-        android:id="@+id/menu_manual_replace_rule"
-        android:checkable="true"
-        android:title="@string/manual_replace_rule"
-        app:showAsAction="never" />
-
-    <item
         android:id="@+id/menu_add_replace_rule"
         android:icon="@drawable/ic_add"
         android:title="@string/add_replace_rule"
@@ -64,6 +58,13 @@
         android:id="@+id/menu_import_qr"
         android:icon="@drawable/ic_import"
         android:title="@string/import_by_qr_code"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/menu_manual_replace_rule"
+        android:checkable="true"
+        android:icon="@drawable/ic_find_replace"
+        android:title="@string/manual_replace_rule"
         app:showAsAction="never" />
 
     <item

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -256,7 +256,7 @@
     <string name="import_local">本地导入</string>
     <string name="import_on_line">网络导入</string>
     <string name="replace_rule_title">替换管理</string>
-    <string name="manual_replace_rule">手动选择替换</string>
+    <string name="manual_replace_rule">手动替换</string>
     <string name="replace_rule_edit">替换规则编辑</string>
     <string name="replace_rule">替换规则</string>
     <string name="replace_to">替换为</string>

--- a/app/src/test/java/io/legado/app/ui/menu/Issue1044ReplaceMenuContractTest.kt
+++ b/app/src/test/java/io/legado/app/ui/menu/Issue1044ReplaceMenuContractTest.kt
@@ -1,0 +1,39 @@
+package io.legado.app.ui.menu
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class Issue1044ReplaceMenuContractTest {
+
+    @Test
+    fun `replace rule menu puts manual replacement before help with its icon`() {
+        val menu = readProjectFile("src/main/res/menu/replace_rule.xml")
+        val order = listOf(
+            "menu_add_replace_rule",
+            "menu_import_local",
+            "menu_import_onLine",
+            "menu_import_qr",
+            "menu_manual_replace_rule",
+            "menu_help"
+        ).map { id ->
+            val index = menu.indexOf("android:id=\"@+id/$id\"")
+            assertTrue("$id should exist in replace_rule.xml", index >= 0)
+            index
+        }
+        assertTrue("replace rule actions should follow the requested order", order.zipWithNext().all { (a, b) -> a < b })
+
+        val manual = menu.substringAfter("android:id=\"@+id/menu_manual_replace_rule\"")
+            .substringBefore("/>")
+        assertTrue(manual.contains("android:icon=\"@drawable/ic_find_replace\""))
+
+        val zhStrings = readProjectFile("src/main/res/values-zh/strings.xml")
+        assertTrue(zhStrings.contains("<string name=\"manual_replace_rule\">手动替换</string>"))
+    }
+
+    private fun readProjectFile(pathInApp: String): String =
+        sequenceOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull(File::isFile)
+            ?.readText()
+            .orEmpty()
+}


### PR DESCRIPTION
## 变更\n- 将替换规则菜单调整为新建、本地导入、网络导入、二维码导入、手动替换、帮助。\n- 为手动替换复用现有 ic_find_replace 图标。\n- 简体中文标题改为手动替换。\n\n## 验证\n- :app:testAppDebugUnitTest --tests io.legado.app.ui.menu.Issue1044ReplaceMenuContractTest --no-daemon --no-configuration-cache --max-workers=1\n- git diff --check\n\nCloses #1044