### PR TITLE
fix: keep large editor transport opt in

### DIFF
--- a/app/src/main/java/io/legado/app/ui/code/CodeEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/code/CodeEditActivity.kt
@@ -563,7 +563,9 @@ class CodeEditActivity :
     }
 
     private fun putEditorText(intent: Intent, text: String) {
-        if (text.length > io.legado.app.ui.widget.code.EditSafety.MAX_INLINE_TEXT_LENGTH) {
+        if (intent.getBooleanExtra("useTextFile", false) &&
+            text.length > io.legado.app.ui.widget.code.EditSafety.MAX_INLINE_TEXT_LENGTH
+        ) {
             intent.putExtra("textFile", CodeTextTransfer.write(this, text))
         } else {
             intent.putExtra("text", text)

--- a/app/src/main/java/io/legado/app/ui/replace/edit/ReplaceEditActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/replace/edit/ReplaceEditActivity.kt
@@ -119,6 +119,7 @@ class ReplaceEditActivity :
             val hint = findParentTextInputLayout(view)?.hint?.toString()
             val currentText = rawFields[view.id] ?: view.text.toString()
             val intent = Intent(this, CodeEditActivity::class.java).apply {
+                putExtra("useTextFile", true)
                 if (currentText.length > EditSafety.MAX_INLINE_TEXT_LENGTH) {
                     putExtra("textFile", CodeTextTransfer.write(this@ReplaceEditActivity, currentText))
                 } else putExtra("text", currentText)

--- a/app/src/test/java/io/legado/app/ui/code/CodeTextTransferContractTest.kt
+++ b/app/src/test/java/io/legado/app/ui/code/CodeTextTransferContractTest.kt
@@ -1,0 +1,24 @@
+package io.legado.app.ui.code
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class CodeTextTransferContractTest {
+    @Test
+    fun `large result file transport is opt in for replacement editor`() {
+        val activity = projectFile("app/src/main/java/io/legado/app/ui/code/CodeEditActivity.kt").readText()
+        val replacement = projectFile(
+            "app/src/main/java/io/legado/app/ui/replace/edit/ReplaceEditActivity.kt"
+        ).readText()
+        assertTrue(activity.contains("intent.getBooleanExtra(\"useTextFile\", false)"))
+        assertTrue(replacement.contains("putExtra(\"useTextFile\", true)"))
+    }
+
+    private fun projectFile(path: String): File {
+        val userDir = requireNotNull(System.getProperty("user.dir"))
+        return generateSequence(File(userDir)) { it.parentFile }
+            .map { File(it, path) }
+            .first { it.exists() }
+    }
+}


### PR DESCRIPTION
## 变更说明

修复 #1126 引入的共享代码编辑器协议回归。大文本文件传递现在必须由调用方显式声明 `useTextFile`，仅替换规则编辑器启用；书源、订阅源和自动任务等原有编辑器调用方继续使用兼容的 `text` 返回字段。

关联 Issue：#1125

## 变更类型

- [x] Bug 修复

## 涉及平台

- [x] Android

## 涉及模块

- [x] 书源与规则解析
- [x] 其他或不确定

## 影响类型

- [x] 数据丢失或损坏
- [x] 兼容性

## 验证

- [x] `git diff --check`
- [x] 新增代码编辑器传输协议源契约测试
- [x] 未运行本地 Android/Gradle 构建，使用 GitHub Actions 验证
