### PR TITLE
fix: narrow release version replacement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Unify Version Name
         run: |
           echo "统一版本号"
-          sed "/def version/c def version = \"${{ env.VERSION }}\"" $GITHUB_WORKSPACE/app/build.gradle  -i
+          sed "/^def version =/c def version = \"${{ env.VERSION }}\"" $GITHUB_WORKSPACE/app/build.gradle  -i
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6.3.0


### PR DESCRIPTION
修复发布工作流的版本替换匹配范围。

`sed "/def version/c ..."` 会同时匹配 `def versionCodeValue`、`def versionCodeBaseCommit` 和 `def versionCodeAtBase`，把三个声明改成同名 `version`，导致发布构建在 Groovy 编译阶段失败。现在只匹配行首的 `def version =`，保留版本号替换并避免误改 `versionCode*`。

验证：
- `git diff --check` 通过。
- 仅修改 `.github/workflows/release.yml`；不运行本地 Android 构建。
- 发布失败证据：Run 34521402363，Build With Gradle 报 `The current scope already contains a variable of the name version`。
