### PR TITLE
feat(ui): add code dialog position bar

### DIFF
--- a/app/src/main/assets/updateLog.md
+++ b/app/src/main/assets/updateLog.md
@@ -843,3 +843,4 @@
 * [2023年日志](https://github.com/LegadoTeam/legado/blob/record2023/app/src/main/assets/updateLog.md)　
 * [2022年日志](https://github.com/LegadoTeam/legado/blob/record2022/app/src/main/assets/updateLog.md)　
 * [2021年日志](https://github.com/LegadoTeam/legado/blob/record2021/app/src/main/assets/updateLog.md)　
+- 优化代码预览弹窗，增加垂直滚动定位条，长规则可快速定位

--- a/app/src/main/assets/updateLog.md
+++ b/app/src/main/assets/updateLog.md
@@ -2,6 +2,9 @@
 
 ## cronet版本: 152.0.7977.54
 
+**2026/09/07**
+- 优化代码预览弹窗，增加垂直滚动定位条，长规则可快速定位
+
 **2026/09/06**
 - 修复正文接口返回字面量 `\n` 或 `\r\n` 时未换行导致的排版问题
 - 竖排默认封面书名恢复为原版错落布局，横排布局保持不变
@@ -843,4 +846,3 @@
 * [2023年日志](https://github.com/LegadoTeam/legado/blob/record2023/app/src/main/assets/updateLog.md)　
 * [2022年日志](https://github.com/LegadoTeam/legado/blob/record2022/app/src/main/assets/updateLog.md)　
 * [2021年日志](https://github.com/LegadoTeam/legado/blob/record2021/app/src/main/assets/updateLog.md)　
-- 优化代码预览弹窗，增加垂直滚动定位条，长规则可快速定位

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/CodeDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/CodeDialog.kt
@@ -352,6 +352,12 @@ class CodeDialog() : BaseDialogFragment(R.layout.dialog_code_view) {
         if (!searchView.isIconified) updateSearch(keepIndex = true)
     }
 
+    override fun onDestroyView() {
+        binding.codeView.viewTreeObserver.removeOnScrollChangedListener(scrollListener)
+        binding.codeView.viewTreeObserver.removeOnGlobalLayoutListener(layoutListener)
+        super.onDestroyView()
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putInt("searchIndex", searchIndex)
         originalCodeStateKey = saveStateData(originalCodeStateKey, currentOriginalCode())

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/CodeDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/CodeDialog.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.text.method.KeyListener
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
+import android.widget.SeekBar
 import androidx.appcompat.widget.SearchView
 import androidx.core.widget.doAfterTextChanged
 import io.legado.app.R
@@ -28,6 +30,15 @@ internal fun resolveCodeDialogOriginal(
     originalCode: String,
     displayedCode: String,
 ): String = if (showingAlternate) originalCode else displayedCode
+
+internal fun resolveCodeDialogPositionProgress(
+    scrollY: Int,
+    maxScrollY: Int,
+    progressMax: Int = 10000,
+): Int {
+    if (maxScrollY <= 0 || progressMax <= 0) return 0
+    return (scrollY.coerceIn(0, maxScrollY).toLong() * progressMax / maxScrollY).toInt()
+}
 
 class CodeDialog() : BaseDialogFragment(R.layout.dialog_code_view) {
 
@@ -61,6 +72,8 @@ class CodeDialog() : BaseDialogFragment(R.layout.dialog_code_view) {
     private var replaceRuleRefreshPending = false
     private var originalCodeStateKey: String? = null
     private var alternateCodeStateKey: String? = null
+    private val scrollListener = ViewTreeObserver.OnScrollChangedListener { updatePositionBar() }
+    private val layoutListener = ViewTreeObserver.OnGlobalLayoutListener { updatePositionBar() }
     val requestId: String?
         get() = arguments?.getString("requestId")
 
@@ -82,6 +95,22 @@ class CodeDialog() : BaseDialogFragment(R.layout.dialog_code_view) {
         binding.codeView.addLegadoPattern()
         binding.codeView.addJsonPattern()
         binding.codeView.addJsPattern()
+        binding.codeView.viewTreeObserver.addOnScrollChangedListener(scrollListener)
+        binding.codeView.viewTreeObserver.addOnGlobalLayoutListener(layoutListener)
+        binding.positionBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(bar: SeekBar, progress: Int, fromUser: Boolean) {
+                if (fromUser) {
+                    val max = maxScrollY()
+                    binding.codeView.scrollTo(
+                        0,
+                        (max * progress.toLong() / bar.max).toInt(),
+                    )
+                }
+            }
+
+            override fun onStartTrackingTouch(bar: SeekBar) = Unit
+            override fun onStopTrackingTouch(bar: SeekBar) = Unit
+        })
         originalCodeStateKey = savedInstanceState?.getString("originalCode")
             ?: arguments?.getString("code")
         originalCode = originalCodeStateKey
@@ -96,6 +125,7 @@ class CodeDialog() : BaseDialogFragment(R.layout.dialog_code_view) {
         }
         editKeyListener = binding.codeView.keyListener
         binding.codeView.setText(originalCode)
+        binding.codeView.post { updatePositionBar() }
         val canPreviewReplacement = !disableEdit && alternateCode != null
         binding.cbSourceReplacementPreview.apply {
             isChecked = savedInstanceState?.getBoolean("showingAlternate")
@@ -134,6 +164,7 @@ class CodeDialog() : BaseDialogFragment(R.layout.dialog_code_view) {
         binding.toolBar.menu.findItem(R.id.menu_save)?.isVisible =
             saveEnabled && !show && searchView.isIconified
         if (!searchView.isIconified) showCurrentMatch()
+        binding.codeView.post { updatePositionBar() }
     }
 
     private fun initMenu(canSave: Boolean) {
@@ -248,6 +279,22 @@ class CodeDialog() : BaseDialogFragment(R.layout.dialog_code_view) {
     private fun setSearchActionsEnabled(enabled: Boolean) {
         binding.toolBar.menu.findItem(R.id.menu_search_previous).isEnabled = enabled
         binding.toolBar.menu.findItem(R.id.menu_search_next).isEnabled = enabled
+    }
+
+    private fun maxScrollY(): Int {
+        val codeView = binding.codeView
+        return ((codeView.layout?.height ?: 0) + codeView.totalPaddingTop +
+            codeView.totalPaddingBottom - codeView.height).coerceAtLeast(0)
+    }
+
+    private fun updatePositionBar() {
+        val max = maxScrollY()
+        binding.positionBar.isEnabled = max > 0
+        binding.positionBar.progress = resolveCodeDialogPositionProgress(
+            binding.codeView.scrollY,
+            max,
+            binding.positionBar.max,
+        )
     }
 
     fun refreshAlternateCode() {

--- a/app/src/main/res/layout/dialog_code_view.xml
+++ b/app/src/main/res/layout/dialog_code_view.xml
@@ -26,11 +26,34 @@
         android:text="@string/show_source_replacement"
         android:visibility="gone" />
 
-    <io.legado.app.ui.widget.code.CodeView
-        android:id="@+id/code_view"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:padding="12dp" />
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <io.legado.app.ui.widget.code.CodeView
+            android:id="@+id/code_view"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:padding="12dp" />
+
+        <io.legado.app.ui.widget.seekbar.VerticalSeekBarWrapper
+            android:id="@+id/position_bar_container"
+            android:layout_width="40dp"
+            android:layout_height="match_parent">
+
+            <io.legado.app.lib.theme.view.ThemeSeekBar
+                android:id="@+id/position_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/content_edit_position"
+                android:max="10000"
+                android:rotation="90"
+                android:saveEnabled="false" />
+        </io.legado.app.ui.widget.seekbar.VerticalSeekBarWrapper>
+    </LinearLayout>
 
 </LinearLayout>
 

--- a/app/src/test/java/io/legado/app/ui/widget/dialog/CodeDialogPositionTest.kt
+++ b/app/src/test/java/io/legado/app/ui/widget/dialog/CodeDialogPositionTest.kt
@@ -1,0 +1,23 @@
+package io.legado.app.ui.widget.dialog
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CodeDialogPositionTest {
+
+    @Test
+    fun `no scrollable content starts at zero`() {
+        assertEquals(0, resolveCodeDialogPositionProgress(10, 0))
+    }
+
+    @Test
+    fun `progress is clamped to the scroll range`() {
+        assertEquals(0, resolveCodeDialogPositionProgress(-10, 100))
+        assertEquals(10000, resolveCodeDialogPositionProgress(110, 100))
+    }
+
+    @Test
+    fun `progress maps the middle of the scroll range`() {
+        assertEquals(5000, resolveCodeDialogPositionProgress(50, 100))
+    }
+}


### PR DESCRIPTION
## Summary
- Add a vertical position bar to the long-code preview dialog.
- Keep the code editor and position bar synchronized while scrolling, resizing, or switching replacement preview.
- Add JVM coverage for zero, clamped, and midpoint scroll progress mapping.

## Issue
Follow-up to #1144: the category spacing fix is complete, but the code preview dialog still lacked the quick position control requested in the discussion.

## Validation
- git diff --check
- GitHub Actions Test Build (no local Android build)