### PR TITLE
fix: render HEIF images in legacy reviews

### DIFF
--- a/app/src/main/java/io/legado/app/api/controller/ReviewController.kt
+++ b/app/src/main/java/io/legado/app/api/controller/ReviewController.kt
@@ -2,6 +2,7 @@ package io.legado.app.api.controller
 
 import androidx.annotation.Keep
 import androidx.collection.LruCache
+import com.google.gson.JsonParser
 import com.google.gson.annotations.SerializedName
 import com.script.rhino.runScriptWithContext
 import io.legado.app.api.ReturnData
@@ -22,12 +23,57 @@ import io.legado.app.utils.GSON
 import io.legado.app.utils.fromJsonObject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
+import java.net.URLEncoder
 import java.util.UUID
 import kotlin.coroutines.coroutineContext
 
 private val legacyReviewClickPattern = Regex(
     """^(?:getDP\(\s*\d+\s*,\s*\d+\s*\)|getZP\(\s*\d+\s*\))$"""
 )
+private val legacyHeifUrlPattern = Regex("""(?i)^https?://.*\.(?:heic|heif)(?:[?#].*|$)""")
+private val legacyReviewImageTagPattern = Regex("""(?is)<img\b[^>]*>""")
+private val legacyReviewImageAttributePattern = Regex(
+    """(?i)(\b(?:src|data-src|data-original)\s*=\s*)([\"'])(.*?)\2"""
+)
+
+internal fun rewriteLegacyReviewImages(html: String, bookUrl: String): String =
+    legacyReviewImageTagPattern.replace(html) { tag ->
+        legacyReviewImageAttributePattern.replace(tag.value) { attribute ->
+            val raw = attribute.groupValues[3]
+            if (!legacyHeifUrlPattern.matches(raw)) {
+                attribute.value
+            } else {
+                val proxy = "/image?path=${encodeLegacyReviewQuery(raw)}" +
+                    "&url=${encodeLegacyReviewQuery(bookUrl)}&width=2048"
+                attribute.groupValues[1] + attribute.groupValues[2] +
+                    escapeHtmlAttribute(proxy) + attribute.groupValues[2]
+            }
+        }
+    }
+
+internal fun rewriteLegacyReviewResult(result: String, bookUrl: String): String {
+    val parsed = runCatching { JsonParser.parseString(result) }.getOrNull()
+    if (parsed?.isJsonObject == true) {
+        val json = parsed.asJsonObject
+        val html = json.get("html")
+            ?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }
+            ?.asString
+        if (html != null) {
+            json.addProperty("html", rewriteLegacyReviewImages(html, bookUrl))
+            return GSON.toJson(json)
+        }
+    }
+    return rewriteLegacyReviewImages(result, bookUrl)
+}
+
+private fun encodeLegacyReviewQuery(value: String): String =
+    URLEncoder.encode(value, Charsets.UTF_8.name())
+
+private fun escapeHtmlAttribute(value: String): String = value
+    .replace("&", "&amp;")
+    .replace("\"", "&quot;")
+    .replace("<", "&lt;")
+    .replace(">", "&gt;")
 
 internal fun parseLegacyReviewClickScript(src: String): String? {
     val matcher = AnalyzeUrl.paramPattern.matcher(src)
@@ -363,7 +409,12 @@ object ReviewController {
             browserPage = it
         }
         val page = requireNotNull(browserPage) { "旧评论脚本未返回页面" }
-        require(!page.html.isNullOrBlank()) { "旧评论页面内容为空" }
+        val pageHtml = requireNotNull(page.html?.takeIf { it.isNotBlank() }) {
+            "旧评论页面内容为空"
+        }
+        val normalizedPage = page.copy(
+            html = rewriteLegacyReviewImages(pageHtml, context.book.bookUrl)
+        )
 
         val id = UUID.randomUUID().toString()
         val nonce = UUID.randomUUID().toString()
@@ -375,7 +426,7 @@ object ReviewController {
                     chapterIndex = context.chapter.index,
                     sourceKey = source.getKey(),
                     nonce = nonce,
-                    page = page,
+                    page = normalizedPage,
                     frameOrigin = frameOrigin,
                     expiresAt = System.currentTimeMillis() + LEGACY_REVIEW_SESSION_TTL,
                 )
@@ -395,12 +446,13 @@ object ReviewController {
         val context = requireContext(session.bookUrl, session.chapterIndex)
         require(context.source?.getKey() == session.sourceKey) { "书源已变更，请重新打开评论" }
         val source = requireNotNull(context.source) { "未找到书源" }
-        requireNotNull(runScriptWithContext {
+        val result = requireNotNull(runScriptWithContext {
             AnalyzeRule(context.book, source)
                 .setChapter(context.chapter)
                 .setCoroutineContext(coroutineContext)
                 .evalJS(request.script)
         }) { "旧评论脚本未返回结果" }.toString()
+        rewriteLegacyReviewResult(result, session.bookUrl)
     }
 
     internal fun getLegacyReviewPage(
@@ -411,7 +463,7 @@ object ReviewController {
         val session = getLegacyReviewSession(id) ?: return null
         if (nonce != session.nonce) return null
         return LegacyReviewWebPage(
-            html = injectLegacyReviewBridge(session.nonce, session.page),
+            html = injectLegacyReviewBridge(session.nonce, session.bookUrl, session.page),
             frameOrigin = session.frameOrigin,
         )
     }
@@ -448,6 +500,7 @@ object ReviewController {
 
     private fun injectLegacyReviewBridge(
         nonce: String,
+        bookUrl: String,
         page: LegacyReviewBrowserPage,
     ): String {
         val bridge = """
@@ -457,6 +510,71 @@ object ReviewController {
               window.setInterval = (callback, delay, ...args) =>
                 nativeSetInterval(callback, Math.max(100, Number(delay) || 0), ...args);
               const nonce = ${GSON.toJson(nonce)};
+              const bookUrl = ${GSON.toJson(bookUrl).replace("<", "\\u003c")};
+              const heifPattern = /\.(?:heic|heif)(?:[?#]|$)/i;
+              const isProxyImageUrl = raw => {
+                try {
+                  const target = new URL(String(raw || ''), window.location.href);
+                  return target.pathname === '/image' &&
+                    target.searchParams.has('path') && target.searchParams.has('url');
+                } catch (_) {
+                  return false;
+                }
+              };
+              const proxyImageUrl = raw => {
+                const value = String(raw || '');
+                if (isProxyImageUrl(value) || !/^https?:/i.test(value) || !heifPattern.test(value)) {
+                  return value;
+                }
+                try {
+                  const target = new URL('/image', window.location.href);
+                  target.searchParams.set('path', value);
+                  target.searchParams.set('url', bookUrl);
+                  target.searchParams.set('width', '2048');
+                  return target.toString();
+                } catch (_) {
+                  return value;
+                }
+              };
+              const rewriteImage = image => {
+                if (!(image instanceof HTMLImageElement)) return;
+                const dataOriginal = image.getAttribute('data-original') ||
+                  image.getAttribute('data-src') || '';
+                const current = image.getAttribute('src') || '';
+                const storedOriginal = image.getAttribute('data-legado-original-src') || '';
+                const raw = storedOriginal ||
+                  (heifPattern.test(dataOriginal) ? dataOriginal :
+                    heifPattern.test(current) ? current : dataOriginal || current);
+                const proxied = proxyImageUrl(raw);
+                if (proxied === raw) return;
+                if (!storedOriginal) image.setAttribute('data-legado-original-src', raw);
+                if (image.getAttribute('data-original') !== proxied)
+                  image.setAttribute('data-original', proxied);
+                if (current !== proxied) image.setAttribute('src', proxied);
+              };
+              const rewriteImages = root => {
+                if (!root) return;
+                rewriteImage(root);
+                root.querySelectorAll?.('img').forEach(rewriteImage);
+              };
+              const observeImages = () => {
+                const root = document.documentElement;
+                if (!root) {
+                  document.addEventListener('DOMContentLoaded', observeImages, {once: true});
+                  return;
+                }
+                rewriteImages(document);
+                new MutationObserver(records => records.forEach(record => {
+                  record.addedNodes.forEach(node => rewriteImages(node));
+                  if (record.type === 'attributes') rewriteImage(record.target);
+                })).observe(root, {
+                  childList: true,
+                  subtree: true,
+                  attributes: true,
+                  attributeFilter: ['src', 'data-src', 'data-original']
+                });
+              };
+              observeImages();
               const finishLoading = () =>
                 document.getElementById('loading')?.classList.add('hidden');
               const showError = error => {
@@ -526,12 +644,6 @@ object ReviewController {
         }
         return injection + page.html
     }
-
-    private fun escapeHtmlAttribute(value: String): String = value
-        .replace("&", "&amp;")
-        .replace("\"", "&quot;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
 
     private fun respond(block: suspend () -> Any): ReturnData {
         return try {

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt
@@ -31,6 +31,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
+import com.bumptech.glide.Glide
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import io.legado.app.R
@@ -41,6 +42,7 @@ import io.legado.app.data.entities.BaseSource
 import io.legado.app.databinding.DialogWebViewBinding
 import io.legado.app.help.WebCacheManager
 import io.legado.app.help.config.AppConfig
+import io.legado.app.help.glide.ImageLoader
 import io.legado.app.help.webView.PooledWebView
 import io.legado.app.help.webView.WebJsExtensions
 import io.legado.app.help.webView.WebJsExtensions.Companion.JS_INJECTION
@@ -90,11 +92,14 @@ import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.lang.ref.WeakReference
 import java.net.URLDecoder
 import java.util.ArrayDeque
 import java.util.Date
+import java.util.concurrent.TimeUnit
 import androidx.core.graphics.createBitmap
+import splitties.init.appCtx
 
 internal data class BottomSheetHeightConfig(
     val dialogHeight: Int?,
@@ -1105,6 +1110,40 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
             view: WebView, request: WebResourceRequest
         ): WebResourceResponse? {
             val url = request.url.toString()
+            if (!request.isForMainFrame && request.method.equals("GET", ignoreCase = true) &&
+                request.url.path?.let { path ->
+                    path.endsWith(".heic", ignoreCase = true) ||
+                        path.endsWith(".heif", ignoreCase = true)
+                } == true
+            ) {
+                val sourceOrigin = source?.getKey()
+                val converted = runBlocking(IO) {
+                    val target = runCatching {
+                        ImageLoader.loadBitmap(appCtx, url, sourceOrigin)
+                            .disallowHardwareConfig()
+                            .submit(2048, 2048)
+                    }.getOrNull() ?: return@runBlocking null
+                    try {
+                        val bitmap = target.get(10, TimeUnit.SECONDS)
+                        ByteArrayOutputStream().use { output ->
+                            if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                                null
+                            } else {
+                                WebResourceResponse(
+                                    "image/png",
+                                    null,
+                                    ByteArrayInputStream(output.toByteArray())
+                                )
+                            }
+                        }
+                    } catch (_: Exception) {
+                        null
+                    } finally {
+                        Glide.with(appCtx).clear(target)
+                    }
+                }
+                if (converted != null) return converted
+            }
             if (request.isForMainFrame) {
                 if (!preloadJs.isNullOrEmpty()) {
                     jsInjected = false

--- a/app/src/test/java/io/legado/app/api/ReviewWebApiContractTest.kt
+++ b/app/src/test/java/io/legado/app/api/ReviewWebApiContractTest.kt
@@ -1,5 +1,10 @@
 package io.legado.app.api
 
+import com.google.gson.JsonParser
+import io.legado.app.api.controller.rewriteLegacyReviewImages
+import io.legado.app.api.controller.rewriteLegacyReviewResult
+import io.legado.app.utils.GSON
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -127,6 +132,16 @@ class ReviewWebApiContractTest {
         assertTrue(controller.contains("image instanceof HTMLImageElement"))
         assertTrue(controller.contains("type: 'legado-legacy-review-image'"))
         assertTrue(controller.contains("image.currentSrc || image.src"))
+        assertTrue(controller.contains("const bookUrl = ${'$'}{GSON.toJson(bookUrl)"))
+        assertTrue(controller.contains("new URL('/image', window.location.href)"))
+        assertTrue(controller.contains("/\\.(?:heic|heif)(?:[?#]|${'$'})/i"))
+        assertTrue(controller.contains("target.pathname === '/image'"))
+        assertTrue(controller.contains("target.searchParams.has('path')"))
+        assertTrue(controller.contains("MutationObserver"))
+        assertTrue(controller.contains("observeImages();"))
+        assertTrue(controller.contains("data-legado-original-src"))
+        assertTrue(controller.contains("image.setAttribute('data-original', proxied)"))
+        assertFalse(controller.contains("wsrv.nl"))
         assertFalse(controller.contains("fetch('runLegacyReview'"))
         assertTrue(server.contains("http-equiv=\\\"Content-Security-Policy\\\""))
         assertTrue(controller.contains("if (nonce != session.nonce) return null"))
@@ -152,6 +167,28 @@ class ReviewWebApiContractTest {
         val imageBranch = dialog.indexOf("message.type === 'legado-legacy-review-image'")
         assertTrue(dialog.indexOf("event.source !== frameWindow") in 0 until imageBranch)
         assertTrue(dialog.indexOf("message.nonce !== props.sessionNonce") in 0 until imageBranch)
+    }
+
+    @Test
+    fun `legacy review HEIF URLs are rewritten in initial and JSON HTML`() {
+        val imageUrl = "https://cdn.example/review.heic?token=a&x-signature=b"
+        val bookUrl = "https://books.example/book?id=1"
+        val html = "<img src=\"$imageUrl\" data-original=\"$imageUrl\"><img src=\"https://cdn.example/review.jpg\">"
+
+        val rewritten = rewriteLegacyReviewImages(html, bookUrl)
+        assertFalse(rewritten.contains(imageUrl))
+        assertTrue(rewritten.contains("/image?path=https%3A%2F%2Fcdn.example%2Freview.heic"))
+        assertTrue(rewritten.contains("&amp;url=https%3A%2F%2Fbooks.example%2Fbook%3Fid%3D1"))
+        assertTrue(rewritten.contains("https://cdn.example/review.jpg"))
+
+        val result = rewriteLegacyReviewResult(
+            GSON.toJson(mapOf("html" to html, "refferContent" to "<span>3</span>")),
+            bookUrl,
+        )
+        val resultJson = JsonParser.parseString(result).asJsonObject
+        assertTrue(resultJson["html"].asString.contains("/image?path="))
+        assertTrue(resultJson["html"].asString.contains("&amp;url="))
+        assertEquals("<span>3</span>", resultJson["refferContent"].asString)
     }
 
     private fun readProjectFile(path: String): String {

--- a/app/src/test/java/io/legado/app/utils/ImageDecoderContractTest.kt
+++ b/app/src/test/java/io/legado/app/utils/ImageDecoderContractTest.kt
@@ -32,6 +32,19 @@ class ImageDecoderContractTest {
         assertTrue(bookHelp.contains("BitmapUtils.isImage(bytes)"))
     }
 
+    @Test
+    fun `legacy browser converts heif requests through native decoder`() {
+        val dialog = projectFile(
+            "src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt"
+        ).readText()
+        assertTrue(dialog.contains("ImageLoader.loadBitmap(appCtx, url, sourceOrigin)"))
+        assertTrue(dialog.contains(".disallowHardwareConfig()"))
+        assertTrue(dialog.contains("path.endsWith(\".heic\", ignoreCase = true)"))
+        assertTrue(dialog.contains("path.endsWith(\".heif\", ignoreCase = true)"))
+        assertTrue(dialog.contains("Bitmap.CompressFormat.PNG"))
+        assertTrue(dialog.contains("\"image/png\""))
+    }
+
     private fun projectFile(pathInApp: String): File {
         return listOf(File(pathInApp), File("app/$pathInApp"))
             .firstOrNull { it.isFile }


### PR DESCRIPTION
## Summary

Legacy review pages can contain signed HEIC/HEIF avatar and comment-image URLs that WebView cannot render directly.

- Rewrite initial and JSON-returned legacy review HTML to the app's local /image endpoint.
- Keep the browser bridge rewrite idempotent for dynamically inserted images.
- Convert HEIC/HEIF requests in BottomWebViewDialog with the existing Glide/native ImageDecoder path, force a software bitmap, and return PNG to WebView.
- Add focused contract and behavior tests.

No third-party image proxy or ffmpeg is used.

## Test

gradlew.bat --no-daemon --max-workers=1 :app:testAppDebugUnitTest --tests io.legado.app.api.ReviewWebApiContractTest --tests io.legado.app.utils.ImageDecoderContractTest

Result: BUILD SUCCESSFUL.