### PR TITLE
fix: align vertical cover title columns

### DIFF
--- a/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/image/CoverImageView.kt
@@ -91,6 +91,51 @@ internal fun coverTitleTextSize(
     viewWidth / 7
 }
 
+internal fun coverTitleColumnStartY(
+    top: Float,
+    maxColumnBottom: Float,
+    columnBottom: Float
+): Float = top + (maxColumnBottom - columnBottom).coerceAtLeast(0f)
+
+internal fun coverTitleColumnOffsets(
+    characterCount: Int,
+    viewHeight: Float,
+    textHeight: Float
+): List<List<Float>> {
+    if (characterCount <= 0 || viewHeight <= 0f || textHeight <= 0f) return emptyList()
+    val columns = mutableListOf<List<Float>>()
+    var column = mutableListOf<Float>()
+    var columnOffset = 0f
+    var line = 0
+    var nextY = viewHeight * 0.2f
+    repeat(characterCount) { index ->
+        column += columnOffset
+        columnOffset += textHeight
+        nextY += textHeight
+        val remaining = characterCount - index - 1
+        if (nextY > viewHeight * 0.9f) {
+            if (remaining == 1) {
+                nextY -= textHeight / 5
+                columnOffset -= textHeight / 5
+            } else if (remaining > 0) {
+                columns += column.toList()
+                column = mutableListOf()
+                columnOffset = 0f
+                line++
+                nextY = viewHeight * 0.2f + textHeight * line
+            }
+        } else if (nextY > viewHeight * 0.8f && remaining > 2) {
+            columns += column.toList()
+            column = mutableListOf()
+            columnOffset = 0f
+            line++
+            nextY = viewHeight * 0.2f + textHeight * line
+        }
+    }
+    if (column.isNotEmpty()) columns += column.toList()
+    return columns
+}
+
 /**
  * 封面
  */
