### PR TITLE
fix: prevent duplicate review dialogs

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
@@ -1948,9 +1948,17 @@ class ReadBookActivity : BaseReadBookActivity(),
             return
         }
         val source = ReadBook.bookSource ?: return
+        val reviewDialogTag = ReviewDetailDialog::class.simpleName
+        val fragmentManager = supportFragmentManager
+        if (fragmentManager.isStateSaved ||
+            fragmentManager.findFragmentByTag(reviewDialogTag) != null
+        ) return
+        fun showReviewDialog(dialog: ReviewDetailDialog) {
+            dialog.showNow(fragmentManager, reviewDialogTag)
+        }
         if (source.isJsSource()) {
             val book = ReadBook.book ?: return
-            showDialogFragment(
+            showReviewDialog(
                 ReviewDetailDialog(
                     paragraphNum = paragraphNum,
                     totalCount = count,
@@ -1980,7 +1988,7 @@ class ReadBookActivity : BaseReadBookActivity(),
             return
         }
         val book = ReadBook.book ?: return
-        showDialogFragment(
+        showReviewDialog(
             ReviewDetailDialog(
                 paragraphNum = paragraphNum,
                 totalCount = count,

--- a/app/src/test/java/io/legado/app/ui/book/read/ReviewDialogClickGuardSourceTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/ReviewDialogClickGuardSourceTest.kt
@@ -1,0 +1,28 @@
+package io.legado.app.ui.book.read
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ReviewDialogClickGuardSourceTest {
+
+    @Test
+    fun reviewClickUsesOneSynchronousTaggedDialog() {
+        val activity = projectFile(
+            "src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt"
+        ).readText()
+        val clickBlock = activity.substringAfter("override fun onReviewClick(")
+            .substringBefore("private fun loadReviewSummaryIfNeeded(")
+
+        assertTrue(clickBlock.contains("fragmentManager.isStateSaved"))
+        assertTrue(clickBlock.contains("fragmentManager.findFragmentByTag(reviewDialogTag)"))
+        assertTrue(clickBlock.contains("dialog.showNow(fragmentManager, reviewDialogTag)"))
+        assertTrue(!clickBlock.contains("showDialogFragment(\n"))
+    }
+
+    private fun projectFile(pathInApp: String): File {
+        return listOf(File(pathInApp), File("app/$pathInApp"))
+            .firstOrNull { it.isFile }
+            ?: error("Missing project file: $pathInApp")
+    }
+}


### PR DESCRIPTION
## What Changed

- Prevent duplicate review dialog transactions when a delayed first click is followed by a second click.
- Use the existing dialog tag and synchronous display for the shared review callback used by paragraph reviews and custom review buttons.
- Add a source contract test.
- Keep #1111 open for device verification of the loading behavior.

## Validation

- git diff --check passed.
- No local Android build was run; GitHub Actions will validate release and releaseA.