### PR TITLE
fix: debounce duplicate review dialog requests

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/ReadBookActivity.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import android.os.Bundle
 import android.os.Looper
+import android.os.SystemClock
 import android.view.Gravity
 import android.view.InputDevice
 import android.view.KeyEvent
@@ -316,6 +317,7 @@ class ReadBookActivity : BaseReadBookActivity(),
     }
     private var reviewSummaryAppliedKey: String? = null
     private var reviewSummaryLoadingKey: String? = null
+    private var lastReviewDialogRequestAt = 0L
     private var reviewSummaryRequestToken = 0L
     private val reviewSummaryCache = object :
         LinkedHashMap<String, ReviewRuleParser.SummaryResult>(8, 0.75f, true) {
@@ -1950,10 +1952,16 @@ class ReadBookActivity : BaseReadBookActivity(),
         val source = ReadBook.bookSource ?: return
         val reviewDialogTag = ReviewDetailDialog::class.simpleName
         val fragmentManager = supportFragmentManager
-        if (fragmentManager.isStateSaved ||
-            fragmentManager.findFragmentByTag(reviewDialogTag) != null
-        ) return
         fun showReviewDialog(dialog: ReviewDetailDialog) {
+            val now = SystemClock.uptimeMillis()
+            val taggedDialog = fragmentManager.findFragmentByTag(reviewDialogTag)
+            val existingDialog = taggedDialog != null || fragmentManager.fragments.any {
+                it is ReviewDetailDialog && !it.isRemoving
+            }
+            if (fragmentManager.isStateSaved || existingDialog ||
+                now - lastReviewDialogRequestAt < REVIEW_DIALOG_REQUEST_COOLDOWN_MS
+            ) return
+            lastReviewDialogRequestAt = now
             dialog.showNow(fragmentManager, reviewDialogTag)
         }
         if (source.isJsSource()) {
@@ -3006,6 +3014,7 @@ class ReadBookActivity : BaseReadBookActivity(),
     }
 
     companion object {
+        private const val REVIEW_DIALOG_REQUEST_COOLDOWN_MS = 1500L
         const val RESULT_DELETED = 100
         private const val ACTION_READER_ITEM_PREFIX = "readerItem:"
         private const val ACTION_READER_MORE = "readerMore"

--- a/app/src/main/java/io/legado/app/ui/book/read/page/ContentTextView.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/ContentTextView.kt
@@ -290,11 +290,13 @@ class ContentTextView(context: Context, attrs: AttributeSet?) : View(context, at
                 }
 
                 is ReviewColumn -> {
-                    callBack.onReviewClick(
-                        resolveReviewId(textLine),
-                        column.count,
-                        textPage.chapterIndex
-                    )
+                    if (!debounceClick) {
+                        callBack.onReviewClick(
+                            resolveReviewId(textLine),
+                            column.count,
+                            textPage.chapterIndex
+                        )
+                    }
                     handled = true
                 }
 

--- a/app/src/test/java/io/legado/app/ui/book/read/ReviewDialogClickGuardSourceTest.kt
+++ b/app/src/test/java/io/legado/app/ui/book/read/ReviewDialogClickGuardSourceTest.kt
@@ -16,8 +16,23 @@ class ReviewDialogClickGuardSourceTest {
 
         assertTrue(clickBlock.contains("fragmentManager.isStateSaved"))
         assertTrue(clickBlock.contains("fragmentManager.findFragmentByTag(reviewDialogTag)"))
+        assertTrue(clickBlock.contains("it is ReviewDetailDialog && !it.isRemoving"))
+        assertTrue(clickBlock.contains("REVIEW_DIALOG_REQUEST_COOLDOWN_MS"))
         assertTrue(clickBlock.contains("dialog.showNow(fragmentManager, reviewDialogTag)"))
         assertTrue(!clickBlock.contains("showDialogFragment(\n"))
+    }
+
+    @Test
+    fun reviewColumnClickUsesExistingTouchDebounce() {
+        val source = projectFile(
+            "src/main/java/io/legado/app/ui/book/read/page/ContentTextView.kt"
+        ).readText()
+        val clickBlock = source.substringAfter("fun click(x: Float, y: Float): Boolean")
+            .substringBefore("fun longPress(")
+        val reviewBlock = clickBlock.substringAfter("is ReviewColumn")
+            .substringBefore("is ImageColumn")
+        assertTrue(reviewBlock.contains("if (!debounceClick)"))
+        assertTrue(reviewBlock.contains("callBack.onReviewClick("))
     }
 
     private fun projectFile(pathInApp: String): File {


### PR DESCRIPTION
## What Changed

- Debounce review-column callbacks using the existing touch debounce window.
- Guard review dialog requests against active dialog instances and delayed duplicate requests.
- Keep #1111 open for device verification after the previous fix still reproduced in Beta 3.26090516.
- Extend the source contract test.

## Validation

- `git diff --check` passed.
- No local Android build was run; GitHub Actions will validate release and releaseA.