### PR TITLE
fix: dismiss stopped live update notifications

### DIFF
--- a/app/src/main/java/io/legado/app/service/McpService.kt
+++ b/app/src/main/java/io/legado/app/service/McpService.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import splitties.init.appCtx
+import splitties.systemservices.notificationManager
 
 class McpService : BaseService() {
 
@@ -153,6 +154,7 @@ class McpService : BaseService() {
         terminalStopJob?.cancel()
         terminalStopJob = lifecycleScope.launch {
             delay(TERMINAL_NOTIFICATION_DURATION)
+            notificationManager.cancel(NotificationId.McpService)
             stopSelf()
         }
     }

--- a/app/src/main/java/io/legado/app/service/WebService.kt
+++ b/app/src/main/java/io/legado/app/service/WebService.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.launch
 import splitties.init.appCtx
 import splitties.systemservices.powerManager
 import splitties.systemservices.wifiManager
+import splitties.systemservices.notificationManager
 import java.io.IOException
 
 class WebService : BaseService() {
@@ -184,6 +185,7 @@ class WebService : BaseService() {
         terminalStopJob?.cancel()
         terminalStopJob = lifecycleScope.launch {
             delay(TERMINAL_NOTIFICATION_DURATION)
+            notificationManager.cancel(NotificationId.WebService)
             stopSelf()
         }
     }

--- a/app/src/test/java/io/legado/app/service/LiveUpdateNotificationTest.kt
+++ b/app/src/test/java/io/legado/app/service/LiveUpdateNotificationTest.kt
@@ -135,6 +135,7 @@ class LiveUpdateNotificationTest {
         assertTrue(web.contains("IntentAction.stop -> stopServiceWithNotification()"))
         assertTrue(web.contains("setTimeoutAfter(TERMINAL_NOTIFICATION_DURATION)"))
         assertTrue(web.contains("terminalStopJob"))
+        assertTrue(web.contains("notificationManager.cancel(NotificationId.WebService)"))
         assertTrue(web.contains("if (isRun)"))
         assertTrue(web.contains("createNotification(terminal = stopping)"))
 
@@ -145,6 +146,7 @@ class LiveUpdateNotificationTest {
         assertTrue(mcp.contains("IntentAction.stop -> stopServiceWithNotification()"))
         assertTrue(mcp.contains("setTimeoutAfter(TERMINAL_NOTIFICATION_DURATION)"))
         assertTrue(mcp.contains("terminalStopJob"))
+        assertTrue(mcp.contains("notificationManager.cancel(NotificationId.McpService)"))
         assertTrue(mcp.contains("if (isRun)"))
         assertTrue(mcp.contains("createNotification(terminal = stopping)"))
 


### PR DESCRIPTION
## Summary
- cancel Web and MCP live notifications after their 4.5 second stopped-state window
- keep the terminal status visible briefly while ensuring it does not remain indefinitely
- add a focused source contract test

Closes #1043

## Validation
- :app:testAppDebugUnitTest --tests io.legado.app.service.LiveUpdateNotificationTest passed
- git diff --check passed