### PR TITLE
fix(dialog): 修复复用网页弹窗无法下滑关闭

### DIFF
--- a/.github/workflows/source-browser-test.yml
+++ b/.github/workflows/source-browser-test.yml
@@ -11,6 +11,7 @@ on:
       - 'gradle.properties'
       - 'gradle/libs.versions.toml'
       - 'app/src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt'
+      - 'app/src/main/java/io/legado/app/help/webView/WebViewPool.kt'
       - 'app/src/main/java/io/legado/app/ui/widget/dialog/BookMemoDialog.kt'
       - 'app/src/main/java/io/legado/app/ui/code/**'
       - 'app/src/androidTest/java/io/legado/app/ui/code/**'

--- a/app/src/androidTest/java/io/legado/app/ui/widget/dialog/BottomWebViewDialogShowTest.kt
+++ b/app/src/androidTest/java/io/legado/app/ui/widget/dialog/BottomWebViewDialogShowTest.kt
@@ -2,21 +2,31 @@ package io.legado.app.ui.widget.dialog
 
 import android.graphics.Bitmap
 import android.os.SystemClock
+import android.graphics.Rect
 import android.view.View
 import android.webkit.WebChromeClient
+import android.webkit.WebView
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.GeneralSwipeAction
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.action.Swipe
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.R as MaterialR
 import io.legado.app.data.appDb
 import io.legado.app.data.entities.BookSource
