### PR TITLE
fix: delete the selected welcome image on reset

### DIFF
--- a/app/src/main/java/io/legado/app/ui/config/WelcomeConfigFragment.kt
+++ b/app/src/main/java/io/legado/app/ui/config/WelcomeConfigFragment.kt
@@ -129,7 +129,7 @@ class WelcomeConfigFragment : PreferenceFragment(),
                         )
                     ) { _, i ->
                         if (i == 0) {
-                            deleteStoredImage(preference.key)
+                            deleteStoredImage(getPrefString(preference.key))
                             removePref(preference.key)
 //                            AppConfig.welcomeShowText = true
 //                            AppConfig.welcomeShowIcon = true
@@ -163,7 +163,7 @@ class WelcomeConfigFragment : PreferenceFragment(),
                         )
                     ) { _, i ->
                         if (i == 0) {
-                            deleteStoredImage(preference.key)
+                            deleteStoredImage(getPrefString(preference.key))
                             removePref(preference.key)
 //                            AppConfig.welcomeShowTextDark = true
 //                            AppConfig.welcomeShowIconDark = true

--- a/app/src/test/java/io/legado/app/ui/welcome/WelcomeWindowContractTest.kt
+++ b/app/src/test/java/io/legado/app/ui/welcome/WelcomeWindowContractTest.kt
@@ -26,6 +26,7 @@ class WelcomeWindowContractTest {
         assertTrue(manifest.contains("android:theme=\"@style/AppTheme.Welcome\""))
         assertTrue(styles.contains("android:windowBackground\">@android:color/transparent"))
         assertTrue(config.contains("private fun deleteStoredImage(path: String?)"))
+        assertTrue(config.contains("deleteStoredImage(getPrefString(preference.key))"))
         assertTrue(config.contains("file.canonicalFile.parentFile == coversDir.canonicalFile"))
         assertTrue(config.contains("if (oldPath != file.absolutePath) deleteStoredImage(oldPath)"))
     }


### PR DESCRIPTION
## Summary
- pass the stored welcome image path to the ownership-checked cleanup helper when deleting a custom image
- extend the existing welcome contract test

## Validation
- Welcome image delete contract passed
- git diff --check
- Android validation is delegated to GitHub Actions