### PR TITLE
feat(backup): securely back up source runtime caches

### DIFF
--- a/app/src/main/java/io/legado/app/data/dao/CacheDao.kt
+++ b/app/src/main/java/io/legado/app/data/dao/CacheDao.kt
@@ -22,6 +22,17 @@ interface CacheDao {
     fun delete(key: String)
 
     @Query(
+        """select * from caches
+        where (substr(`key`, 1, 2) = 'v_'
+        or substr(`key`, 1, 9) = 'userInfo_'
+        or substr(`key`, 1, 12) = 'loginHeader_'
+        or substr(`key`, 1, 15) = 'sourceVariable_'
+        or substr(`key`, 1, 8) = 'infoMap_')
+        and (deadline = 0 or deadline > :now)"""
+    )
+    fun getRuntimeSourceCaches(now: Long): List<Cache>
+
+    @Query(
         """delete from caches where `key` like 'v_' || :key || '_%'
         or `key` = 'userInfo_' || :key
         or `key` = 'loginHeader_' || :key

--- a/app/src/main/java/io/legado/app/help/CacheManager.kt
+++ b/app/src/main/java/io/legado/app/help/CacheManager.kt
@@ -38,6 +38,7 @@ object AppCacheManager {
                 || it.startsWith("userInfo_")
                 || it.startsWith("loginHeader_")
                 || it.startsWith("sourceVariable_")
+                || it.startsWith("infoMap_")
             ) {
                 memoryLruCache.remove(it)
             }

--- a/app/src/main/java/io/legado/app/help/storage/Backup.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Backup.kt
@@ -63,6 +63,9 @@ internal fun selectedBackupFileNames(isEnabled: (String) -> Boolean): List<Strin
         if (isEnabled(BackupConfig.cookieContentKey)) {
             add(BackupConfig.cookieFileName)
         }
+        if (isEnabled(BackupConfig.runtimeSourceCacheContentKey)) {
+            add(BackupConfig.runtimeSourceCacheFileName)
+        }
         if (isEnabled(BackupConfig.ruleContentKey)) {
             addAll(
                 listOf(
@@ -199,7 +202,8 @@ object Backup {
                         uploadWebDav = false,
                         contentKeys = BackupConfig.contentKeys
                             .filterNotTo(hashSetOf()) {
-                                it == BackupConfig.cookieContentKey
+                                it == BackupConfig.cookieContentKey ||
+                                    it == BackupConfig.runtimeSourceCacheContentKey
                             },
                     )
                 ) { "生成恢复前备份失败" }
@@ -222,12 +226,23 @@ object Backup {
             }
         if (lanTransfer) {
             enabledContentKeys.remove(BackupConfig.cookieContentKey)
+            enabledContentKeys.remove(BackupConfig.runtimeSourceCacheContentKey)
         }
         val password = LocalConfig.password
-        if (BackupConfig.cookieContentKey in enabledContentKeys &&
-            password.isNullOrBlank()
-        ) {
-            throw NoStackTraceException(appCtx.getString(R.string.cookie_backup_password_required))
+        if (password.isNullOrBlank()) {
+            when {
+                BackupConfig.cookieContentKey in enabledContentKeys -> {
+                    throw NoStackTraceException(
+                        appCtx.getString(R.string.cookie_backup_password_required)
+                    )
+                }
+
+                BackupConfig.runtimeSourceCacheContentKey in enabledContentKeys -> {
+                    throw NoStackTraceException(
+                        appCtx.getString(R.string.source_variables_backup_password_required)
+                    )
+                }
+            }
         }
         if (!lanTransfer) {
             LocalConfig.lastBackup = System.currentTimeMillis()
@@ -299,6 +314,13 @@ object Backup {
             FileUtils.createFileIfNotExist(
                 backupPath + File.separator + BackupConfig.cookieFileName
             ).writeText(encryptedCookies)
+        }
+        if (BackupConfig.runtimeSourceCacheContentKey in enabledContentKeys) {
+            val runtimeCaches = appDb.cacheDao.getRuntimeSourceCaches(System.currentTimeMillis())
+            val encryptedRuntimeCaches = aes.encryptBase64(GSON.toJson(runtimeCaches))
+            FileUtils.createFileIfNotExist(
+                backupPath + File.separator + BackupConfig.runtimeSourceCacheFileName
+            ).writeText(encryptedRuntimeCaches)
         }
         currentCoroutineContext().ensureActive()
         GSON.toJson(readConfigSnapshot).let {

--- a/app/src/main/java/io/legado/app/help/storage/BackupConfig.kt
+++ b/app/src/main/java/io/legado/app/help/storage/BackupConfig.kt
@@ -25,6 +25,7 @@ object BackupConfig {
     private const val coverConfigKey = "coverConfig"
     private const val localBookKey = "localBook"
     private const val cookieIgnoreKey = "ignoreCookies"
+    private const val runtimeSourceCacheIgnoreKey = "ignoreSourceVariables"
 
     internal const val bookshelfContentKey = "backupBookshelf"
     internal const val annotationContentKey = "backupAnnotations"
@@ -37,6 +38,8 @@ object BackupConfig {
     internal const val backgroundContentKey = "backupBackgrounds"
     internal const val cookieContentKey = "backupCookies"
     internal const val cookieFileName = "cookies.json"
+    internal const val runtimeSourceCacheContentKey = "backupSourceVariables"
+    internal const val runtimeSourceCacheFileName = "runtimeSourceCache.json"
 
     val contentKeys = arrayOf(
         bookshelfContentKey,
@@ -49,6 +52,7 @@ object BackupConfig {
         otherCoverContentKey,
         backgroundContentKey,
         cookieContentKey,
+        runtimeSourceCacheContentKey,
     )
 
     val contentTitles = arrayOf(
@@ -62,6 +66,7 @@ object BackupConfig {
         appCtx.getString(R.string.backup_content_other_covers),
         appCtx.getString(R.string.backup_content_backgrounds),
         appCtx.getString(R.string.backup_content_cookies),
+        appCtx.getString(R.string.backup_content_source_variables),
     )
 
     //配置忽略key
@@ -75,6 +80,7 @@ object BackupConfig {
         PreferKey.threadCount,
         localBookKey,
         cookieIgnoreKey,
+        runtimeSourceCacheIgnoreKey,
     )
 
     //配置忽略标题
@@ -88,6 +94,7 @@ object BackupConfig {
         appCtx.getString(R.string.thread_count),
         appCtx.getString(R.string.local_book),
         appCtx.getString(R.string.backup_content_cookies),
+        appCtx.getString(R.string.backup_content_source_variables),
     )
 
     //自动忽略keys
@@ -189,12 +196,17 @@ object BackupConfig {
     val ignoreCookies: Boolean
         get() = ignoreConfig[cookieIgnoreKey] == true
 
+    val ignoreSourceVariables: Boolean
+        get() = ignoreConfig[runtimeSourceCacheIgnoreKey] == true
+
     internal fun contentIsEnabled(key: String): Boolean {
-        return if (key == cookieContentKey) {
-            ignoreConfig[key] == false
-        } else {
-            ignoreConfig[key] != true
+        if (key == cookieContentKey) {
+            return ignoreConfig[key] == false
         }
+        if (key == runtimeSourceCacheContentKey) {
+            return ignoreConfig[key] == false
+        }
+        return ignoreConfig[key] != true
     }
 
     fun saveIgnoreConfig() {

--- a/app/src/main/java/io/legado/app/help/storage/Restore.kt
+++ b/app/src/main/java/io/legado/app/help/storage/Restore.kt
@@ -17,6 +17,7 @@ import io.legado.app.data.entities.BookGroup
 import io.legado.app.data.entities.BookHighlight
 import io.legado.app.data.entities.BookSource
 import io.legado.app.data.entities.Bookmark
+import io.legado.app.data.entities.Cache
 import io.legado.app.data.entities.Cookie
 import io.legado.app.data.entities.DictRule
 import io.legado.app.data.entities.HttpTTS
@@ -31,6 +32,7 @@ import io.legado.app.data.entities.SearchKeyword
 import io.legado.app.data.entities.Server
 import io.legado.app.data.entities.TxtTocRule
 import io.legado.app.exception.NoStackTraceException
+import io.legado.app.help.AppCacheManager
 import io.legado.app.help.DirectLinkUpload
 import io.legado.app.help.HighlightStyle
 import io.legado.app.help.LauncherIconHelp
@@ -87,6 +89,52 @@ internal fun parseCookieBackup(json: String): List<Cookie> {
         require(cookie != null && cookie.isJsonPrimitive && cookie.asJsonPrimitive.isString)
         Cookie(url.asString.also { require(it.isNotBlank()) }, cookie.asString)
     }
+}
+
+private val runtimeSourceCachePrefixes = arrayOf(
+    "v_",
+    "userInfo_",
+    "loginHeader_",
+    "sourceVariable_",
+    "infoMap_",
+)
+
+internal fun isRuntimeSourceCacheKey(key: String): Boolean {
+    return runtimeSourceCachePrefixes.any { prefix ->
+        key.startsWith(prefix) && key.length > prefix.length
+    }
+}
+
+internal fun parseRuntimeSourceCacheBackup(json: String): List<Cache> {
+    val latestByKey = linkedMapOf<String, Cache>()
+    GSONStrict.fromJsonArray<JsonElement>(json).getOrThrow().forEach { element ->
+        require(element.isJsonObject)
+        val objectElement = element.asJsonObject
+        val keyElement = objectElement.get("key")
+        require(keyElement != null && keyElement.isJsonPrimitive && keyElement.asJsonPrimitive.isString)
+        val key = keyElement.asString
+        require(isRuntimeSourceCacheKey(key))
+
+        val valueElement = objectElement.get("value")
+        require(
+            valueElement != null && (valueElement.isJsonNull ||
+                (valueElement.isJsonPrimitive && valueElement.asJsonPrimitive.isString))
+        )
+        val deadlineElement = objectElement.get("deadline")
+        require(
+            deadlineElement != null && deadlineElement.isJsonPrimitive &&
+                deadlineElement.asJsonPrimitive.isNumber
+        )
+        val deadline = deadlineElement.asJsonPrimitive.asString.toLongOrNull()
+            ?: throw IllegalArgumentException("deadline must be an integer")
+        require(deadline >= 0L)
+        latestByKey[key] = Cache(
+            key = key,
+            value = if (valueElement.isJsonNull) null else valueElement.asString,
+            deadline = deadline,
+        )
+    }
+    return latestByKey.values.toList()
 }
 
 /**
@@ -184,6 +232,26 @@ object Restore {
                     )
                 }
                 parseCookieBackup(aes.decryptStr(file.readText()))
+            }
+        } else {
+            null
+        }
+        val restoredRuntimeSourceCaches = if (!lanTransfer &&
+            !BackupConfig.ignoreSourceVariables
+        ) {
+            File(path, BackupConfig.runtimeSourceCacheFileName).takeIf { it.exists() }?.let { file ->
+                if (password.isNullOrBlank()) {
+                    throw NoStackTraceException(
+                        appCtx.getString(R.string.source_variables_backup_password_required)
+                    )
+                }
+                val raw = file.readText()
+                val json = if (raw.isJsonArray()) {
+                    raw
+                } else {
+                    aes.decryptStr(raw)
+                }
+                parseRuntimeSourceCacheBackup(json)
             }
         } else {
             null
@@ -327,6 +395,11 @@ object Restore {
             } else {
                 CookieStore.restoreCookie(cookie.url, cookie.cookie)
             }
+        }
+        restoredRuntimeSourceCaches?.takeIf { it.isNotEmpty() }?.let { caches ->
+            // REPLACE updates matching keys while leaving local-only runtime entries intact.
+            appDb.cacheDao.insert(*caches.toTypedArray())
+            AppCacheManager.clearSourceVariables()
         }
         File(path, DirectLinkUpload.ruleFileName).takeIf {
             !lanTransfer && it.exists()

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -808,6 +808,7 @@
     <string name="backup_content_persisted_covers">書籍固化封面</string>
     <string name="backup_content_other_covers">其他封面文件</string>
     <string name="backup_content_backgrounds">閱讀背景</string>
+    <string name="backup_content_source_variables">來源變數</string>
     <string name="read_config">閱讀界面設置</string>
     <string name="rule_image_style">圖片樣式 (imageStyle)</string>
     <string name="rule_replace_regex">替換規則 (replaceRegex)</string>
@@ -1196,6 +1197,7 @@
     <string name="select_update_source">选中更新源</string>
     <string name="set_local_password">设置本地密码</string>
     <string name="set_local_password_summary">本地密码用来对备份的敏感信息加密和解密,如需在不同设备之间同步,本地密码需一致.</string>
+    <string name="source_variables_backup_password_required">備份或恢復來源變數前，請先設定非空的本地密碼。</string>
     <string name="only_latest_backup_t">仅保留最新备份</string>
     <string name="only_latest_backup_s">本地备份仅保留最新备份文件</string>
     <string name="webdav_application_authorization_error">webDav应用验证失败</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -815,6 +815,7 @@
     <string name="backup_content_persisted_covers">書籍固化封面</string>
     <string name="backup_content_other_covers">其他封面檔案</string>
     <string name="backup_content_backgrounds">閱讀背景</string>
+    <string name="backup_content_source_variables">來源變數</string>
     <string name="read_config">閱讀介面設定</string>
     <string name="group_name">分組名稱</string>
     <string name="note_content">備註內容</string>
@@ -1198,6 +1199,7 @@
     <string name="select_update_source">选中更新源</string>
     <string name="set_local_password">设置本地密码</string>
     <string name="set_local_password_summary">本地密码用来对备份的敏感信息加密和解密,如需在不同设备之间同步,本地密码需一致.</string>
+    <string name="source_variables_backup_password_required">備份或復原來源變數前，請先設定非空的本機密碼。</string>
     <string name="only_latest_backup_t">仅保留最新备份</string>
     <string name="only_latest_backup_s">本地备份仅保留最新备份文件</string>
     <string name="webdav_application_authorization_error">webDav应用验证失败</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -968,6 +968,7 @@
     <string name="backup_content_other_covers">其他封面文件</string>
     <string name="backup_content_backgrounds">阅读背景</string>
     <string name="backup_content_cookies">持久 Cookie</string>
+    <string name="backup_content_source_variables">源变量</string>
     <string name="read_config">阅读界面设置</string>
     <string name="confirm_read_config_import">是否导入阅读排版？</string>
     <string name="read_config_import_success">导入排版成功</string>
@@ -1413,6 +1414,7 @@
     <string name="set_local_password">设置本地密码</string>
     <string name="set_local_password_summary">本地密码用来对备份的敏感信息加密和解密,如需在不同设备之间同步,本地密码需一致.</string>
     <string name="cookie_backup_password_required">备份或恢复持久 Cookie 前，请先设置非空的本地密码。</string>
+    <string name="source_variables_backup_password_required">备份或恢复源变量前，请先设置非空的本地密码。</string>
     <string name="only_latest_backup_t">仅保留最新备份</string>
     <string name="only_latest_backup_s">本地备份仅保留最新备份文件</string>
     <string name="webdav_application_authorization_error">webDav应用验证失败</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -972,6 +972,7 @@
     <string name="backup_content_other_covers">Other cover files</string>
     <string name="backup_content_backgrounds">Reading backgrounds</string>
     <string name="backup_content_cookies">Persistent cookies</string>
+    <string name="backup_content_source_variables">Source variables</string>
     <string name="read_config">Reading interface settings</string>
     <string name="confirm_read_config_import">Import reading layout?</string>
     <string name="read_config_import_success">Reading layout imported</string>
@@ -1420,6 +1421,7 @@
     <string name="set_local_password">Setting the local password</string>
     <string name="set_local_password_summary">The local password is used to encrypt and decrypt the sensitive information of the backup, if you need to synchronize between different devices, the local password should be the same.</string>
     <string name="cookie_backup_password_required">Set a non-empty local password before backing up or restoring persistent cookies.</string>
+    <string name="source_variables_backup_password_required">Set a non-empty local password before backing up or restoring source variables.</string>
     <string name="only_latest_backup_t">Keep only the latest backup</string>
     <string name="only_latest_backup_s">Local backup keeps only the latest backup file</string>
     <string name="webdav_application_authorization_error">Fail to authorize WebDav application</string>

--- a/app/src/test/java/io/legado/app/help/storage/BackupMediaTest.kt
+++ b/app/src/test/java/io/legado/app/help/storage/BackupMediaTest.kt
@@ -60,6 +60,7 @@ class BackupMediaTest {
                 "rssStar.json",
                 "sourceSub.json",
                 "cookies.json",
+                "runtimeSourceCache.json",
                 "replaceRule.json",
                 "txtTocRule.json",
                 "httpTTS.json",
@@ -86,6 +87,14 @@ class BackupMediaTest {
         assertEquals(
             listOf("cookies.json"),
             selectedBackupFileNames { it == "backupCookies" },
+        )
+    }
+
+    @Test
+    fun sourceVariablesAreOptInBackupContent() {
+        assertEquals(
+            listOf("runtimeSourceCache.json"),
+            selectedBackupFileNames { it == "backupSourceVariables" },
         )
     }
 

--- a/app/src/test/java/io/legado/app/help/storage/RuntimeSourceCacheBackupTest.kt
+++ b/app/src/test/java/io/legado/app/help/storage/RuntimeSourceCacheBackupTest.kt
@@ -1,0 +1,96 @@
+package io.legado.app.help.storage
+
+import io.legado.app.data.entities.Cache
+import io.legado.app.utils.GSON
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class RuntimeSourceCacheBackupTest {
+
+    @Test
+    fun parserAcceptsLegacyPlaintextAndKeepsLatestValuePerKey() {
+        val json = """
+            [
+              {"key":"sourceVariable_demo","value":"old","deadline":0},
+              {"key":"v_demo_token","value":"42","deadline":123},
+              {"key":"sourceVariable_demo","value":"new","deadline":0}
+            ]
+        """.trimIndent()
+
+        assertEquals(
+            listOf(
+                Cache("sourceVariable_demo", "new", 0),
+                Cache("v_demo_token", "42", 123),
+            ),
+            parseRuntimeSourceCacheBackup(json),
+        )
+    }
+
+    @Test
+    fun backupPayloadIsEncryptedWithTheLocalPassword() {
+        val caches = listOf(Cache("userInfo_demo", "secret-token", 0))
+        val plaintext = GSON.toJson(caches)
+        val aes = BackupAES("runtime-password")
+        val encrypted = aes.encryptBase64(plaintext)
+
+        assertFalse(encrypted.contains("secret-token"))
+        assertEquals(caches, parseRuntimeSourceCacheBackup(aes.decryptStr(encrypted)))
+    }
+
+    @Test
+    fun parserRejectsUnknownOrUnsafeEntries() {
+        assertThrows(IllegalArgumentException::class.java) {
+            parseRuntimeSourceCacheBackup(
+                """[{"key":"ordinary-cache","value":"x","deadline":0}]"""
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            parseRuntimeSourceCacheBackup(
+                """[{"key":"v_demo","value":"x","deadline":-1}]"""
+            )
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            parseRuntimeSourceCacheBackup(
+                """[{"key":"v_demo","value":{"token":"x"},"deadline":0}]"""
+            )
+        }
+    }
+
+    @Test
+    fun runtimeBackupContractIsOptInEncryptedMergeAndLanSafe() {
+        val backup = projectFile(
+            "src/main/java/io/legado/app/help/storage/Backup.kt"
+        ).readText()
+        val restore = projectFile(
+            "src/main/java/io/legado/app/help/storage/Restore.kt"
+        ).readText()
+        val config = projectFile(
+            "src/main/java/io/legado/app/help/storage/BackupConfig.kt"
+        ).readText()
+        val dao = projectFile("src/main/java/io/legado/app/data/dao/CacheDao.kt").readText()
+
+        assertTrue(config.contains("runtimeSourceCacheContentKey = \"backupSourceVariables\""))
+        assertTrue(config.contains("runtimeSourceCacheIgnoreKey = \"ignoreSourceVariables\""))
+        assertTrue(config.contains("runtimeSourceCacheFileName = \"runtimeSourceCache.json\""))
+        assertTrue(backup.contains("aes.encryptBase64(GSON.toJson(runtimeCaches))"))
+        assertTrue(backup.contains("enabledContentKeys.remove(BackupConfig.runtimeSourceCacheContentKey)"))
+        assertTrue(restore.contains("!lanTransfer &&"))
+        assertTrue(restore.contains("!BackupConfig.ignoreSourceVariables"))
+        assertTrue(restore.contains("raw.isJsonArray()"))
+        assertTrue(restore.contains("aes.decryptStr(raw)"))
+        assertTrue(restore.contains("appDb.cacheDao.insert(*caches.toTypedArray())"))
+        assertFalse(restore.contains("deleteAllRuntimeSourceCaches()"))
+        assertTrue(dao.contains("fun getRuntimeSourceCaches(now: Long): List<Cache>"))
+        assertTrue(dao.contains("'userInfo_'"))
+        assertTrue(dao.contains("'sourceVariable_'"))
+        assertTrue(dao.contains("'infoMap_'"))
+    }
+
+    private fun projectFile(pathInApp: String): File =
+        sequenceOf(File(pathInApp), File("app/$pathInApp"))
+            .first(File::isFile)
+}


### PR DESCRIPTION
## 变更说明

源变量和书源运行时缓存此前未纳入标准备份，跨设备恢复会丢失登录信息、变量和段评界面状态。新增可选的 `runtimeSourceCache.json` 备份项；整文件使用本地密码通过 `BackupAES` 加密，恢复支持旧版明文数组并按 key 合并。

关联 Issue：#1047

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档
- [ ] 构建或依赖
- [ ] 重构或维护

## 涉及平台

- [x] Android
- [ ] Web
- [ ] Android 与 Web

## 涉及模块

- [ ] 阅读文本与翻页
- [ ] 漫画阅读
- [ ] 朗读与音频
- [ ] 书架与书籍管理
- [ ] 书源与规则解析
- [ ] Web 服务与前端
- [x] 备份、同步与数据
- [ ] 构建、安装与更新
- [ ] 其他或不确定

## 影响类型

- [ ] 崩溃或无响应
- [ ] 数据丢失或损坏
- [ ] 性能或耗电
- [x] 兼容性
- [x] 界面或交互
- [ ] 功能结果错误
- [ ] 无用户可见影响

## 验证

- [x] 已完成与改动范围相符的验证：`RuntimeSourceCacheBackupTest`、`BackupMediaTest`、`CookieBackupCompatibilityTest` 共 21 项 JVM 单元测试通过。
- [x] 未引入无关改动