+import io.legado.app.help.webView.PooledWebView
 import io.legado.app.ui.about.AboutActivity
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -260,6 +270,91 @@ class BottomWebViewDialogShowTest {
         val restored = awaitGeometry { it.height < initial.height && !it.fitToContents }
         assertTrue(restored.toString(), abs(restored.bottomGap) <= 2)
         screenshot("paragraph-sheet-after-full-screen")
+    }
+
+    @Test
+    fun attachedSourcesSwipeDownAfterReusingTheSameWebView() {
+        // Only the dialog options from #1135 comment 5578580309 are needed;
+        // local HTML keeps the native gesture and pool regression independent of login/network.
+        val source1Config = """{"expandedCornersRadius":15,"backgroundDimAmount":0.7,
+            "heightPercentage":0.9}"""
+        val source2Config = """{"expandedCornersRadius":20,"dismissOnTouchOutside":true,
+            "isDraggable":true,"shouldDimBackground":true,"backgroundDimAmount":0.5,
+            "hardwareAccelerated":true,"isNestedScrollingEnabled":true,
+            "isGestureInsetBottomIgnored":true,"setFitToContents":false,
+            "heightPercentage":0.85,"isHideable":true}"""
+        val secondSource = source.copy(bookSourceUrl = source.bookSourceUrl + "/second")
+        appDb.bookSourceDao.insert(secondSource)
+        val failures = mutableListOf<String>()
+        var previous: PooledWebView? = null
+        try {
+            for ((index, entry) in listOf(source to source1Config, secondSource to source2Config,
+                source to source1Config).withIndex()) {
+                val label = "source-${if (index == 1) 2 else 1}-step-${index + 1}"
+                lateinit var browser: BottomWebViewDialog
+                lateinit var pooled: PooledWebView
+                scenario!!.onActivity { activity ->
+                    browser = BottomWebViewDialog(entry.first.bookSourceUrl, 0,
+                        "${entry.first.bookSourceUrl}/$label",
+                        """<html><head><meta name="viewport" content="width=device-width,initial-scale=1">
+                            <title>$label</title></head><body style="margin:0;background:#dbeafe">
+                            <h2>$label</h2><p>Swipe down from this comment page to close it.</p>
+                            </body></html>""", config = entry.second)
+                    browser.show(activity.supportFragmentManager, label)
+                    val field = BottomWebViewDialog::class.java.getDeclaredField("pooledWebView")
+                    field.isAccessible = true
+                    pooled = field.get(browser) as PooledWebView
+                    previous?.let { assertSame("The regression must reuse one WebView", it, pooled) }
+                }
+                previous = pooled
+                val geometry = awaitGeometry {
+                    it.state == BottomSheetBehavior.STATE_EXPANDED && it.height > 0 &&
+                        abs(it.bottomGap) <= 2
+                }
+                assertTrue("$label lost its bottom anchor: $geometry", abs(geometry.bottomGap) <= 2)
+                assertTrue("The local comment page did not finish loading", awaitCondition {
+                    pooled.realWebView.title == label && pooled.realWebView.progress == 100 &&
+                        pooled.realWebView.width > 0 && !pooled.realWebView.canScrollVertically(-1)
+                })
+                screenshot("paragraph-$label-before-swipe")
+                onView(isAssignableFrom(WebView::class.java)).inRoot(isDialog()).perform(
+                    GeneralSwipeAction(Swipe.FAST, { swipePoint(it, 0.15f) },
+                        { swipePoint(it, 0.90f) }, Press.FINGER))
+                if (!awaitCondition(timeoutMs = 3_000) { browser.dialog?.isShowing != true }) {
+                    failures += "$label did not dismiss: ${sheetGeometry()}, " +
+                        "nestedScrolling=${pooled.realWebView.isNestedScrollingEnabled}"
+                    screenshot("paragraph-$label-blocked")
+                    // Clean up a failed stage so the source 1 -> source 2 -> source 1 sequence
+                    // still records whether the same recycled view contaminates the next source.
+                    scenario!!.onActivity { browser.dismiss() }
+                }
+                assertTrue("WebView was not returned to the pool after $label",
+                    awaitCondition { !pooled.isInUse })
+            }
+            assertTrue(failures.joinToString("\n"), failures.isEmpty())
+        } finally {
+            scenario!!.onActivity {
+                previous?.realWebView?.isNestedScrollingEnabled = false
+            }
+            appDb.bookSourceDao.delete(secondSource.bookSourceUrl)
+        }
+    }
+
+    private fun swipePoint(view: View, heightFraction: Float): FloatArray {
+        val visible = Rect()
+        assertTrue(view.getGlobalVisibleRect(visible))
+        return floatArrayOf(visible.exactCenterX(), visible.top + visible.height() * heightFraction)
+    }
+
+    private fun awaitCondition(timeoutMs: Long = 5_000, condition: () -> Boolean): Boolean {
+        val deadline = SystemClock.uptimeMillis() + timeoutMs
+        do {
+            var matched = false
+            scenario!!.onActivity { matched = condition() }
+            if (matched) return true
+            SystemClock.sleep(50)
+        } while (SystemClock.uptimeMillis() < deadline)
+        return false
     }
 
     private fun newDialog(page: String = "comments", config: String? = null) = BottomWebViewDialog(

--- a/app/src/main/assets/updateLog.md
+++ b/app/src/main/assets/updateLog.md
@@ -3,6 +3,7 @@
 ## cronet版本: 152.0.7977.54
 
 **2026/09/08**
+- 修复部分非原生段评弹窗启用嵌套滚动后无法下滑关闭，并污染后续弹窗手势的问题
 - 统一正式版和测试版更新按钮为“立即更新”
 - 修复切换“总是使用默认封面”后书架未立即刷新封面的问题
 - 测试版更新对话框新增右上角“浏览器下载”备用入口
@@ -890,3 +891,4 @@
 * [2023年日志](https://github.com/LegadoTeam/legado/blob/record2023/app/src/main/assets/updateLog.md)　
 * [2022年日志](https://github.com/LegadoTeam/legado/blob/record2022/app/src/main/assets/updateLog.md)　
 * [2021年日志](https://github.com/LegadoTeam/legado/blob/record2021/app/src/main/assets/updateLog.md)　
+- 修复部分非原生段评弹窗启用嵌套滚动后无法下滑关闭，并污染后续弹窗手势的问题

--- a/app/src/main/java/io/legado/app/help/webView/WebViewPool.kt
+++ b/app/src/main/java/io/legado/app/help/webView/WebViewPool.kt
@@ -82,6 +82,7 @@ object WebViewPool {
             removeJavascriptInterface(WebJsExtensions.nameSource)
             removeJavascriptInterface(WebJsExtensions.nameCache)
             clearFocus() //清除焦点
+            isNestedScrollingEnabled = false
             setOnLongClickListener(null)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 setOnScrollChangeListener(null)

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/BottomWebViewDialog.kt
@@ -546,7 +546,9 @@ class BottomWebViewDialog() : BottomSheetDialogFragment(R.layout.dialog_web_view
                 webView.settings.cacheMode = cacheMode
             }
             config.isNestedScrollingEnabled?.let { enabled ->
-                webView.isNestedScrollingEnabled = enabled
+                // WebView does not implement nested scrolling; advertising it makes Material's
+                // bottom sheet reserve the gesture for a scrolling child that cannot consume it.
+                webView.isNestedScrollingEnabled = false
             }
         }
 


### PR DESCRIPTION
修复部分非原生段评弹窗无法下滑关闭，并避免该状态污染后续复用的 WebView。

问题来自书源配置把普通 WebView 标成嵌套滚动子项。Material BottomSheet 因此把触摸交给无法实现嵌套滚动协议的 WebView，真实下滑不会关闭；WebView 回池时又保留了这个标志，后续书源也会受影响。

本次将该配置在普通 WebView 上固定为关闭，并在 WebView 回池时重置状态；贴底布局和已有 scrollNoDraggable 逻辑保持不变。Android 16 回归先在未修复 head `2f08414e96` 复现了源 2 及复用后的源 1 均无法下滑关闭，失败结果显示 `nestedScrolling=true` 且 bottomGap 为 0。修复 head `7b3499f225` 的 111 项 Android UI 回归全部通过，release 与 releaseA 构建通过，已合并为 d8bc8b79ab。

Test Release 34210862124 已发布 Beta 3.26090817/vc38375，四个实际 APK 的哈希、原始生产签名、Cronet 152 无内置原生库及 Web 资源检查通过。蓝奏下载得到的普通版及 releaseA 与 GitHub APK 字节数和 SHA256 完全一致。UI 截图存在早于网页画面提交的白屏帧，不能据此宣称页面视觉验收完成；仍需补页面渲染及长内容滚动验证。未运行本地 Android 构建或测试。

跟进 #1135 的下滑关闭反馈；侧滑返回和重复弹窗仍由后续独立回归继续覆盖，本 PR 不自动关闭 issue。
