### PR TITLE
feat: 定时任务管理页增加登录入口

### DIFF
--- a/app/src/main/java/io/legado/app/ui/autoTask/AutoTaskAdapter.kt
+++ b/app/src/main/java/io/legado/app/ui/autoTask/AutoTaskAdapter.kt
@@ -10,8 +10,11 @@ import io.legado.app.base.adapter.RecyclerAdapter
 import io.legado.app.constant.AppConst
 import io.legado.app.data.entities.AutoTaskRule
 import io.legado.app.databinding.ItemAutoTaskBinding
+import io.legado.app.model.AutoTask
+import io.legado.app.ui.login.SourceLoginActivity
 import io.legado.app.ui.widget.popupActionMenu
 import io.legado.app.ui.widget.recycler.DragSelectTouchHelper
+import io.legado.app.utils.startActivity
 
 class AutoTaskAdapter(context: Context, private val callback: Callback) :
     RecyclerAdapter<AutoTaskRule, ItemAutoTaskBinding>(context) {
@@ -120,6 +123,7 @@ class AutoTaskAdapter(context: Context, private val callback: Callback) :
     private fun showMenu(anchor: View, position: Int) {
         val task = getItem(position) ?: return
         popupActionMenu(context) {
+            item(context.getString(R.string.login), "login", AutoTask.buildSource(task).hasLogin())
             item(context.getString(R.string.auto_task_log), "log")
             item(context.getString(R.string.auto_task_move_up), "moveUp")
             item(context.getString(R.string.auto_task_move_down), "moveDown")
@@ -127,6 +131,11 @@ class AutoTaskAdapter(context: Context, private val callback: Callback) :
             danger("delete")
         }.show(anchor) { action ->
             when (action) {
+                "login" -> context.startActivity<SourceLoginActivity> {
+                    putExtra("type", "autoTask")
+                    putExtra("key", task.id)
+                }
+
                 "log" -> callback.showLog(task)
                 "moveUp" -> callback.move(task, -1)
                 "moveDown" -> callback.move(task, 1)

--- a/app/src/main/java/io/legado/app/ui/autoTask/AutoTaskEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/autoTask/AutoTaskEditActivity.kt
@@ -113,7 +113,7 @@ class AutoTaskEditActivity : BaseActivity<ActivityAutoTaskEditBinding>() {
                 startActivity(AutoTaskDebugActivity.intent(this, saved.id))
             }
             R.id.menu_login -> save { saved ->
-                if (saved.loginUrl.isNullOrBlank()) {
+                if (!AutoTask.buildSource(saved).hasLogin()) {
                     toastOnUi(R.string.source_no_login)
                 } else {
                     startActivity<SourceLoginActivity> {

--- a/app/src/test/java/io/legado/app/ui/login/LoginEntryRoutingTest.kt
+++ b/app/src/test/java/io/legado/app/ui/login/LoginEntryRoutingTest.kt
@@ -7,8 +7,10 @@ import java.io.File
 class LoginEntryRoutingTest {
 
     @Test
-    fun `book and video entry points use unified login capability`() {
+    fun `login entry points use unified login capability`() {
         val paths = listOf(
+            "src/main/java/io/legado/app/ui/autoTask/AutoTaskAdapter.kt",
+            "src/main/java/io/legado/app/ui/autoTask/AutoTaskEditActivity.kt",
             "src/main/java/io/legado/app/ui/book/info/BookInfoActivity.kt",
             "src/main/java/io/legado/app/ui/book/audio/AudioPlayActivity.kt",
             "src/main/java/io/legado/app/ui/book/read/ReadMenu.kt",
@@ -20,5 +22,19 @@ class LoginEntryRoutingTest {
         paths.forEach { path ->
             assertTrue("$path should use hasLogin()", File(path).readText().contains("hasLogin()"))
         }
+    }
+
+    @Test
+    fun `auto task management login is first and routes by task id`() {
+        val source = File(
+            "src/main/java/io/legado/app/ui/autoTask/AutoTaskAdapter.kt"
+        ).readText()
+        val loginItem =
+            "item(context.getString(R.string.login), \"login\", AutoTask.buildSource(task).hasLogin())"
+
+        assertTrue(source.indexOf(loginItem) in 0 until source.indexOf("R.string.auto_task_log"))
+        assertTrue(source.contains("\"login\" -> context.startActivity<SourceLoginActivity>"))
+        assertTrue(source.contains("putExtra(\"type\", \"autoTask\")"))
+        assertTrue(source.contains("putExtra(\"key\", task.id)"))
     }
 }


### PR DESCRIPTION
## 变更说明

定时任务登录入口此前只在编辑页中，管理列表无法直接进入。现在为有登录配置的任务在行溢出菜单首项显示“登录”，并按任务 ID 复用现有 SourceLoginActivity；编辑页同步使用统一 hasLogin 能力判断，因此 loginUi-only 配置也能进入登录界面。

Closes #1039

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档
- [ ] 构建或依赖
- [ ] 重构或维护

## 涉及平台

- [x] Android
- [ ] Web
- [ ] Android 与 Web

## 涉及模块

- [ ] 阅读文本与翻页
- [ ] 漫画阅读
- [ ] 朗读与音频
- [x] 书架与书籍管理
- [x] 书源与规则解析
- [ ] Web 服务与前端
- [ ] 备份、同步与数据
- [ ] 构建、安装与更新
- [ ] 其他或不确定

## 影响类型

- [ ] 崩溃或无响应
- [ ] 数据丢失或损坏
- [ ] 性能或耗电
- [ ] 兼容性
- [x] 界面或交互
- [x] 功能结果错误
- [ ] 无用户可见影响

## 验证

- [x] 已完成与改动范围相符的验证：LoginEntryRoutingTest、ManagePopupActionMigrationTest、AutoTaskEditActivitySourceTest 共 14 项通过；完整修改路径 Kotlin 编译通过。
- [x] 未引入无关改动