@@ -300,7 +345,6 @@ class CoverImageView @JvmOverloads constructor(
         val bitmap = createBitmap(renderWidth, renderHeight)
         val bitmapCanvas = Canvas(bitmap)
         var startX = renderWidth * 0.2f
-        var startY = viewHeight * 0.2f
         if (horizontal) {
             drawHorizontalTextCover(
                 bitmapCanvas,
@@ -320,7 +364,6 @@ class CoverImageView @JvmOverloads constructor(
             textAlign = Paint.Align.CENTER
         }
         name?.toStringArray()?.let { name ->
-            var line = 0
             namePaint.textSize = viewWidth / 7
             namePaint.textSize = coverTitleTextSize(
                 viewWidth,
@@ -329,27 +372,28 @@ class CoverImageView @JvmOverloads constructor(
                 namePaint.textHeight
             )
             namePaint.strokeWidth = namePaint.textSize / 6
-            name.forEachIndexed { index, char ->
-                namePaint.color = backgroundColor
-                namePaint.style = Paint.Style.STROKE
-                bitmapCanvas.drawText(char, startX, startY, namePaint)
-                namePaint.color = accentColor
-                namePaint.style = Paint.Style.FILL
-                bitmapCanvas.drawText(char, startX, startY, namePaint)
-                startY += namePaint.textHeight
-                if (startY > viewHeight * 0.9) {
-                    if ((name.size - index - 1) == 1) { //只剩一个字
-                        startY -= namePaint.textHeight / 5
-                        return@forEachIndexed
-                    }
-                    startX += namePaint.textSize
-                    line++
-                    startY = viewHeight * 0.2f + namePaint.textHeight * line
-                }
-                else if (startY > viewHeight * 0.8 && (name.size - index - 1) > 2) { //剩余字数大于2
-                    startX += namePaint.textSize
-                    line++
-                    startY = viewHeight * 0.2f + namePaint.textHeight * line
+            val titleColumns = coverTitleColumnOffsets(
+                name.size,
+                viewHeight,
+                namePaint.textHeight
+            )
+            val maxColumnBottom = titleColumns.maxOfOrNull { it.last() } ?: 0f
+            var nameIndex = 0
+            titleColumns.forEachIndexed { columnIndex, offsets ->
+                startX = renderWidth * 0.2f + namePaint.textSize * columnIndex
+                val startY = coverTitleColumnStartY(
+                    viewHeight * 0.2f,
+                    maxColumnBottom,
+                    offsets.last()
+                )
+                offsets.forEach { offsetY ->
+                    val char = name[nameIndex++]
+                    namePaint.color = backgroundColor
+                    namePaint.style = Paint.Style.STROKE
+                    bitmapCanvas.drawText(char, startX, startY + offsetY, namePaint)
+                    namePaint.color = accentColor
+                    namePaint.style = Paint.Style.FILL
+                    bitmapCanvas.drawText(char, startX, startY + offsetY, namePaint)
                 }
             }
         }
@@ -363,7 +407,7 @@ class CoverImageView @JvmOverloads constructor(
             authorPaint.textSize = viewWidth / 10
             authorPaint.strokeWidth = authorPaint.textSize / 5
             startX = renderWidth * 0.8f
-            startY = viewHeight * 0.95f - author.size * authorPaint.textHeight
+            var startY = viewHeight * 0.95f - author.size * authorPaint.textHeight
             startY = maxOf(startY, viewHeight * 0.3f)
             author.forEach {
                 authorPaint.color = backgroundColor

--- a/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
+++ b/app/src/test/java/io/legado/app/RuntimeMediaStabilityTest.kt
@@ -4,6 +4,8 @@ import io.legado.app.data.entities.Book
 import io.legado.app.service.buildHttpTtsCacheFileName
 import io.legado.app.ui.book.info.normalizeWebFileName
 import io.legado.app.ui.widget.image.coverBitmapCacheKey
+import io.legado.app.ui.widget.image.coverTitleColumnOffsets
+import io.legado.app.ui.widget.image.coverTitleColumnStartY
 import io.legado.app.ui.widget.image.coverTitleTextSize
 import io.legado.app.ui.widget.image.normalizeCoverText
 import io.legado.app.utils.calculateSvgBitmapSize
@@ -137,10 +139,37 @@ class RuntimeMediaStabilityTest {
             .first { it.isDirectory }
             .resolve("io/legado/app/ui/widget/image/CoverImageView.kt")
             .readText()
-        val titleLoop = source.substringAfter("name.forEachIndexed { index, char ->")
-            .substringBefore("if (!drawBookAuthor)")
+        val titleLoop = source.substringAfter("titleColumns.forEachIndexed")
+            .substringBefore("if (!drawAuthor)")
 
         assertFalse(titleLoop.contains("namePaint.textSize ="))
+    }
+
+    @Test
+    fun verticalCoverTitleColumnsShareTheLastBaseline() {
+        val top = 28f
+        val textHeight = 10f
+        val columns = coverTitleColumnOffsets(20, 140f, textHeight)
+        assertEquals(listOf(9, 8, 3), columns.map { it.size })
+        val maxColumnBottom = columns.maxOf { it.last() }
+        val starts = columns.map {
+            coverTitleColumnStartY(top, maxColumnBottom, it.last())
+        }
+
+        assertEquals(listOf(top, top + textHeight, top + textHeight * 6), starts)
+        val bottoms = starts.zip(columns).map { (start, offsets) ->
+            start + offsets.last()
+        }
+        bottoms.forEach { assertEquals(bottoms.first(), it, 0.001f) }
+
+        assertEquals(listOf(9, 3), coverTitleColumnOffsets(12, 140f, textHeight).map { it.size })
+        val singleColumn = coverTitleColumnOffsets(11, 140f, textHeight).single()
+        assertEquals(11, singleColumn.size)
+        assertEquals(98f, singleColumn.last(), 0.001f)
+        assertTrue(coverTitleColumnOffsets(0, 140f, textHeight).isEmpty())
+        assertTrue(coverTitleColumnOffsets(3, 0f, textHeight).isEmpty())
+        assertTrue(coverTitleColumnOffsets(3, 140f, 0f).isEmpty())
+        assertEquals(top, coverTitleColumnStartY(top, 80f, 90f), 0.001f)
     }
 
     @Test


### PR DESCRIPTION
## 变更

- 保留现有竖排标题断列阈值和 #955/#964 的统一字号选择。
- 先收集竖排列，再按最长列的末字基线下移较短列，修复 #1007 截图中的末列底部错位。
- 保留旧逻辑在最后两个字之间的边界压缩，并增加空标题、单列和多列回归测试。
- 不改变作者绘制、横排模式、缓存键或布局尺寸。

## 验证

- gradlew.bat :app:testAppReleaseUnitTest --tests io.legado.app.RuntimeMediaStabilityTest --no-daemon --max-workers=1
- 12 tests, 0 failures, 0 errors
- git diff --check

Fixes #1007

字号大小仍遵循已合并的 #955/#964 契约；本 PR 聚焦底线对齐。