### PR TITLE
fix: decode HEIF images from book sources

### DIFF
--- a/app/src/main/java/io/legado/app/help/book/BookHelp.kt
+++ b/app/src/main/java/io/legado/app/help/book/BookHelp.kt
@@ -1,6 +1,5 @@
 package io.legado.app.help.book
 
-import android.graphics.BitmapFactory
 import android.os.ParcelFileDescriptor
 import androidx.documentfile.provider.DocumentFile
 import com.script.rhino.runScriptWithContext
@@ -23,6 +22,7 @@ import io.legado.app.utils.MD5Utils
 import io.legado.app.utils.NetworkUtils
 import io.legado.app.utils.StringUtils
 import io.legado.app.utils.SvgUtils
+import io.legado.app.utils.BitmapUtils
 import io.legado.app.utils.UrlUtil
 import io.legado.app.utils.createFileIfNotExist
 import io.legado.app.utils.exists
@@ -490,8 +490,6 @@ object BookHelp {
             return false
         }
         var ret = true
-        val op = BitmapFactory.Options()
-        op.inJustDecodeBounds = true
         getContent(book, bookChapter)?.let {
             val matcher = AppPattern.imgPattern.matcher(it)
             while (matcher.find()) {
@@ -501,8 +499,7 @@ object BookHelp {
                     ret = false
                     continue
                 }
-                BitmapFactory.decodeFile(image.absolutePath, op)
-                if (op.outWidth < 1 && op.outHeight < 1) {
+                if (BitmapUtils.getImageSize(image.absolutePath) == null) {
                     if (SvgUtils.getSize(image.absolutePath) != null) {
                         continue
                     }
@@ -515,13 +512,8 @@ object BookHelp {
     }
 
     private fun checkImage(bytes: ByteArray): Boolean {
-        val op = BitmapFactory.Options()
-        op.inJustDecodeBounds = true
-        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, op)
-        if (op.outWidth < 1 && op.outHeight < 1) {
-            return SvgUtils.getSize(ByteArrayInputStream(bytes)) != null
-        }
-        return true
+        return BitmapUtils.isImage(bytes) ||
+            SvgUtils.getSize(ByteArrayInputStream(bytes)) != null
     }
 
     /**

--- a/app/src/main/java/io/legado/app/help/glide/LegadoGlideModule.kt
+++ b/app/src/main/java/io/legado/app/help/glide/LegadoGlideModule.kt
@@ -44,6 +44,7 @@ class LegadoGlideModule : AppGlideModule() {
         val bitmapPool = AsyncRecycleBitmapPool(calculator.bitmapPoolSize)
         builder.setMemorySizeCalculator(calculator)
         builder.setBitmapPool(bitmapPool)
+        builder.setImageDecoderEnabledForBitmaps(true)
         builder.setDiskCache(InternalCacheDiskCacheFactory(context, 1024 * 1024 * 1000))
         if (!BuildConfig.DEBUG && !AppConfig.recordLog) {
             builder.setLogLevel(Log.ERROR)

--- a/app/src/main/java/io/legado/app/model/ImageProvider.kt
+++ b/app/src/main/java/io/legado/app/model/ImageProvider.kt
@@ -158,11 +158,8 @@ object ImageProvider {
         bookSource: BookSource?
     ): Size {
         val file = cacheImage(book, src, bookSource)
-        val op = BitmapFactory.Options()
-        // inJustDecodeBounds如果设置为true,仅仅返回图片实际的宽和高,宽和高是赋值给opts.outWidth,opts.outHeight;
-        op.inJustDecodeBounds = true
-        BitmapFactory.decodeFile(file.absolutePath, op)
-        if (op.outWidth < 1 && op.outHeight < 1) {
+        BitmapUtils.getImageSize(file.absolutePath)?.let { return it }
+        run {
             //svg size
             val size = SvgUtils.getSize(file.absolutePath)
             if (size != null) return size
@@ -170,7 +167,6 @@ object ImageProvider {
             //file.delete() 重复下载
             return Size(errorBitmap.width, errorBitmap.height)
         }
-        return Size(op.outWidth, op.outHeight)
     }
 
     /**

--- a/app/src/main/java/io/legado/app/utils/BitmapUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/BitmapUtils.kt
@@ -9,6 +9,9 @@ import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.NinePatchDrawable
+import android.os.Build
+import android.util.Size
+import androidx.annotation.RequiresApi
 import com.google.android.renderscript.Toolkit
 import java.io.*
 import kotlin.math.*
@@ -29,7 +32,7 @@ object BitmapUtils {
     @Throws(IOException::class)
     fun decodeBitmap(path: String, width: Int, height: Int? = null): Bitmap? {
         val fis = FileInputStream(path)
-        return fis.use {
+        val bitmap = fis.use {
             val op = BitmapFactory.Options()
             // inJustDecodeBounds如果设置为true,仅仅返回图片实际的宽和高,宽和高是赋值给opts.outWidth,opts.outHeight;
             op.inJustDecodeBounds = true
@@ -37,6 +40,39 @@ object BitmapUtils {
             op.inSampleSize = calculateInSampleSize(op, width, height)
             op.inJustDecodeBounds = false
             BitmapFactory.decodeFileDescriptor(fis.fd, null, op)
+        }
+        return bitmap ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            decodeBitmapWithImageDecoder(File(path), width, height)
+        } else {
+            null
+        }
+    }
+
+    /**
+     * 获取图片尺寸。BitmapFactory 不认识的格式（例如 HEIF/HEIC）交给系统解码器探测。
+     */
+    fun getImageSize(path: String): Size? {
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(path, options)
+        if (options.outWidth > 0 && options.outHeight > 0) {
+            return Size(options.outWidth, options.outHeight)
+        }
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            decodeImageSizeWithImageDecoder(File(path))
+        } else {
+            null
+        }
+    }
+
+    /** 检测网络返回的图片字节，保留 SVG 的调用方回退。 */
+    fun isImage(bytes: ByteArray): Boolean {
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
+        if (options.outWidth > 0 && options.outHeight > 0) return true
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            isImageWithImageDecoder(bytes)
+        } else {
+            false
         }
     }
 
@@ -62,16 +98,83 @@ object BitmapUtils {
         options: BitmapFactory.Options,
         width: Int? = null,
         height: Int? = null
+    ): Int = calculateInSampleSize(options.outWidth, options.outHeight, width, height)
+
+    private fun calculateInSampleSize(
+        imageWidth: Int,
+        imageHeight: Int,
+        width: Int? = null,
+        height: Int? = null
     ): Int {
         //获取比例大小
-        val wRatio = width?.let { options.outWidth / it } ?: -1
-        val hRatio = height?.let { options.outHeight / it } ?: -1
+        val wRatio = width?.takeIf { it > 0 }?.let { imageWidth / it } ?: -1
+        val hRatio = height?.takeIf { it > 0 }?.let { imageHeight / it } ?: -1
         //如果超出指定大小，则缩小相应的比例
         return when {
             wRatio > 1 && hRatio > 1 -> max(wRatio, hRatio)
             wRatio > 1 -> wRatio
             hRatio > 1 -> hRatio
             else -> 1
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    private fun decodeBitmapWithImageDecoder(file: File, width: Int, height: Int?): Bitmap? {
+        return try {
+            android.graphics.ImageDecoder.decodeBitmap(
+                android.graphics.ImageDecoder.createSource(file)
+            ) { decoder, info, _ ->
+                decoder.setAllocator(android.graphics.ImageDecoder.ALLOCATOR_SOFTWARE)
+                val sampleSize = calculateInSampleSize(
+                    info.size.width,
+                    info.size.height,
+                    width,
+                    height,
+                )
+                if (sampleSize > 1) decoder.setTargetSampleSize(sampleSize)
+            }
+        } catch (_: IOException) {
+            null
+        } catch (_: RuntimeException) {
+            null
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    private fun decodeImageSizeWithImageDecoder(file: File): Size? {
+        var imageSize: Size? = null
+        return try {
+            val bitmap = android.graphics.ImageDecoder.decodeBitmap(
+                android.graphics.ImageDecoder.createSource(file)
+            ) { decoder, info, _ ->
+                imageSize = info.size
+                decoder.setAllocator(android.graphics.ImageDecoder.ALLOCATOR_SOFTWARE)
+                decoder.setTargetSize(1, 1)
+            }
+            bitmap.recycle()
+            imageSize
+        } catch (_: IOException) {
+            null
+        } catch (_: RuntimeException) {
+            null
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    private fun isImageWithImageDecoder(bytes: ByteArray): Boolean {
+        return try {
+            val bitmap = android.graphics.ImageDecoder.decodeBitmap(
+                android.graphics.ImageDecoder.createSource(bytes)
+            ) { decoder, _, _ ->
+                decoder.setAllocator(android.graphics.ImageDecoder.ALLOCATOR_SOFTWARE)
+                decoder.setTargetSize(1, 1)
+            }
+            bitmap.recycle()
+            true
+        } catch (_: IOException) {
+            false
+        } catch (_: RuntimeException) {
+            false
         }
     }
 

--- a/app/src/test/java/io/legado/app/utils/ImageDecoderContractTest.kt
+++ b/app/src/test/java/io/legado/app/utils/ImageDecoderContractTest.kt
@@ -1,0 +1,40 @@
+package io.legado.app.utils
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ImageDecoderContractTest {
+
+    @Test
+    fun `glide enables platform decoder for network images`() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/help/glide/LegadoGlideModule.kt"
+        ).readText()
+        assertTrue(source.contains("builder.setImageDecoderEnabledForBitmaps(true)"))
+    }
+
+    @Test
+    fun `bitmap utility keeps an api guarded image decoder fallback`() {
+        val source = projectFile("src/main/java/io/legado/app/utils/BitmapUtils.kt").readText()
+        assertTrue(source.contains("Build.VERSION.SDK_INT >= Build.VERSION_CODES.P"))
+        assertTrue(source.contains("ImageDecoder.createSource(file)"))
+        assertTrue(source.contains("ImageDecoder.createSource(bytes)"))
+        assertTrue(source.contains("setAllocator(android.graphics.ImageDecoder.ALLOCATOR_SOFTWARE)"))
+    }
+
+    @Test
+    fun `image consumers use decoder aware validation`() {
+        val provider = projectFile("src/main/java/io/legado/app/model/ImageProvider.kt").readText()
+        val bookHelp = projectFile("src/main/java/io/legado/app/help/book/BookHelp.kt").readText()
+        assertTrue(provider.contains("BitmapUtils.getImageSize(file.absolutePath)"))
+        assertTrue(bookHelp.contains("BitmapUtils.getImageSize(image.absolutePath)"))
+        assertTrue(bookHelp.contains("BitmapUtils.isImage(bytes)"))
+    }
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+    }
+}


### PR DESCRIPTION
## Summary
- enable Glide platform ImageDecoder for network-loaded bitmaps
- fall back to Android ImageDecoder for cached HEIF/HEIC book images when BitmapFactory cannot decode them
- use decoder-aware size and download validation so supported images are not treated as invalid

Closes #1052

## Validation
- app testAppDebugUnitTest ImageDecoderContractTest passed
- git diff --check passed
- full app Kotlin compilation completed during focused Gradle test