### PR TITLE
perf: avoid redundant HEIF image decoding

### DIFF
--- a/app/src/main/java/io/legado/app/model/ImageProvider.kt
+++ b/app/src/main/java/io/legado/app/model/ImageProvider.kt
@@ -203,6 +203,7 @@ object ImageProvider {
 
     fun clear() {
         bitmapLruCache.evictAll()
+        BitmapUtils.clearImageSizeCache()
     }
 
 }

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt
@@ -10,6 +10,7 @@ import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle
 import android.util.Base64
+import android.util.LruCache
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.KeyEvent
@@ -1053,6 +1054,10 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
     }
 
     inner class CustomWebViewClient : WebViewClient() {
+        private val heifResponseCache = object : LruCache<String, ByteArray>(8 * 1024 * 1024) {
+            override fun sizeOf(key: String, value: ByteArray): Int = value.size
+        }
+
         override fun shouldOverrideUrlLoading(
             view: WebView?, request: WebResourceRequest?
         ): Boolean {
@@ -1117,29 +1122,41 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
                 } == true
             ) {
                 val sourceOrigin = source?.getKey()
-                val converted = runBlocking(IO) {
-                    val target = runCatching {
-                        ImageLoader.loadBitmap(appCtx, url, sourceOrigin)
-                            .disallowHardwareConfig()
-                            .submit(2048, 2048)
-                    }.getOrNull() ?: return@runBlocking null
-                    try {
-                        val bitmap = target.get(10, TimeUnit.SECONDS)
-                        ByteArrayOutputStream().use { output ->
-                            if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
-                                null
-                            } else {
-                                WebResourceResponse(
-                                    "image/png",
-                                    null,
-                                    ByteArrayInputStream(output.toByteArray())
-                                )
+                val cacheKey = "${sourceOrigin.orEmpty()}\u0000$url"
+                val cached = heifResponseCache.get(cacheKey)
+                val converted = if (cached != null) {
+                    WebResourceResponse(
+                        "image/png",
+                        null,
+                        ByteArrayInputStream(cached)
+                    )
+                } else {
+                    runBlocking(IO) {
+                        val target = runCatching {
+                            ImageLoader.loadBitmap(appCtx, url, sourceOrigin)
+                                .disallowHardwareConfig()
+                                .submit(2048, 2048)
+                        }.getOrNull() ?: return@runBlocking null
+                        try {
+                            val bitmap = target.get(10, TimeUnit.SECONDS)
+                            ByteArrayOutputStream().use { output ->
+                                if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)) {
+                                    null
+                                } else {
+                                    val bytes = output.toByteArray()
+                                    heifResponseCache.put(cacheKey, bytes)
+                                    WebResourceResponse(
+                                        "image/png",
+                                        null,
+                                        ByteArrayInputStream(bytes)
+                                    )
+                                }
                             }
+                        } catch (_: Exception) {
+                            null
+                        } finally {
+                            Glide.with(appCtx).clear(target)
                         }
-                    } catch (_: Exception) {
-                        null
-                    } finally {
-                        Glide.with(appCtx).clear(target)
                     }
                 }
                 if (converted != null) return converted

--- a/app/src/main/java/io/legado/app/utils/BitmapUtils.kt
+++ b/app/src/main/java/io/legado/app/utils/BitmapUtils.kt
@@ -10,6 +10,7 @@ import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.NinePatchDrawable
 import android.os.Build
+import android.util.LruCache
 import android.util.Size
 import androidx.annotation.RequiresApi
 import com.google.android.renderscript.Toolkit
@@ -19,6 +20,24 @@ import kotlin.math.*
 
 @Suppress("WeakerAccess", "MemberVisibilityCanBePrivate")
 object BitmapUtils {
+
+    private data class ImageSizeCacheEntry(
+        val exists: Boolean,
+        val length: Long,
+        val lastModified: Long,
+        val size: Size?,
+    ) {
+        fun matches(file: File): Boolean =
+            exists == file.exists() &&
+                length == file.length() &&
+                lastModified == file.lastModified()
+    }
+
+    private val imageSizeCache = LruCache<String, ImageSizeCacheEntry>(128)
+    private const val HEIF_HEADER_SCAN_BYTES = 1024 * 1024
+    private val heifBrands = setOf(
+        "heic", "heif", "heix", "hevc", "hevx", "heim", "heis", "hevm", "hevs", "mif1", "msf1"
+    )
 
     /**
      * 从path中获取图片信息,在通过BitmapFactory.decodeFile(String path)方法将突破转成Bitmap时，
@@ -31,6 +50,10 @@ object BitmapUtils {
      */
     @Throws(IOException::class)
     fun decodeBitmap(path: String, width: Int, height: Int? = null): Bitmap? {
+        val isHeif = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isHeifPath(path)
+        if (isHeif) {
+            decodeBitmapWithImageDecoder(File(path), width, height)?.let { return it }
+        }
         val fis = FileInputStream(path)
         val bitmap = fis.use {
             val op = BitmapFactory.Options()
@@ -41,7 +64,7 @@ object BitmapUtils {
             op.inJustDecodeBounds = false
             BitmapFactory.decodeFileDescriptor(fis.fd, null, op)
         }
-        return bitmap ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        return bitmap ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && !isHeif) {
             decodeBitmapWithImageDecoder(File(path), width, height)
         } else {
             null
@@ -52,20 +75,36 @@ object BitmapUtils {
      * 获取图片尺寸。BitmapFactory 不认识的格式（例如 HEIF/HEIC）交给系统解码器探测。
      */
     fun getImageSize(path: String): Size? {
-        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        BitmapFactory.decodeFile(path, options)
-        if (options.outWidth > 0 && options.outHeight > 0) {
-            return Size(options.outWidth, options.outHeight)
-        }
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            decodeImageSizeWithImageDecoder(File(path))
+        val file = File(path)
+        imageSizeCache.get(path)?.takeIf { it.matches(file) }?.let { return it.size }
+        val size = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && isHeifPath(path)) {
+            readHeifImageSize(file)
+                ?: decodeImageSizeWithImageDecoder(file)
+                ?: readImageSizeWithBitmapFactory(file)
         } else {
-            null
+            readImageSizeWithBitmapFactory(file)
+                ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    decodeImageSizeWithImageDecoder(file)
+                } else {
+                    null
+                }
         }
+        imageSizeCache.put(
+            path,
+            ImageSizeCacheEntry(file.exists(), file.length(), file.lastModified(), size)
+        )
+        return size
+    }
+
+    fun clearImageSizeCache() {
+        imageSizeCache.evictAll()
     }
 
     /** 检测网络返回的图片字节，保留 SVG 的调用方回退。 */
     fun isImage(bytes: ByteArray): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && hasHeifFileSignature(bytes)) {
+            return true
+        }
         val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
         if (options.outWidth > 0 && options.outHeight > 0) return true
@@ -116,6 +155,114 @@ object BitmapUtils {
             hRatio > 1 -> hRatio
             else -> 1
         }
+    }
+
+    private fun readImageSizeWithBitmapFactory(file: File): Size? {
+        val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(file.absolutePath, options)
+        return if (options.outWidth > 0 && options.outHeight > 0) {
+            Size(options.outWidth, options.outHeight)
+        } else {
+            null
+        }
+    }
+
+    internal fun isHeifPath(path: String): Boolean {
+        val cleanPath = path.substringBefore('?').substringBefore('#')
+        return cleanPath.endsWith(".heic", ignoreCase = true) ||
+            cleanPath.endsWith(".heif", ignoreCase = true)
+    }
+
+    /**
+     * HEIF uses an ISO-BMFF `ftyp` header. Recognizing its brand is enough for
+     * download validation and avoids decoding the same image just to inspect it.
+     */
+    internal fun hasHeifFileSignature(bytes: ByteArray): Boolean {
+        if (bytes.size < 12) return false
+        val lastTypeOffset = (bytes.size - 4).coerceAtMost(64)
+        for (typeOffset in 0..lastTypeOffset) {
+            if (!asciiEquals(bytes, typeOffset, "ftyp")) continue
+            val majorBrandOffset = typeOffset + 4
+            if (asciiBrand(bytes, majorBrandOffset)) return true
+            var compatibleBrandOffset = typeOffset + 12
+            while (compatibleBrandOffset + 4 <= bytes.size &&
+                compatibleBrandOffset < typeOffset + 4 + 4 * 32
+            ) {
+                if (asciiBrand(bytes, compatibleBrandOffset)) return true
+                compatibleBrandOffset += 4
+            }
+        }
+        return false
+    }
+
+    private fun readHeifImageSize(file: File): Size? {
+        if (!file.isFile || file.length() < 24) return null
+        val length = min(file.length(), HEIF_HEADER_SCAN_BYTES.toLong()).toInt()
+        val bytes = ByteArray(length)
+        return try {
+            FileInputStream(file).use { input ->
+                var offset = 0
+                while (offset < bytes.size) {
+                    val count = input.read(bytes, offset, bytes.size - offset)
+                    if (count <= 0) break
+                    offset += count
+                }
+                findHeifImageDimensions(bytes, offset)?.let { (width, height) ->
+                    Size(width, height)
+                }
+            }
+        } catch (_: IOException) {
+            null
+        }
+    }
+
+    internal fun findHeifImageDimensions(
+        bytes: ByteArray,
+        length: Int = bytes.size,
+    ): Pair<Int, Int>? {
+        // An ispe FullBox stores size/type, version+flags, width and height.
+        val limit = length.coerceIn(0, bytes.size)
+        if (limit < 20) return null
+        var best: Pair<Int, Int>? = null
+        for (typeOffset in 4..(limit - 20)) {
+            if (!asciiEquals(bytes, typeOffset, "ispe")) continue
+            val boxStart = typeOffset - 4
+            val boxSize = readUInt32(bytes, boxStart, limit)
+            if (boxSize < 20L || boxSize == 1L || boxStart.toLong() + boxSize > limit) continue
+            val width = readUInt32(bytes, typeOffset + 8, limit)
+            val height = readUInt32(bytes, typeOffset + 12, limit)
+            if (width <= 0L || height <= 0L || width > Int.MAX_VALUE || height > Int.MAX_VALUE) {
+                continue
+            }
+            val candidate = width.toInt() to height.toInt()
+            val candidateArea = candidate.first.toLong() * candidate.second
+            val bestArea = best?.let { it.first.toLong() * it.second } ?: -1L
+            if (candidateArea > bestArea) {
+                best = candidate
+            }
+        }
+        return best
+    }
+
+    private fun readUInt32(bytes: ByteArray, offset: Int, limit: Int): Long {
+        if (offset < 0 || offset + 4 > limit) return -1L
+        return ((bytes[offset].toLong() and 0xff) shl 24) or
+            ((bytes[offset + 1].toLong() and 0xff) shl 16) or
+            ((bytes[offset + 2].toLong() and 0xff) shl 8) or
+            (bytes[offset + 3].toLong() and 0xff)
+    }
+
+    private fun asciiBrand(bytes: ByteArray, offset: Int): Boolean {
+        if (offset < 0 || offset + 4 > bytes.size) return false
+        return heifBrands.any { asciiEquals(bytes, offset, it) }
+    }
+
+    private fun asciiEquals(bytes: ByteArray, offset: Int, value: String): Boolean {
+        if (offset < 0 || offset + value.length > bytes.size) return false
+        value.indices.forEach { index ->
+            if (bytes[offset + index].toInt() != value[index].code) return false
+        }
+        return true
     }
 
     @RequiresApi(Build.VERSION_CODES.P)

--- a/app/src/test/java/io/legado/app/utils/ImageDecoderContractTest.kt
+++ b/app/src/test/java/io/legado/app/utils/ImageDecoderContractTest.kt
@@ -1,6 +1,8 @@
 package io.legado.app.utils
 
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.File
 
@@ -21,6 +23,9 @@ class ImageDecoderContractTest {
         assertTrue(source.contains("ImageDecoder.createSource(file)"))
         assertTrue(source.contains("ImageDecoder.createSource(bytes)"))
         assertTrue(source.contains("setAllocator(android.graphics.ImageDecoder.ALLOCATOR_SOFTWARE)"))
+        assertTrue(source.contains("isHeifPath(path)"))
+        assertTrue(source.contains("setTargetSampleSize(sampleSize)"))
+        assertTrue(source.contains("imageSizeCache"))
     }
 
     @Test
@@ -43,6 +48,55 @@ class ImageDecoderContractTest {
         assertTrue(dialog.contains("path.endsWith(\".heif\", ignoreCase = true)"))
         assertTrue(dialog.contains("Bitmap.CompressFormat.PNG"))
         assertTrue(dialog.contains("\"image/png\""))
+        assertTrue(dialog.contains("heifResponseCache"))
+    }
+
+    @Test
+    fun `heif file signatures are recognized without pixel decoding`() {
+        assertTrue(BitmapUtils.hasHeifFileSignature(bytesWithBrand("heic")))
+        assertTrue(BitmapUtils.hasHeifFileSignature(bytesWithBrand("mif1")))
+        assertTrue(BitmapUtils.hasHeifFileSignature(bytesWithCompatibleBrand("heix")))
+        assertFalse(BitmapUtils.hasHeifFileSignature(bytesWithBrand("avif")))
+        assertFalse(BitmapUtils.hasHeifFileSignature(ByteArray(32)))
+    }
+
+    @Test
+    fun `heif path detection ignores query and fragment`() {
+        assertTrue(BitmapUtils.isHeifPath("/cache/image.HEIF?token=1"))
+        assertTrue(BitmapUtils.isHeifPath("/cache/image.heic#preview"))
+        assertFalse(BitmapUtils.isHeifPath("/cache/image.jpg?format=heic"))
+    }
+
+    @Test
+    fun `heif dimensions can be read from the ispe metadata box`() {
+        val bytes = ByteArray(64)
+        writeUInt32(bytes, 16, 20)
+        "ispe".toByteArray().copyInto(bytes, 20)
+        writeUInt32(bytes, 28, 1280)
+        writeUInt32(bytes, 32, 720)
+        val dimensions = BitmapUtils.findHeifImageDimensions(bytes)
+        assertEquals(1280, dimensions?.first)
+        assertEquals(720, dimensions?.second)
+    }
+
+    private fun bytesWithBrand(brand: String): ByteArray {
+        val bytes = ByteArray(24)
+        "ftyp".toByteArray().copyInto(bytes, 4)
+        brand.toByteArray().copyInto(bytes, 8)
+        return bytes
+    }
+
+    private fun bytesWithCompatibleBrand(brand: String): ByteArray {
+        val bytes = bytesWithBrand("mif1")
+        brand.toByteArray().copyInto(bytes, 16)
+        return bytes
+    }
+
+    private fun writeUInt32(bytes: ByteArray, offset: Int, value: Int) {
+        bytes[offset] = (value ushr 24).toByte()
+        bytes[offset + 1] = (value ushr 16).toByte()
+        bytes[offset + 2] = (value ushr 8).toByte()
+        bytes[offset + 3] = value.toByte()
     }
 
     private fun projectFile(pathInApp: String): File {


### PR DESCRIPTION
## Summary
- Skip the redundant bitmap probe for HEIF book images and read standard `ispe` dimensions from the container header.
- Cache file dimensions and keep ImageDecoder's native sample-size path for the final software decode.
- Cache converted HEIF/HEIF WebView responses per browser client to avoid repeated PNG conversion.

This removes the validation plus 1x1 decode chain from the native book-source path introduced by #1055, while keeping the local conversion route added by #1061. Older Android versions retain the existing BitmapFactory behavior.

## Validation
- `:app:testAppDebugUnitTest --tests io.legado.app.utils.ImageDecoderContractTest --tests io.legado.app.api.ReviewWebApiContractTest --tests io.legado.app.api.controller.BookControllerImageIsolationTest`
- `git diff --check`

Refs #1052, #1055, #1061