### PR TITLE
fix: validate Lanzou session before publishing

### DIFF
--- a/.github/scripts/lzy_web.py
+++ b/.github/scripts/lzy_web.py
@@ -6,9 +6,9 @@ import time
 import requests
 
 # Cookie 中 phpdisk_info 的值
-cookie_phpdisk_info = os.environ.get('phpdisk_info')
+cookie_phpdisk_info = os.environ.get('phpdisk_info', '').strip()
 # Cookie 中 ylogin 的值
-cookie_ylogin = os.environ.get('ylogin')
+cookie_ylogin = os.environ.get('ylogin', '').strip()
 
 # 请求头
 headers = {
@@ -34,16 +34,24 @@ def log(msg):
 
 # 检查是否已登录
 def login_by_cookie():
-    url_account = "https://accounts.woozooo.com/accounts.php"
-    if cookie['phpdisk_info'] is None:
+    url_account = "https://pc.woozooo.com/mydisk.php?item=files&action=index&u=" + cookie_ylogin
+    if not cookie['phpdisk_info']:
         log('ERROR: 请指定 Cookie 中 phpdisk_info 的值！')
         return False
-    if cookie['ylogin'] is None:
+    if not cookie['ylogin']:
         log('ERROR: 请指定 Cookie 中 ylogin 的值！')
         return False
-    res = requests.get(url_account, headers=headers, cookies=cookie, verify=True)
-    if '网盘用户登录' in res.text:
-        log('ERROR: 登录失败,请更新Cookie')
+    res = requests.get(
+        url_account,
+        headers=headers,
+        cookies=cookie,
+        allow_redirects=False,
+        timeout=30,
+        verify=True,
+    )
+    location = res.headers.get('Location', '')
+    if res.status_code >= 300 or 'accounts.woozooo.com' in location or '网盘用户登录' in res.text:
+        log(f'ERROR: 登录失败,请更新Cookie (HTTP {res.status_code})')
         return False
     else:
         log('登录成功')

--- a/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
+++ b/app/src/test/java/io/legado/app/ci/TestReleaseWorkflowTest.kt
@@ -85,5 +85,8 @@ class TestReleaseWorkflowTest {
         assertTrue(lanzouUploaderText.contains("sys.exit(main(sys.argv[1:]))"))
         assertFalse(lanzouUploaderText.contains("\"name\": '{file_name}'"))
         assertFalse(lanzouUploaderText.contains("retry_tim+"))
+        assertTrue(lanzouUploaderText.contains("mydisk.php?item=files&action=index&u="))
+        assertTrue(lanzouUploaderText.contains("allow_redirects=False"))
+        assertTrue(lanzouUploaderText.contains("accounts.woozooo.com"))
     }
 }


### PR DESCRIPTION
## 变更内容

- 蓝奏云登录检查改为访问实际上传域 pc.woozooo.com。
- 检查重定向、HTTP 状态和登录页，避免 Cookie 失效时误报登录成功。
- 对 GitHub Secret 值去除首尾空白，并保留上传失败退出。

## 根因

Test Release 的 APK 构建和 GitHub Release 发布均成功；Upload To Lanzou 连续收到 {"zt":9,"info":"login not"}，说明 GitHub Actions 中的蓝奏云 Cookie 已失效或不适用于上传域。

## 验证

- python -m py_compile .github/scripts/lzy_web.py`n- git diff --check`n- 未运行本地 Android 构建。