### PR TITLE
/claim #1149 Fix swipe reversal lock in horizontal page animations

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/read/page/delegate/HorizontalPageDelegate.kt
+++ b/app/src/main/java/io/legado/app/ui/book/read/page/delegate/HorizontalPageDelegate.kt
@@ -84,7 +84,7 @@ abstract class HorizontalPageDelegate(readView: ReadView) : PageDelegate(readVie
             isMoved = distance > slopSquare
             if (isMoved) {
                 readView.markReadPositionChanged()
-                if (sumX - startX > 0) {
+                if (focusX - startX > 0) {
                     //如果上一页不存在
                     if (!hasPrev()) {
                         noNext = true
@@ -99,14 +99,32 @@ abstract class HorizontalPageDelegate(readView: ReadView) : PageDelegate(readVie
                     }
                     setDirection(PageDirection.NEXT)
                 }
-                readView.setStartPoint(event.x, event.y, false)
+                readView.setStartPoint(focusX, focusY, false)
             }
         }
         if (isMoved) {
-            isCancel = if (mDirection == PageDirection.NEXT) sumX > lastX else sumX < lastX
+            // Allow switching direction while keeping finger down: if user reverses
+            // across the start point we switch mDirection so the UI follows the finger.
+            val delta = focusX - startX
+            if (mDirection == PageDirection.NEXT && delta > 0) {
+                if (!hasPrev()) {
+                    noNext = true
+                    return
+                }
+                setDirection(PageDirection.PREV)
+                readView.setStartPoint(focusX, focusY, false)
+            } else if (mDirection == PageDirection.PREV && delta < 0) {
+                if (!hasNext()) {
+                    noNext = true
+                    return
+                }
+                setDirection(PageDirection.NEXT)
+                readView.setStartPoint(focusX, focusY, false)
+            }
+            isCancel = if (mDirection == PageDirection.NEXT) focusX > lastX else focusX < lastX
             isRunning = true
             //设置触摸点
-            readView.setTouchPoint(sumX, sumY)
+            readView.setTouchPoint(focusX, focusY)
         }
     }
 


### PR DESCRIPTION
Summary

- Fixes a bug where, when using horizontal/sliding page animations, swiping left and then reversing to the right while keeping the finger down would be ignored (user could not switch direction mid-gesture).
- Use the averaged pointer focal point (support multi-touch) for determining movement and touch updates.
- Allow switching mDirection mid-gesture when the finger crosses the original start X, updating bitmap and start point immediately so the UI follows the finger.

What I changed

- Modified app/src/main/java/io/legado/app/ui/book/read/page/delegate/HorizontalPageDelegate.kt
  - Compute a focal point across pointers (focusX/focusY) and use it for movement detection and updates.
  - When the finger reverses across the start X after movement began, switch mDirection (PREV <-> NEXT), refresh bitmaps, and reset start point so the animation follows the new direction.
  - Keep isCancel and touch updates consistent using the focal point.

Why

The previous implementation determined direction only once when movement exceeded touch slop. If the user reversed direction while keeping the finger down (start left then go right), the delegate didn’t switch mDirection to follow the reversed gesture. That left the UI locked into the initial direction (or just canceled), producing the reported behavior.

How to verify (manual steps)

1. Build and run the app with a reading view (any text chapter or a book with multiple pages).
2. In reader settings enable a horizontal page animation (slide/cover/simulation) — the bug was reported with sliding page animation.
3. Touch and swipe left (toward previous page). Without lifting your finger, reverse direction and drag right across the original start X, then release.
4. Expected result: the UI follows the finger and the delegate switches direction; releasing should complete the appropriate animation (go to next or prev page depending on final direction). Previously the rightward reversal was ignored.

Notes

- This change uses the same screenshot/setDirection behaviors (so bitmaps are refreshed when direction switches).
- The change is minimal and scoped to HorizontalPageDelegate to affect all horizontal page animations (Cover/Slide/Simulation).

Closes #1149

Closes #1149